### PR TITLE
Do not duplicate existing queries when appending via URL param

### DIFF
--- a/packages/browser-tests/cypress/integration/console/editor.spec.js
+++ b/packages/browser-tests/cypress/integration/console/editor.spec.js
@@ -137,6 +137,14 @@ describe("&query URL param", () => {
     cy.visit(`${baseUrl}?query=${query}&executeQuery=true`);
     cy.getGridRow(0).should("contain", "2").snapshot();
   });
+
+  it("should not append query if it already exists in editor", () => {
+    cy.visit(baseUrl);
+    const query = "select x\nfrom long_sequence(1);\n\n-- a\n-- b\n-- c";
+    cy.runQuery(query);
+    cy.visit(`${baseUrl}?query=${encodeURIComponent(query)}&executeQuery=true`);
+    cy.getEditor().should("have.value", query);
+  });
 });
 
 describe("autocomplete", () => {

--- a/packages/web-console/CHANGELOG.md
+++ b/packages/web-console/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `Fixed` for any bug fixes.
 * `Security` in case of vulnerabilities.
 
+## Next
+
+### Fixed
+
+- fix duplication issue when loading web console with `?query=some sql&executeQuery=true` multiple time [#33](https://github.com/questdb/ui/pull/33)
+
 ## 0.0.6 - 2022-09-26
 
 ### Added

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -203,9 +203,18 @@ const MonacoEditor = () => {
 
     // Insert query, if one is found in the URL
     const params = new URLSearchParams(window.location.search)
-    const query = params.get("query")
+    // Support multi-line queries (URL encoded)
+    const query = params.get("query")?.replaceAll("%0A", "\n")
+    const model = editor.getModel()
     if (query) {
-      appendQuery(editor, query, { appendAt: "end" })
+      // Find if the query is already in the editor
+      const matches = model?.findMatches(query, true, false, true, null, true)
+      if (matches) {
+        editor.setSelection(matches[0].range)
+        // otherwise, append the query
+      } else {
+        appendQuery(editor, query, { appendAt: "end" })
+      }
     }
 
     const executeQuery = params.get("executeQuery")

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -204,7 +204,7 @@ const MonacoEditor = () => {
     // Insert query, if one is found in the URL
     const params = new URLSearchParams(window.location.search)
     // Support multi-line queries (URL encoded)
-    const query = params.get("query")?.replaceAll("%0A", "\n")
+    const query = params.get("query")
     const model = editor.getModel()
     if (query) {
       // Find if the query is already in the editor

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -209,7 +209,7 @@ const MonacoEditor = () => {
     if (query) {
       // Find if the query is already in the editor
       const matches = model?.findMatches(query, true, false, true, null, true)
-      if (matches) {
+      if (matches && matches.length > 0) {
         editor.setSelection(matches[0].range)
         // otherwise, append the query
       } else {


### PR DESCRIPTION
Detect if a query passed via URL param already exists in the editor buffer and instead of duplicating, highlight the first match.

Tests - to be added

<img width="526" alt="CleanShot 2022-09-26 at 19 44 21@2x" src="https://user-images.githubusercontent.com/1871646/192345278-96e29590-40a9-4dcc-9136-51d0e8c23d15.png">
