### PR TITLE
Fix clipboard action on Safari

### DIFF
--- a/packages/web-console/src/scenes/Schema/Table/ContextualMenu/index.tsx
+++ b/packages/web-console/src/scenes/Schema/Table/ContextualMenu/index.tsx
@@ -36,8 +36,9 @@ type Props = {
 
 const ContextualMenu = ({ name, partitionBy }: Props) => {
   const { quest } = useContext(QuestContext)
+  const [schema, setSchema] = React.useState<string | undefined>()
 
-  const handleCopySchemaToClipboard = useCallback(() => {
+  const handleShow = useCallback(() => {
     void quest.queryRaw(`table_columns('${name}')`).then((result) => {
       if (result.type === QuestDB.Type.DQL && result.count > 0) {
         const formattedResult = formatTableSchemaQueryResult(
@@ -45,16 +46,22 @@ const ContextualMenu = ({ name, partitionBy }: Props) => {
           partitionBy,
           result,
         )
-        copyToClipboard(formattedResult)
+        setSchema(formattedResult)
       }
     })
   }, [quest, name, partitionBy])
 
+  const handleCopySchemaToClipboard = useCallback(() => {
+    if (schema) {
+      copyToClipboard(schema)
+    }
+  }, [schema])
+
   return (
-    <ContextMenu id={name}>
-      <MenuItem onClick={handleCopySchemaToClipboard}>
-        Copy Schema To Clipboard
-      </MenuItem>
+    <ContextMenu id={name} onShow={handleShow}>
+      {schema && (
+        <MenuItem onClick={handleCopySchemaToClipboard}>Copy schema</MenuItem>
+      )}
       <MenuItem divider />
       <MenuItem>Close</MenuItem>
     </ContextMenu>

--- a/packages/web-console/src/scenes/Schema/Table/ContextualMenu/index.tsx
+++ b/packages/web-console/src/scenes/Schema/Table/ContextualMenu/index.tsx
@@ -60,7 +60,9 @@ const ContextualMenu = ({ name, partitionBy }: Props) => {
   return (
     <ContextMenu id={name} onShow={handleShow}>
       {schema && (
-        <MenuItem onClick={handleCopySchemaToClipboard}>Copy schema</MenuItem>
+        <MenuItem onClick={handleCopySchemaToClipboard}>
+          Copy schema to clipboard
+        </MenuItem>
       )}
       <MenuItem divider />
       <MenuItem>Close</MenuItem>


### PR DESCRIPTION
The reason why Safari did silently block copy to clipboard action irrespective of used method is because of an async promise being resolved on click first. It appears the copy has to be invoked directly in the onClick handler, otherwise it's getting ignored without warning.

The fix fetches the table schema upon opening the context menu and makes sure the copy option is available only when data is ready.