### PR TITLE
release(web-console): 0.0.2

### DIFF
--- a/.github/workflows/web-console.yml
+++ b/.github/workflows/web-console.yml
@@ -29,4 +29,3 @@ jobs:
           access: public
           check-version: true
           package: ./packages/web-console/package.json
-          dry-run: true


### PR DESCRIPTION
This PR, once merged, should trigger `npm publish` to work
