### PR TITLE
web-console: fix arrow down button positioning in grid logs

### DIFF
--- a/packages/web-console/src/js/console/grid.js
+++ b/packages/web-console/src/js/console/grid.js
@@ -34,7 +34,6 @@ export function grid(root, msgBus) {
     viewportHeight: 400,
     yMaxThreshold: 10000000,
     maxRowsToAnalyze: 100,
-    bottomMargin: 75,
     minVpHeight: 120,
     minDivHeight: 160,
   }
@@ -568,9 +567,12 @@ export function grid(root, msgBus) {
   function resize() {
     if ($("#grid").css("display") !== "none") {
       const wh = window.innerHeight - $(window).scrollTop()
-      vp =
-        Math.round(wh - viewport.getBoundingClientRect().top) -
-        defaults.bottomMargin
+      vp = Math.round(
+        wh -
+          viewport.getBoundingClientRect().top -
+          $('[data-hook="notifications-wrapper"]').height() -
+          $("#footer").height(),
+      )
       vp = Math.max(vp, defaults.minVpHeight)
       rowsInView = Math.floor(vp / rh)
       // viewport.style.height = vp + "px"
@@ -659,7 +661,7 @@ export function grid(root, msgBus) {
           activeRowDown(1)
         }
         break
-      case 34: // arrow down
+      case 34: // page down
         activeRowDown(rowsInView)
         break
       case 39: // arrow right

--- a/packages/web-console/src/scenes/Notifications/index.tsx
+++ b/packages/web-console/src/scenes/Notifications/index.tsx
@@ -127,7 +127,7 @@ const Notifications = () => {
   }
 
   return (
-    <Wrapper minimized={isMinimized}>
+    <Wrapper minimized={isMinimized} data-hook="notifications-wrapper">
       <Menu>
         <Header color="draculaForeground">
           <TerminalBoxIcon size="18px" />


### PR DESCRIPTION
This PR adjusts the way viewport is calculated in the results grid.

The calculation is later used in `activeRowDown` function. Previously it
was hardcoded, leading to a scenario where user was able to click arrow
down or page down key and highlight arrow below viewport area. As a
result active arrow was below visible area.

with this change the constants used in calculation are no longer
hardcoded, thus the positioning of highlighted row is correct
