### PR TITLE
fix(web-console): remove file separator symbol from `queryRaw` result

### DIFF
--- a/packages/web-console/src/utils/questdb.ts
+++ b/packages/web-console/src/utils/questdb.ts
@@ -112,6 +112,17 @@ export type Options = {
   explain?: boolean
 }
 
+const parseJSON = <T extends object>(raw: string): T | null => {
+  try {
+    // remove file separator symbol, as it's not valid a token for JSON.parse
+    return JSON.parse(raw.replace(/\u001C/g, ""))
+  } catch (e) {
+    console.error("Unable to parse JSON returned from QuestDB")
+    console.error(e)
+    return null
+  }
+}
+
 export class Client {
   private readonly _host: string
   private _controllers: AbortController[] = []
@@ -231,7 +242,7 @@ export class Client {
     if (response.ok || response.status === 400) {
       // 400 is only for SQL errors
       const fetchTime = (new Date().getTime() - start.getTime()) * 1e6
-      const data = (await response.json()) as RawResult
+      const data = parseJSON<RawResult>(await response.text()) as RawResult
 
       bus.trigger(BusEvent.MSG_CONNECTION_OK)
 


### PR DESCRIPTION
QuestDB might return data which can include non printing symbols, like
[File Separator](https://unicode-table.com/en/001C/)

Such symbol is not a valid token for `JSON.parse`, so code like
`JSON.parse(stringWithFileSeparatorSymbol)` breaks

This change simply removes that symbol. It is a non-printing symbol so
it should not be displayed in the web console grid anyway.
