### PR TITLE
feat(ui): Add WAL indication

### DIFF
--- a/packages/web-console/src/scenes/Schema/Row/index.tsx
+++ b/packages/web-console/src/scenes/Schema/Row/index.tsx
@@ -31,7 +31,7 @@ import { CheckboxBlankCircle } from "styled-icons/remix-line"
 import { CodeSSlash } from "styled-icons/remix-line"
 import { Information } from "styled-icons/remix-line"
 import { Table as TableIcon } from "styled-icons/remix-line"
-import { PieChart } from "styled-icons/remix-line"
+import { FileList, PieChart } from "styled-icons/remix-line"
 import type { TreeNodeKind } from "../../../components/Tree"
 
 import {
@@ -166,6 +166,11 @@ const PieChartIcon = styled(PieChart)`
   margin-right: 0.5rem;
 `
 
+const FileListIcon = styled(FileList)`
+  color: ${color("draculaYellow")};
+  margin-right: 0.5rem;
+`
+
 const Row = ({
   className,
   designatedTimestamp,
@@ -242,6 +247,7 @@ const Row = ({
 
         {kind === "table" && walEnabled && (
           <PartitionByWrapper>
+            <FileListIcon size="14px" />
             <Text color="draculaYellow">WAL</Text>
           </PartitionByWrapper>
         )}

--- a/packages/web-console/src/scenes/Schema/Row/index.tsx
+++ b/packages/web-console/src/scenes/Schema/Row/index.tsx
@@ -54,6 +54,7 @@ type Props = Readonly<{
   name: string
   onClick?: (event: MouseEvent) => void
   partitionBy?: string
+  walEnabled?: boolean
   suffix?: ReactNode
   tooltip?: boolean
   type?: string
@@ -174,6 +175,7 @@ const Row = ({
   indexed,
   name,
   partitionBy,
+  walEnabled,
   onClick,
   suffix,
   tooltip,
@@ -235,6 +237,12 @@ const Row = ({
           <PartitionByWrapper>
             <PieChartIcon size="14px" />
             <Text color="gray2">{partitionBy}</Text>
+          </PartitionByWrapper>
+        )}
+
+        {kind === "table" && walEnabled && (
+          <PartitionByWrapper>
+            <Text color="draculaYellow">WAL</Text>
           </PartitionByWrapper>
         )}
 

--- a/packages/web-console/src/scenes/Schema/Table/ContextualMenu/index.tsx
+++ b/packages/web-console/src/scenes/Schema/Table/ContextualMenu/index.tsx
@@ -32,9 +32,10 @@ import { copyToClipboard } from "../../../../utils"
 type Props = {
   name: string
   partitionBy: string
+  walEnabled: boolean
 }
 
-const ContextualMenu = ({ name, partitionBy }: Props) => {
+const ContextualMenu = ({ name, partitionBy, walEnabled }: Props) => {
   const { quest } = useContext(QuestContext)
   const [schema, setSchema] = React.useState<string | undefined>()
 
@@ -45,6 +46,7 @@ const ContextualMenu = ({ name, partitionBy }: Props) => {
           name,
           partitionBy,
           result,
+          walEnabled,
         )
         setSchema(formattedResult)
       }

--- a/packages/web-console/src/scenes/Schema/Table/ContextualMenu/services.ts
+++ b/packages/web-console/src/scenes/Schema/Table/ContextualMenu/services.ts
@@ -30,6 +30,7 @@ export const formatTableSchemaQueryResult = (
   name: string,
   partitionBy: string,
   result: QuestDB.QueryRawResult,
+  walEnabled: boolean,
 ): string => {
   if (result.type === QuestDB.Type.DQL) {
     let designatedName = null
@@ -81,6 +82,10 @@ export const formatTableSchemaQueryResult = (
 
     if (partitionBy !== "NONE") {
       query += ` PARTITION BY ${partitionBy}`
+    }
+
+    if (walEnabled) {
+      query += " WAL"
     }
 
     return `${formatSql(query)};`

--- a/packages/web-console/src/scenes/Schema/Table/index.tsx
+++ b/packages/web-console/src/scenes/Schema/Table/index.tsx
@@ -118,6 +118,7 @@ const Table = ({
   name,
   partitionBy,
   expanded = false,
+  walEnabled,
   onChange = () => {},
 }: Props) => {
   const currentName = useRef(name)
@@ -201,7 +202,13 @@ const Table = ({
 
   return (
     <Wrapper _height={columns ? columns.length * 30 : 0}>
-      {!isScrolling && <ContextualMenu name={name} partitionBy={partitionBy} />}
+      {!isScrolling && (
+        <ContextualMenu
+          name={name}
+          partitionBy={partitionBy}
+          walEnabled={walEnabled}
+        />
+      )}
 
       <Tree root={tree} />
     </Wrapper>

--- a/packages/web-console/src/scenes/Schema/Table/index.tsx
+++ b/packages/web-console/src/scenes/Schema/Table/index.tsx
@@ -191,6 +191,7 @@ const Table = ({
               name={name}
               onClick={() => toggleOpen()}
               partitionBy={partitionBy}
+              walEnabled={walEnabled}
               suffix={isLoading && <Loader size="18px" />}
               tooltip={!!description}
             />

--- a/packages/web-console/src/scenes/Schema/index.tsx
+++ b/packages/web-console/src/scenes/Schema/index.tsx
@@ -157,6 +157,7 @@ const Schema = ({
             onChange={handleChange}
             partitionBy={table.partitionBy}
             refresh={refresh}
+            walEnabled={table.walEnabled}
           />
         )
       }

--- a/packages/web-console/src/utils/questdb.ts
+++ b/packages/web-console/src/utils/questdb.ts
@@ -99,6 +99,7 @@ export type Table = {
   name: string
   partitionBy: string
   designatedTimestamp: string
+  walEnabled: boolean
 }
 
 export type Column = {
@@ -161,7 +162,7 @@ export class Client {
     if (result.type === Type.DQL) {
       const { columns, count, dataset, timings } = result
 
-      const parsed = (dataset.map(
+      const parsed = dataset.map(
         (row) =>
           row.reduce(
             (acc: RawData, val: Value, idx) => ({
@@ -170,7 +171,7 @@ export class Client {
             }),
             {},
           ) as RawData,
-      ) as unknown) as T[]
+      ) as unknown as T[]
 
       return {
         columns,
@@ -316,7 +317,9 @@ export class Client {
 
   async getLatestRelease() {
     try {
-      const response: Response = await fetch(`https://api.github.com/repos/questdb/questdb/releases/latest`)
+      const response: Response = await fetch(
+        `https://api.github.com/repos/questdb/questdb/releases/latest`,
+      )
       return (await response.json()) as Release
     } catch (error) {
       // eslint-disable-next-line prefer-promise-reject-errors


### PR DESCRIPTION
This PR does two things:
- Adds an indication to the left of the table name if [WAL](https://en.wikipedia.org/wiki/Write-ahead_logging) is enabled for it.
- Adds `WAL` statement to table schema in the same scenario.

<img width="415" alt="CleanShot 2023-01-27 at 08 36 36@2x" src="https://user-images.githubusercontent.com/1871646/215032945-ab224ec3-a1e2-47d5-849e-82e52593da22.png">
<img width="376" alt="CleanShot 2023-01-27 at 08 36 25@2x" src="https://user-images.githubusercontent.com/1871646/215032947-38c10bb1-84d0-433d-90e5-ba805c188bbc.png">
