### PR TITLE
feat: grid horizontal virtualization

### DIFF
--- a/packages/web-console/README.md
+++ b/packages/web-console/README.md
@@ -24,12 +24,12 @@ Download is what takes the most amount of time (~1 minute on a decent connection
 
 * clone using SSH:
   ```
-  git clone git@github.com/questdb/ui.git
+  git clone git@github.com:questdb/ui.git
   ```
 
 * or using HTTPS:
   ```
-  git clone git@github.com/questdb/ui.git
+  git clone https://github.com/questdb/ui.git
   ```
 
 * or using [Github CLI](https://cli.github.com/):

--- a/packages/web-console/src/js/console/grid.js
+++ b/packages/web-console/src/js/console/grid.js
@@ -73,7 +73,6 @@ export function grid(root, msgBus) {
   let visColumnLo = 0
   // visible column count, e.g. number of columns that is actually rendered in the grid
   let visColumnCount = 10
-  const visColumnCountExtra = 3
   // X coordinate of the leftmost visible column
   let visColumnX = 0
   // width in pixels of all visible columns
@@ -550,8 +549,6 @@ export function grid(root, msgBus) {
           visColumnX -= getColumnWidth(i)
         }
       }
-      console.log('set: '+lo)
-      console.trace()
       visColumnLo = lo
 
       // compute new width
@@ -786,18 +783,15 @@ export function grid(root, msgBus) {
 
       // take into account the last stride
       count = Math.max(count, hi - lo + 1)
-      visColumnCount = Math.min(
-        count + visColumnCountExtra,
-        columnCount
-      )
+      visColumnCount = Math.min(count, columnCount)
       // When scroller is positioned to extreme right, window resize pulls left side
       // of the grid into the view. In other scroller positions right side of the grid is extended first.
       // The delta is by how much we overshot our column count. If non-zero, we have to reduce `lo`
       const delta = visColumnLo + visColumnCount - columnCount
-      console.log('computing for: ' + viewportWidth + ', visColumnCount: ' + visColumnCount + ', delta: ' + delta)
       if (delta > 0 && visColumnLo >= delta) {
-        console.log('set3: ' + visColumnLo)
+        const xShift = columnOffsets[visColumnLo + delta] - columnOffsets[visColumnLo]
         visColumnLo -= delta
+        visColumnX -= xShift
       }
     }
   }
@@ -861,15 +855,6 @@ export function grid(root, msgBus) {
         } else if (prevVisColumnCount > visColumnCount) {
           removeColumns(prevVisColumnCount);
         }
-
-        // check if the focused cell is visible
-        console.log("focusedCellIndex: " + focusedCellIndex + ", visColumnLo: " + visColumnLo + ", visColumnCount: " + visColumnCount + ", visColumnCountExtra: " + visColumnCountExtra)
-        /*
-                if (focusedCellIndex !== -1 && focusedCellIndex >= visColumnLo + visColumnCount - visColumnCountExtra) {
-                  focusedCellIndex = visColumnLo + visColumnCount  - 1
-                  updateFocusedCellFromIndex();
-                }
-        */
       }
       scroll()
     }

--- a/packages/web-console/src/js/console/grid.js
+++ b/packages/web-console/src/js/console/grid.js
@@ -1130,7 +1130,6 @@ export function grid(root, msgBus) {
       const dataBatchLen = dataBatch.length
       // a little inefficient, but lets traverse
       let offset = 0
-      console.log(dataBatch)
       for (let i = 0; i < columnCount; i++) {
         // this assumes that initial width has been set to the width of the header
         let w = getColumnWidth(i)

--- a/packages/web-console/src/js/console/grid.js
+++ b/packages/web-console/src/js/console/grid.js
@@ -118,7 +118,7 @@ export function grid(root, msgBus) {
   // Aggressive grid navigation might reorder data fetch and render. In that
   // when render is attempted before data is available, we need to "remember" the
   // last render attempt and repeat is when data is ready
-  const pendingRender = {colLo: 0, colHi: 0, nextVisColumnLo: 0, render: false};
+  const pendingRender = {colLo: 0, colHi: 0, nextVisColumnLo: 0, render: false}
   const scrollerGirth = defaults.scrollerGirth
   let headerScrollerPlaceholder
 
@@ -162,7 +162,7 @@ export function grid(root, msgBus) {
           row.className = 'qg-r qg-r-active'
           setFocus(row.childNodes[focusedCellIndex % visColumnCount])
         } else {
-          row.className ='qg-r'
+          row.className = 'qg-r'
           removeFocus(row.childNodes[focusedCellIndex % visColumnCount])
         }
       }
@@ -342,7 +342,7 @@ export function grid(root, msgBus) {
   }
 
   function getColumnAlignment(i) {
-    const col = columns[i];
+    const col = columns[i]
     if (col) {
       switch (col.type) {
         case 'STRING':
@@ -355,11 +355,11 @@ export function grid(root, msgBus) {
   }
 
   function getColumnWidth(i) {
-    return columnOffsets[i + 1] - columnOffsets[i];
+    return columnOffsets[i + 1] - columnOffsets[i]
   }
 
   function createColumnWidthStyleSelector(columnIndex, width, left) {
-    return '.' + getColumnWidthSelector(columnIndex) + '{width:' + width + 'px;' + 'position: absolute;' + 'left:' + left + 'px;' + getColumnAlignment(columnIndex) + '}';
+    return '.' + getColumnWidthSelector(columnIndex) + '{width:' + width + 'px;' + 'position: absolute;' + 'left:' + left + 'px;' + getColumnAlignment(columnIndex) + '}'
   }
 
   function generatePxWidth(rules) {
@@ -415,7 +415,7 @@ export function grid(root, msgBus) {
   function columnResizeStart(e) {
     e.preventDefault()
     const target = e.target
-    const className = e.target.className;
+    const className = e.target.className
     const i1 = className.indexOf(COLUMN_WIDTH_SELECTOR_PREFIX)
     let i2 = className.indexOf(' ', i1)
     if (i2 === -1) {
@@ -432,7 +432,7 @@ export function grid(root, msgBus) {
 
     target.style.marginLeft = '0px'
     colResizeDragHandleStartX = target.offsetLeft
-    colResizeMouseDownX = e.clientX;
+    colResizeMouseDownX = e.clientX
 
     // style up the drag handle to make it apparent we're resizing column
     target.style.left = colResizeDragHandleStartX + 'px'
@@ -481,7 +481,7 @@ export function grid(root, msgBus) {
     for (i = 0; i < columnCount; i++) {
       const c = columns[i]
 
-      const h = document.createElement('div');
+      const h = document.createElement('div')
       h.className = 'qg-header ' + getColumnWidthSelector(i)
       h.setAttribute('data-column-name', c.name)
 
@@ -583,11 +583,11 @@ export function grid(root, msgBus) {
   }
 
   function removeFocus(cell) {
-    removeClass(cell, ACTIVE_CELL_CLASS);
+    removeClass(cell, ACTIVE_CELL_CLASS)
   }
 
   function setFocus(cell) {
-    addClass(cell, ACTIVE_CELL_CLASS);
+    addClass(cell, ACTIVE_CELL_CLASS)
   }
 
   function setCellData(cell, cellData) {
@@ -607,7 +607,7 @@ export function grid(root, msgBus) {
       pendingRender.colLo = colLo
       pendingRender.colHi = colHi
       pendingRender.nextVisColumnLo = nextVisColumnLo
-      pendingRender.render = false;
+      pendingRender.render = false
 
       let t = Math.max(0, Math.floor((y - viewportHeight) / rh))
       let b = Math.min(yMax / rh, Math.ceil((y + viewportHeight + viewportHeight) / rh))
@@ -619,8 +619,8 @@ export function grid(root, msgBus) {
 
       for (let i = t; i < b; i++) {
         const row = rows[i & dcn]
-        const m = Math.floor(i / pageSize);
-        const n = i % pageSize;
+        const m = Math.floor(i / pageSize)
+        const n = i % pageSize
         let d1
         let d2
         if (m < data.length && (d1 = data[m]) && n < d1.length && (d2 = d1[n])) {
@@ -631,7 +631,7 @@ export function grid(root, msgBus) {
             setCellDataAndAttributes(row, d2, j)
           }
         } else {
-          pendingRender.render = true;
+          pendingRender.render = true
         }
       }
 
@@ -678,7 +678,7 @@ export function grid(root, msgBus) {
       renderCells(columnCount - visColumnCount, columnCount, columnCount - visColumnCount)
     }
 
-    updateFocusedCellFromIndex();
+    updateFocusedCellFromIndex()
 
     const columnOffset = columnOffsets[focusedCellIndex]
     const columnWidth = columnOffsets[focusedCellIndex + 1] - columnOffset
@@ -720,7 +720,7 @@ export function grid(root, msgBus) {
   }
 
   function isHorizontalScroller() {
-    return viewport.scrollWidth > lastKnownViewportWidth;
+    return viewport.scrollWidth > lastKnownViewportWidth
   }
 
   function activeRowDown(n) {
@@ -733,7 +733,7 @@ export function grid(root, msgBus) {
       activeRowContainer.className = 'qg-r qg-r-active'
       activeCellOn(NAV_EVENT_ANY_VERTICAL)
       const scrollTop = activeRow * rh - viewportHeight + rh - o
-      const sh = isHorizontalScroller() ? scrollerGirth : 0;
+      const sh = isHorizontalScroller() ? scrollerGirth : 0
       if (scrollTop > viewport.scrollTop) {
         viewport.scrollTop = scrollTop + sh
       } else {
@@ -810,13 +810,13 @@ export function grid(root, msgBus) {
 
   function scroll(event) {
 
-    disableHover();
+    disableHover()
 
     if (header.scrollLeft !== viewport.scrollLeft) {
       header.scrollLeft = viewport.scrollLeft
     }
 
-    renderColumns();
+    renderColumns()
 
     const scrollTop = viewport.scrollTop
     if (scrollTop !== top || !event) {
@@ -845,7 +845,7 @@ export function grid(root, msgBus) {
       renderRows(y - oldY)
     }
 
-    enableHover();
+    enableHover()
     setFocus(focusedCell)
     logDebug()
   }
@@ -855,6 +855,8 @@ export function grid(root, msgBus) {
     if (totalWidth < viewportWidth) {
       // viewport is wider than total column width
       visColumnCount = columnCount
+      visColumnLo = 0
+      visColumnX = 0
     } else {
       let lo = 0
       let hi = 0
@@ -894,7 +896,7 @@ export function grid(root, msgBus) {
 
   function removeColumns(colCount) {
     for (let i = 0, n = rows.length; i < n; i++) {
-      const row = rows[i];
+      const row = rows[i]
       for (let j = visColumnCount; j < colCount; j++) {
         // as we remove, the children shift left
         row.childNodes[visColumnCount].remove()
@@ -905,10 +907,11 @@ export function grid(root, msgBus) {
 
   function appendColumns(colCount) {
     for (let i = 0, n = rows.length; i < n; i++) {
-      const row = rows[i];
+      const row = rows[i]
       // add extra cells
       for (let j = 0; j < colCount; j++) {
         const div = document.createElement('div')
+        div.onclick = rowClick
         row.append(div)
       }
 
@@ -922,7 +925,7 @@ export function grid(root, msgBus) {
   }
 
   function isVerticalScroller() {
-    return viewport.scrollHeight > viewport.getBoundingClientRect().height;
+    return viewport.scrollHeight > viewport.getBoundingClientRect().height
   }
 
   function toggleScrollerPlaceholder() {
@@ -941,14 +944,14 @@ export function grid(root, msgBus) {
       const viewportWidth = viewport.getBoundingClientRect().width
       if (lastKnownViewportWidth !== viewportWidth) {
         lastKnownViewportWidth = viewportWidth
-        toggleScrollerPlaceholder();
+        toggleScrollerPlaceholder()
 
         const prevVisColumnCount = visColumnCount
         updateVisibleColumnCount()
         if (prevVisColumnCount < visColumnCount) {
           appendColumns(visColumnCount - prevVisColumnCount)
         } else if (prevVisColumnCount > visColumnCount) {
-          removeColumns(prevVisColumnCount);
+          removeColumns(prevVisColumnCount)
         }
       }
       scroll()
@@ -1106,7 +1109,7 @@ export function grid(root, msgBus) {
       rowDiv.style.top = '-100'
       rowDiv.style.height = rh.toString() + 'px'
       rows.push(rowDiv)
-      canvas[0].append(rowDiv);
+      canvas[0].append(rowDiv)
     }
   }
 

--- a/packages/web-console/src/js/console/grid.js
+++ b/packages/web-console/src/js/console/grid.js
@@ -129,7 +129,7 @@ export function grid(root, msgBus) {
       h = defaults.yMaxThreshold
     }
     M = yMax / h
-    canvas.css("height", h === 0 ? 1 : h)
+    canvas[0].style.height =  (h === 0 ? 1 : h) + 'px'
   }
 
   function renderRow(row, rowIndex) {
@@ -150,11 +150,11 @@ export function grid(root, msgBus) {
       } else {
         // clear grid if there is no row data
         for (k = 0; k < visColumnCount; k++) {
-          row.childNodes[(k + visColumnLo) % visColumnCount].innerHTML = ""
+          row.childNodes[(k + visColumnLo) % visColumnCount].innerHTML = ''
         }
         row.questIndex = -1
       }
-      row.style.top = rowIndex * rh - o + "px"
+      row.style.top = rowIndex * rh - o + 'px'
       if (row === activeRowContainer) {
         if (rowIndex === activeRow) {
           row.className = "qg-r qg-r-active"
@@ -347,7 +347,6 @@ export function grid(root, msgBus) {
 
   function getColumnWidth(i) {
     return columnOffsets[i + 1] - columnOffsets[i];
-    // return columnWidths[i]
   }
 
   function generatePxWidth(rules) {
@@ -383,6 +382,10 @@ export function grid(root, msgBus) {
     }
   }
 
+  function broadcastColumnName(e) {
+    bus.trigger("editor.insert.column", e.currentTarget.getAttribute("data-column-name"))
+  }
+
   function computeColumnWidths() {
     columnWidths = []
     columnOffsets = []
@@ -391,18 +394,29 @@ export function grid(root, msgBus) {
     for (i = 0; i < columnCount; i++) {
       const c = columns[i]
 
-      const col = $('<div class="qg-header qg-w' + i + '" data-column-name="' + c.name + '"><span class="qg-header-type">' + c.type.toLowerCase() + '</span><span class="qg-header-name">' + c.name + "</span></div>",)
-        .on("click", function (e) {
-          bus.trigger("editor.insert.column", e.currentTarget.getAttribute("data-column-name"),)
-        })
-        .appendTo(header)
+      const h = document.createElement('div');
+      h.className = 'qg-header qg-w' + i
+      h.setAttribute('data-column-name', c.name)
 
       switch (c.type) {
         case "STRING":
         case "SYMBOL":
-          col.addClass("qg-header-l")
+          h.className += ' qg-header-l'
           break
       }
+
+      const hType = document.createElement('span')
+      hType.className = 'qg-header-type'
+      hType.innerHTML = c.type.toLowerCase()
+
+      const hName = document.createElement('span')
+      hName.className = 'qg-header-name'
+      hName.innerHTML = c.name
+
+      h.append(hType, hName)
+      h.onclick = broadcastColumnName
+
+      header[0].append(h)
 
       w = Math.max(defaults.minColumnWidth, Math.ceil((c.name.length + c.type.length) * 8 * 1.2 + 10))
       columnOffsets.push(totalWidth)
@@ -410,8 +424,9 @@ export function grid(root, msgBus) {
       totalWidth += w
     }
 
-    headerScrollerPlaceholder = $('<div class="qg-header qg-stub qg-w' + columnCount + '"/>')
-      .appendTo(header)
+    headerScrollerPlaceholder = document.createElement('div')
+    headerScrollerPlaceholder.className = 'qg-header qg-stub qg-w' + columnCount
+    header[0].append(headerScrollerPlaceholder)
 
     columnOffsets.push(totalWidth)
   }
@@ -425,8 +440,8 @@ export function grid(root, msgBus) {
     if ($style) {
       $style.remove()
     }
-    header.empty()
-    canvas.empty()
+    header[0].innerHTML = ''
+    canvas[0].innerHTML = ''
     rows = []
     data = []
     query = null
@@ -789,11 +804,7 @@ export function grid(root, msgBus) {
 
   function toggleScrollerPlaceholder() {
     if (headerScrollerPlaceholder) {
-      if (isHorizontalScroller() && isVerticalScroller()) {
-        headerScrollerPlaceholder[0].style.display = 'block'
-      } else {
-        headerScrollerPlaceholder[0].style.display = 'none'
-      }
+      headerScrollerPlaceholder.style.display = isHorizontalScroller() && isVerticalScroller() ? 'block' : 'none'
     }
   }
 
@@ -1048,7 +1059,8 @@ export function grid(root, msgBus) {
     canvas.bind("keydown", onKeyDown)
     canvas.bind("keyup", onKeyUp)
 
-    $(window).resize(resize)
+    window.onresize = resize
+
     bus.on(qdb.MSG_QUERY_DATASET, update)
     bus.on("grid.focus", focusCell)
     bus.on("grid.refresh", refreshQuery)

--- a/packages/web-console/src/js/console/grid.js
+++ b/packages/web-console/src/js/console/grid.js
@@ -385,21 +385,53 @@ export function grid(root, msgBus) {
     bus.trigger("editor.insert.column", e.currentTarget.getAttribute("data-column-name"))
   }
 
-  function columnResize(e) {
+  let draggedColumnSizeHandle
+
+  function columnResizeStart(e) {
+    e.preventDefault()
+    const target = e.target
     const className = e.target.className;
-    const i1 = className.indexOf('qg-w');
-    let i2 = className.indexOf(' ', i1);
+    const i1 = className.indexOf('qg-w')
+    let i2 = className.indexOf(' ', i1)
     if (i2 === -1) {
       i2 = className.length
     }
-    const columnIndex = parseInt(className.substr(i1+4,i2))
-    const cl = className.substr(i1, i2)
+    const columnIndex = parseInt(className.substr(i1 + 4, i2))
+    const clz = className.substr(i1, i2)
+
+    const oldTop = target.getBoundingClientRect().top
+    target.style.position = 'absolute'
+    target.style.top = oldTop + window.scrollY
+    target.style.left = e.pageX + 'px'
+    target.style.backgroundColor = 'red'
+    draggedColumnSizeHandle = target
+
+
 
     let list = document.styleSheets;
 
     for (let i = 0; i < list.length; i++) {
-      console.log(list.item(i));
+      const css = list.item(i);
+      if (css.href === '') {
+        console.log(css)
+      }
     }
+
+    console.log("ok")
+    document.onmousemove = columnResizeDrag
+    document.onmouseup = columnResizeEnd
+  }
+
+  function columnResizeDrag(e) {
+    e.preventDefault()
+
+    draggedColumnSizeHandle.style.left = e.pageX + 'px'
+  }
+
+  function columnResizeEnd(e) {
+    e.preventDefault()
+    document.onmousemove = null
+    document.onmouseup = null
   }
 
   function computeColumnWidths() {
@@ -434,8 +466,7 @@ export function grid(root, msgBus) {
 
       const handle = document.createElement('div')
       handle.className = 'qg-drag-handle qg-w' + i
-      handle.draggable = true
-      handle.ondragstart = columnResize
+      handle.onmousedown = columnResizeStart
       header.append(h, handle)
 
       w = Math.max(defaults.minColumnWidth, Math.ceil((c.name.length + c.type.length) * 8 * 1.2 + 10))

--- a/packages/web-console/src/js/console/grid.js
+++ b/packages/web-console/src/js/console/grid.js
@@ -36,6 +36,7 @@ export function grid(root, msgBus) {
     maxRowsToAnalyze: 100,
     minVpHeight: 120,
     minDivHeight: 160,
+    scrollerGirth: 10
   }
   const ACTIVE_CELL_CLASS = ' qg-c-active'
   const STYLE_TILE = 'qg-questdb-grid'
@@ -118,7 +119,7 @@ export function grid(root, msgBus) {
   // when render is attempted before data is available, we need to "remember" the
   // last render attempt and repeat is when data is ready
   const pendingRender = {colLo: 0, colHi: 0, nextVisColumnLo: 0, render: false};
-  const scrollerGirth = 10
+  const scrollerGirth = defaults.scrollerGirth
   let headerScrollerPlaceholder
 
   function setRowCount(rowCount) {

--- a/packages/web-console/src/js/console/grid.js
+++ b/packages/web-console/src/js/console/grid.js
@@ -385,6 +385,23 @@ export function grid(root, msgBus) {
     bus.trigger("editor.insert.column", e.currentTarget.getAttribute("data-column-name"))
   }
 
+  function columnResize(e) {
+    const className = e.target.className;
+    const i1 = className.indexOf('qg-w');
+    let i2 = className.indexOf(' ', i1);
+    if (i2 === -1) {
+      i2 = className.length
+    }
+    const columnIndex = parseInt(className.substr(i1+4,i2))
+    const cl = className.substr(i1, i2)
+
+    let list = document.styleSheets;
+
+    for (let i = 0; i < list.length; i++) {
+      console.log(list.item(i));
+    }
+  }
+
   function computeColumnWidths() {
     columnWidths = []
     columnOffsets = []
@@ -415,7 +432,11 @@ export function grid(root, msgBus) {
       h.append(hType, hName)
       h.onclick = broadcastColumnName
 
-      header.append(h)
+      const handle = document.createElement('div')
+      handle.className = 'qg-drag-handle qg-w' + i
+      handle.draggable = true
+      handle.ondragstart = columnResize
+      header.append(h, handle)
 
       w = Math.max(defaults.minColumnWidth, Math.ceil((c.name.length + c.type.length) * 8 * 1.2 + 10))
       columnOffsets.push(totalWidth)

--- a/packages/web-console/src/js/console/grid.js
+++ b/packages/web-console/src/js/console/grid.js
@@ -124,9 +124,7 @@ export function grid(root, msgBus) {
           rowContainer.style.display = "flex"
           for (k = 0; k < visColumnCount; k++) {
             const dd = d[k + visLeftColumn]
-            if (dd) {
-              rowContainer.childNodes[(k + visLeftColumn) % visColumnCount].innerHTML = dd.toString()
-            }
+            setCellData(rowContainer.childNodes[(k + visLeftColumn) % visColumnCount], dd)
           }
         } else {
           rowContainer.style.display = "none"
@@ -331,17 +329,7 @@ export function grid(root, msgBus) {
     // calculate CSS and width for all columns even though
     // we will render only a subset of them
     for (let i = 0; i < colMax.length; i++) {
-      rules.push(
-        ".qg-w" +
-        i +
-        "{width:" +
-        colMax[i] +
-        "px;" +
-        "position: absolute;" +
-        "left:" + left + "px;" +
-        getColumnAlignment(i) +
-        "}",
-      )
+      rules.push(".qg-w" + i + "{width:" + colMax[i] + "px;" + "position: absolute;" + "left:" + left + "px;" + getColumnAlignment(i) + "}",)
       left += colMax[i];
     }
     rules.push(".qg-r{width:" + totalWidth + "px;}")
@@ -352,9 +340,7 @@ export function grid(root, msgBus) {
       if ($style) {
         $style.remove()
       }
-      $style = $('<style rel="stylesheet"/>').appendTo(
-        $("head"),
-      )
+      $style = $('<style rel="stylesheet"/>').appendTo($("head"),)
       const rules = [];
 
       generatePxWidth(rules)
@@ -376,22 +362,9 @@ export function grid(root, msgBus) {
     for (i = 0; i < columnCount; i++) {
       const c = columns[i];
 
-      const col = $(
-        '<div class="qg-header qg-w' +
-        i +
-        '" data-column-name="' +
-        c.name +
-        '"><span class="qg-header-type">' +
-        c.type.toLowerCase() +
-        '</span><span class="qg-header-name">' +
-        c.name +
-        "</span></div>",
-      )
+      const col = $('<div class="qg-header qg-w' + i + '" data-column-name="' + c.name + '"><span class="qg-header-type">' + c.type.toLowerCase() + '</span><span class="qg-header-name">' + c.name + "</span></div>",)
         .on("click", function (e) {
-          bus.trigger(
-            "editor.insert.column",
-            e.currentTarget.getAttribute("data-column-name"),
-          )
+          bus.trigger("editor.insert.column", e.currentTarget.getAttribute("data-column-name"),)
         })
         .appendTo(header);
 
@@ -402,18 +375,12 @@ export function grid(root, msgBus) {
           break
       }
 
-      w = Math.max(
-        defaults.minColumnWidth,
-        Math.ceil((c.name.length + c.type.length) * 8 * 1.2 + 8),
-      )
+      w = Math.max(defaults.minColumnWidth, Math.ceil((c.name.length + c.type.length) * 8 * 1.2 + 8),)
       colMax.push(w)
       totalWidth += w
     }
 
-    const max =
-      data[0].length > defaults.maxRowsToAnalyze
-        ? defaults.maxRowsToAnalyze
-        : data[0].length;
+    const max = data[0].length > defaults.maxRowsToAnalyze ? defaults.maxRowsToAnalyze : data[0].length;
 
     for (let i = 0; i < max; i++) {
       const row = data[0][i];
@@ -502,13 +469,11 @@ export function grid(root, msgBus) {
           const dataBatch = data[Math.floor(i / pageSize)];
           const rowData = dataBatch[i % pageSize];
           if (rowData) {
-            const k = visLeftColumn;
-            const cell = row.childNodes[k % visColumnCount];
-            const cellData = rowData[visColumnCount + k];
-            cell.className = "qg-c qg-w" + (visColumnCount + k)
-            cell.innerHTML = cellData !== null ? cellData.toString() : "null"
-            // this is necessary for "click()" to know which cell index has focus
-            cell.cellIndex = (visColumnCount + k)
+            setCellDataAndAttributes(
+              row.childNodes[visLeftColumn % visColumnCount],
+              rowData[visColumnCount + visLeftColumn],
+              visColumnCount + visLeftColumn
+            )
           }
         }
       }
@@ -534,11 +499,11 @@ export function grid(root, msgBus) {
           const rowIndexInBatch = i % pageSize;
           const rowData = dataBatch[rowIndexInBatch];
           if (rowData) {
-            const cell = row.childNodes[Math.abs((visLeftColumn - 1) % visColumnCount)];
-            const cellData = rowData[visLeftColumn - 1];
-            cell.className = "qg-c qg-w" + (visLeftColumn - 1)
-            cell.innerHTML = cellData !== null ? cellData.toString() : "null"
-            cell.cellIndex = visLeftColumn - 1
+            setCellDataAndAttributes(
+              row.childNodes[Math.abs((visLeftColumn - 1) % visColumnCount)],
+              rowData[visLeftColumn - 1],
+              visLeftColumn - 1
+            )
           }
         }
       }
@@ -563,16 +528,22 @@ export function grid(root, msgBus) {
         const rowData = dataBatch[rowIndexInBatch];
         if (rowData) {
           for (let j = 0; j < visColumnCount; j++) {
-            const cell = row.childNodes[j];
-            const cellData = rowData[j];
-            cell.className = "qg-c qg-w" + j
-            cell.innerHTML = cellData !== null ? cellData.toString() : "null"
-            cell.cellIndex = j
+            setCellDataAndAttributes(row.childNodes[j], rowData[j], j);
           }
         }
       }
       visLeftColumn = 0;
     }
+  }
+
+  function setCellData(cell, cellData) {
+    cell.innerHTML = cellData !== null ? cellData.toString() : "null"
+  }
+
+  function setCellDataAndAttributes(cell, cellData, cellIndex) {
+    cell.className = "qg-c qg-w" + cellIndex
+    cell.cellIndex = cellIndex
+    setCellData(cell, cellData)
   }
 
   function moveViewPortEnd() {
@@ -602,7 +573,7 @@ export function grid(root, msgBus) {
             const cellIndex = columnCount - visColumnCount - start + j;
             const cellData = rowData[cellIndex];
             cell.className = "qg-c qg-w" + cellIndex
-            cell.innerHTML = cellData !== null ? cellData.toString() : "null"
+            setCellData(cell, cellData);
             cell.cellIndex = cellIndex
           }
         }
@@ -732,12 +703,7 @@ export function grid(root, msgBus) {
   function resize() {
     if ($("#grid").css("display") !== "none") {
       const wh = window.innerHeight - $(window).scrollTop()
-      viewportHeight = Math.round(
-        wh -
-        viewport.getBoundingClientRect().top -
-        $('[data-hook="notifications-wrapper"]').height() -
-        $("#footer").height(),
-      )
+      viewportHeight = Math.round(wh - viewport.getBoundingClientRect().top - $('[data-hook="notifications-wrapper"]').height() - $("#footer").height(),)
       viewportHeight = Math.max(viewportHeight, defaults.minVpHeight)
       rowsInView = Math.floor(viewportHeight / rh)
       createCss()

--- a/packages/web-console/src/scenes/Result/index.tsx
+++ b/packages/web-console/src/scenes/Result/index.tsx
@@ -187,12 +187,7 @@ const Result = () => {
       </Menu>
 
       <Content>
-        <div id="grid">
-          <div className="qg-header-row" />
-          <div className="qg-viewport">
-            <div className="qg-canvas" />
-          </div>
-        </div>
+        <div id="grid"/>
 
         <div id="quick-vis">
           <div className="quick-vis-controls">

--- a/packages/web-console/src/styles/_grid.scss
+++ b/packages/web-console/src/styles/_grid.scss
@@ -162,3 +162,15 @@
   background: white;
   border: 1px solid red;
 }
+
+.qg-drag-handle {
+  margin-left: -10px;
+  background-color: transparent;
+  width: 20px !important;
+  height: 32px;
+  z-index: 1;
+}
+
+.qg-drag-handle:hover {
+  cursor: col-resize;
+}

--- a/packages/web-console/src/styles/_grid.scss
+++ b/packages/web-console/src/styles/_grid.scss
@@ -34,7 +34,7 @@
 .qg-header-row {
   display: flex;
   overflow: hidden;
-  height: 33px;
+  height: 39px;
   position: relative;
 
   .qg-header:last-child {
@@ -77,11 +77,11 @@
   flex-shrink: 0;
   justify-content: flex-end;
   flex-direction: row;
-  padding: 5px 3px 7px;
+  padding: 8px 10px 5px;
   overflow: hidden;
   text-overflow: ellipsis;
   cursor: pointer;
-  border-bottom: 1px solid #191a21;
+  border-bottom: 2px groove #252b3f;
   -webkit-touch-callout: none; /* iOS Safari */
   -webkit-user-select: none; /* Safari */
   -moz-user-select: none; /* Old versions of Firefox */
@@ -90,6 +90,8 @@
   /* Non-prefixed version, currently
                                    supported by Chrome, Opera and Firefox */
   background: #21222c;
+  border-right: 2px groove #252b3f;
+  box-shadow: 4px 1px #252b3f;
 }
 
 .qg-header-name {
@@ -98,11 +100,11 @@
 }
 
 .qg-header-type {
-  font-weight: 700;
-  font-style: italic;
   margin: 0 7px;
   color: #6272a4;
-  white-space: nowrap;
+  vertical-align: sub;
+  font-size: x-small;
+  font-style: italic;
 }
 
 .qg-header-l {
@@ -130,7 +132,7 @@
 
 .qg-c:hover {
   box-shadow: inset 0 0 0 2px #8d95a5;
-  border-bottom: 1px solid transparent;
+  //border-bottom: 1px solid transparent;
 }
 
 .qg-r-active .qg-c:hover {
@@ -139,7 +141,7 @@
 
 .qg-c-active {
   box-shadow: inset 0 0 0 2px #f8f8f2;
-  border-bottom: 1px solid transparent;
+  //border-bottom: 1px solid transparent;
 }
 
 .qg-r-active:hover .qg-c-active,

--- a/packages/web-console/src/styles/_grid.scss
+++ b/packages/web-console/src/styles/_grid.scss
@@ -138,7 +138,6 @@
 
 .qg-c:hover {
   box-shadow: inset 0 0 0 2px #8d95a5;
-  //border-bottom: 1px solid transparent;
 }
 
 .qg-r-active .qg-c:hover {
@@ -147,7 +146,6 @@
 
 .qg-c-active {
   box-shadow: inset 0 0 0 2px #f8f8f2;
-  //border-bottom: 1px solid transparent;
 }
 
 .qg-r-active:hover .qg-c-active,

--- a/packages/web-console/src/styles/_grid.scss
+++ b/packages/web-console/src/styles/_grid.scss
@@ -55,7 +55,7 @@
   right: 0;
 }
 
-.qg-r:hover {
+.qg-hover .qg-r:hover {
   background-color: #44475a;
 }
 
@@ -63,7 +63,7 @@
   outline: none;
 }
 
-.qg-r-active:hover {
+.qg-hover .qg-r-active:hover {
   background-color: #6272a4;
   color: #f8f8f2;
 }

--- a/packages/web-console/src/styles/_grid.scss
+++ b/packages/web-console/src/styles/_grid.scss
@@ -37,8 +37,8 @@
   height: 39px;
   position: relative;
 
-  .qg-header:last-child {
-    margin-right: 10px;
+  .qg-header:nth-last-child(2) {
+    border-right: none !important;
   }
 }
 
@@ -70,6 +70,12 @@
 
 .qg-r-active {
   background-color: #6272a4;
+}
+
+.qg-stub {
+  border: none !important;
+  box-shadow: none !important;
+  height: 100% !important;
 }
 
 .qg-header {

--- a/packages/web-console/src/styles/_grid.scss
+++ b/packages/web-console/src/styles/_grid.scss
@@ -106,7 +106,7 @@
 }
 
 .qg-header-type {
-  margin: 0 7px;
+  margin: 2px 7px;
   color: #6272a4;
   vertical-align: sub;
   font-size: x-small;

--- a/packages/web-console/src/styles/_grid.scss
+++ b/packages/web-console/src/styles/_grid.scss
@@ -35,6 +35,7 @@
   display: flex;
   overflow: hidden;
   height: 33px;
+  position: relative;
 
   .qg-header:last-child {
     margin-right: 10px;


### PR DESCRIPTION
On wide tables or SQLs producing large number of columns the existing grid struggles. That is both render and navigate the data. This implementation renders fixed number of HTML elements that are reused as grid is navigated.

### Additionally fixed the following

- hover is disabled when grid is scrolled and re-enabled when scrolling stops
- fixed glitch causing  unexpected left-right scrolling. To reproduce on master, jump to end of dataset, scroll few rows up and scroll window left or right. You can see that active row jumps to bottom of the grid as you scroll left and right
- grid no longer uses `pct` for column width if columns do not fill the canvas, new grid looks like this:

![image](https://user-images.githubusercontent.com/7276403/215609611-4f9393b1-3f91-4c02-89a8-b36844d85a73.png)


### Also done

- ~~grid resize doesn't change virtual windows size~~
- ~~column resize~~
- row number column
- ~~header restyling~~
- ~~copy cell value into clipboard with standard keyboard shortcut~~