### PR TITLE
web-console: add `LIMIT -10000` to telemetry query

### DIFF
--- a/packages/web-console/src/store/Telemetry/epics.ts
+++ b/packages/web-console/src/store/Telemetry/epics.ts
@@ -137,6 +137,7 @@ export const startTelemetry: Epic<StoreAction, TelemetryAction, StoreShape> = (
                 WHERE created > '${new Date(
                   remoteConfig.lastUpdated,
                 ).toISOString()}'
+                LIMIT -10000
             `,
           ),
         )


### PR DESCRIPTION
set a limit of 10000 latest records, to prevent possibility of excessive amount of rows
