### PR TITLE
web-console: release 0.0.9

### DIFF
--- a/packages/web-console/CHANGELOG.md
+++ b/packages/web-console/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `Fixed` for any bug fixes.
 * `Security` in case of vulnerabilities.
 
+## 0.0.9 - 2023-02-02
+
+### Added
+
+- add icon next to WAL enabled tables [#73](https://github.com/questdb/ui/pull/73)
+- highlight `EXPLAIN` keyword in web console [#74](https://github.com/questdb/ui/pull/73)
+
 ## 0.0.8 - 2022-10-19
 
 ### Fixed

--- a/packages/web-console/package.json
+++ b/packages/web-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@questdb/web-console",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "license": "Apache-2.0",
   "description": "QuestDB Console",
   "files": [


### PR DESCRIPTION
release `@questdb/web-console@0.0.9`

changelog

- add icon next to WAL enabled tables [#73](https://github.com/questdb/ui/pull/73)
- highlight `EXPLAIN` keyword in web console [#74](https://github.com/questdb/ui/pull/73)