### PR TITLE
web-console: fix line ending match on windows

### DIFF
--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -16,6 +16,7 @@ import {
   setErrorMarker,
   clearModelMarkers,
   getQueryFromCursor,
+  findMatches,
 } from "./utils"
 import type { Request } from "./utils"
 import { PaneContent, Text } from "../../../components"
@@ -166,14 +167,8 @@ const MonacoEditor = () => {
     const queryAtCursor = getQueryFromCursor(editor)
     const model = editor.getModel()
     if (queryAtCursor && model !== null) {
-      const matches = model.findMatches(
-        queryAtCursor.query,
-        true,
-        false,
-        true,
-        null,
-        true,
-      )
+      const matches = findMatches(model, queryAtCursor.query)
+
       if (matches.length > 0) {
         const hasError = errorRef.current?.query === queryAtCursor.query
         const cursorMatch = matches.find(
@@ -260,12 +255,7 @@ const MonacoEditor = () => {
       })
 
       window.bus.on(BusEvent.MSG_QUERY_EXEC, (_event, query: { q: string }) => {
-        const matches = editor
-          .getModel()
-          ?.findMatches(query.q, true, false, true, null, true)
-        if (matches) {
-          // TODO: Display a query marker on correct line
-        }
+        // TODO: Display a query marker on correct line
         toggleRunning(true)
       })
 
@@ -331,9 +321,9 @@ const MonacoEditor = () => {
     // Support multi-line queries (URL encoded)
     const query = params.get("query")
     const model = editor.getModel()
-    if (query) {
+    if (query && model) {
       // Find if the query is already in the editor
-      const matches = model?.findMatches(query, true, false, true, null, true)
+      const matches = findMatches(model, query)
       if (matches && matches.length > 0) {
         editor.setSelection(matches[0].range)
         // otherwise, append the query

--- a/packages/web-console/src/scenes/Editor/Monaco/utils.ts
+++ b/packages/web-console/src/scenes/Editor/Monaco/utils.ts
@@ -443,16 +443,12 @@ export const appendQuery = (
     if (position) {
       const newQueryLines = query.split("\n")
 
-      const {
-        prefix,
-        suffix,
-        lineStartOffset,
-        selectStartOffset,
-      } = getTextFixes({
-        appendAt: options.appendAt,
-        model,
-        position,
-      })
+      const { prefix, suffix, lineStartOffset, selectStartOffset } =
+        getTextFixes({
+          appendAt: options.appendAt,
+          model,
+          position,
+        })
 
       const positionInsert = getInsertPosition({
         model,
@@ -546,3 +542,13 @@ export const toTextPosition = (
     column: (row === 0 ? column + request.column : column) + 1,
   }
 }
+
+export const findMatches = (model: editor.ITextModel, needle: string) =>
+  model.findMatches(
+    needle /* searchString */,
+    true /* searchOnlyEditableRange */,
+    false /* isRegex */,
+    true /* matchCase */,
+    null /* wordSeparators */,
+    true /* captureMatches */,
+  ) ?? null

--- a/packages/web-console/src/scenes/Editor/Monaco/utils.ts
+++ b/packages/web-console/src/scenes/Editor/Monaco/utils.ts
@@ -45,7 +45,7 @@ export const getSelectedText = (
 export const getQueryFromCursor = (
   editor: IStandaloneCodeEditor,
 ): Request | undefined => {
-  const text = editor.getValue()
+  const text = editor.getValue({ preserveBOM: false, lineEnding: "\n" })
   const position = editor.getPosition()
 
   let row = 0


### PR DESCRIPTION
- set explicit line ending for `getQueryFromCursor`
- extract repetitive `findMatches` to `utils`

most importantly, this fixes the issue when wrong query is marked by the green gutter marker. This was apparent only on Windows.

before:

![image](https://user-images.githubusercontent.com/4284659/196555802-91619fdf-3771-4ddf-947e-8d2536505570.png)
text cursor is on the second query, but green gutter is marking the first one.

after:
![image](https://user-images.githubusercontent.com/4284659/196556048-8f39db8c-7692-46f0-af1a-d80175869b20.png)
text cursor is on the second query and green gutter correctly marks it.
