### PR TITLE
Add query highlights to editor

### DIFF
--- a/packages/web-console/CHANGELOG.md
+++ b/packages/web-console/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Next
 
+### Added
+
+- Improve visual cues in the query editor. Highlighting active query with green bar, erroneous query with red dot and add run button. [#34](https://github.com/questdb/ui/pull/34)
+
 ### Fixed
 
 - fix duplication issue when loading web console with `?query=some sql&executeQuery=true` multiple time [#33](https://github.com/questdb/ui/pull/33)

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -1,13 +1,9 @@
-import React, {
-  BaseSyntheticEvent,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from "react"
+import React, { useContext, useEffect, useRef, useState } from "react"
+import type { BaseSyntheticEvent } from "react"
 import Editor, { Monaco, loader } from "@monaco-editor/react"
 import dracula from "./dracula"
-import { editor, IDisposable, IRange } from "monaco-editor"
+import { editor } from "monaco-editor"
+import type { IDisposable, IRange } from "monaco-editor"
 import { theme } from "../../../theme"
 import { QuestContext, useEditor } from "../../../providers"
 import { usePreferences } from "./usePreferences"
@@ -17,16 +13,16 @@ import {
   getQueryRequestFromEditor,
   getQueryRequestFromLastExecutedQuery,
   QuestDBLanguageName,
-  Request,
   setErrorMarker,
   clearModelMarkers,
   getQueryFromCursor,
 } from "./utils"
+import type { Request } from "./utils"
 import { PaneContent, Text } from "../../../components"
 import { useDispatch, useSelector } from "react-redux"
 import { actions, selectors } from "../../../store"
 import { BusEvent } from "../../../consts"
-import { ErrorResult } from "../../../utils/questdb"
+import type { ErrorResult } from "../../../utils/questdb"
 import * as QuestDB from "../../../utils/questdb"
 import { NotificationType } from "../../../types"
 import QueryResult from "../QueryResult"
@@ -70,7 +66,6 @@ const Content = styled(PaneContent)`
 
   .cursorQueryGlyph {
     margin-left: 2rem;
-    margin-top: 0.15rem;
     z-index: 1;
     cursor: pointer;
 

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -142,7 +142,6 @@ const MonacoEditor = () => {
   }
 
   const handleEditorClick = (e: BaseSyntheticEvent) => {
-    e.stopPropagation()
     if (e.target.classList.contains("cursorQueryGlyph")) {
       editorRef?.current?.focus()
       toggleRunning()


### PR DESCRIPTION
This PR adds three features:
- Highlighting active query at the point of cursor by a green vertical line. This is what will be executed upon clicking `Run` or by hitting the keyboard shortcut.
- Highlighting erroneous query in red
- Display a play arrow button on the first line of an active query - when clicked, it will evaluate the statement.
- Breakpoint-like line error indication

Screen recording:

https://user-images.githubusercontent.com/1871646/192565870-addd5f92-c1ac-4668-9658-261b264313a4.mp4

Error query highlight:
<img width="899" alt="CleanShot 2022-09-27 at 23 52 25@2x" src="https://user-images.githubusercontent.com/1871646/192642588-a25e7162-fbf6-4cdb-b4cb-c6f32d49550e.png">

Breakpoint-like error indication:
<img width="464" alt="CleanShot 2022-09-28 at 09 46 41@2x" src="https://user-images.githubusercontent.com/1871646/192752784-56a26991-aa5b-485f-b38f-387913d5909a.png">
