### PR TITLE
feat: updated grid visuals

### DIFF
--- a/packages/web-console/src/js/console/grid.js
+++ b/packages/web-console/src/js/console/grid.js
@@ -36,7 +36,8 @@ export function grid(root, msgBus) {
     maxRowsToAnalyze: 100,
     minVpHeight: 120,
     minDivHeight: 160,
-    scrollerGirth: 10
+    scrollerGirth: 10,
+    timestampColor: '#50fa7b'
   }
   const ACTIVE_CELL_CLASS = ' qg-c-active'
   const STYLE_TILE = 'qg-questdb-grid'
@@ -365,7 +366,7 @@ export function grid(root, msgBus) {
 
   function getColumnColor(columnIndex) {
     if (columnIndex === timestampIndex) {
-      return 'color: #8be9fd;'
+      return 'color: ' + defaults.timestampColor + ';'
     }
     return ''
   }

--- a/packages/web-console/src/js/console/grid.js
+++ b/packages/web-console/src/js/console/grid.js
@@ -461,6 +461,7 @@ export function grid(root, msgBus) {
       colResizeDragHandle.style.left = (colResizeDragHandleStartX + delta) + 'px'
       updateColumnWidth(colResizeColIndex, width)
       createCellStyle()
+      ensureCellsFillVisibleWindow()
     }
   }
 
@@ -474,7 +475,7 @@ export function grid(root, msgBus) {
   }
 
   function getCellWidth(valueLen) {
-    return Math.max(defaults.minColumnWidth, Math.ceil(valueLen * 8 * 0.9));
+    return Math.max(defaults.minColumnWidth, Math.ceil(valueLen * 8 * 1.2));
   }
 
   function createHeaderElements() {
@@ -920,25 +921,26 @@ export function grid(root, msgBus) {
     }
   }
 
+  function ensureCellsFillVisibleWindow() {
+    toggleScrollerPlaceholder()
+    const prevVisColumnCount = visColumnCount
+    computeVisibleColumnWindow()
+    if (prevVisColumnCount < visColumnCount) {
+      addCellElements(visColumnCount - prevVisColumnCount)
+    } else if (prevVisColumnCount > visColumnCount) {
+      removeCellElements(prevVisColumnCount)
+    }
+  }
+
   function resize() {
     if (grid[0].style.display !== 'none') {
 
       viewportHeight = Math.max(viewport.getBoundingClientRect().height, defaults.minVpHeight)
       rowsInView = Math.floor(viewportHeight / rh)
-      // createCss()
-
       const viewportWidth = viewport.getBoundingClientRect().width
       if (lastKnownViewportWidth !== viewportWidth) {
         lastKnownViewportWidth = viewportWidth
-        toggleScrollerPlaceholder()
-
-        const prevVisColumnCount = visColumnCount
-        computeVisibleColumnWindow()
-        if (prevVisColumnCount < visColumnCount) {
-          addCellElements(visColumnCount - prevVisColumnCount)
-        } else if (prevVisColumnCount > visColumnCount) {
-          removeCellElements(prevVisColumnCount)
-        }
+        ensureCellsFillVisibleWindow();
       }
       scroll()
     }

--- a/packages/web-console/src/js/console/grid.js
+++ b/packages/web-console/src/js/console/grid.js
@@ -56,6 +56,7 @@ export function grid(root, msgBus) {
   let columnOffsets
   let columns = []
   let columnCount = 0
+  let timestampIndex = -1
   let data = []
   let totalWidth = -1
   // number of divs in "rows" cache, has to be power of two
@@ -349,8 +350,8 @@ export function grid(root, msgBus) {
     }
   }
 
-  function getColumnAlignment(i) {
-    const col = columns[i]
+  function getColumnAlignment(columnIndex) {
+    const col = columns[columnIndex]
     if (col) {
       switch (col.type) {
         case 'STRING':
@@ -362,12 +363,19 @@ export function grid(root, msgBus) {
     }
   }
 
+  function getColumnColor(columnIndex) {
+    if (columnIndex === timestampIndex) {
+      return 'color: #8be9fd;'
+    }
+    return ''
+  }
+
   function getColumnWidth(i) {
     return columnOffsets[i + 1] - columnOffsets[i]
   }
 
   function getColumnWidthStyleSelector(columnIndex, width, left) {
-    return '.' + getColumnWidthSelector(columnIndex) + '{width:' + width + 'px;' + 'position: absolute;' + 'left:' + left + 'px;' + getColumnAlignment(columnIndex) + '}'
+    return '.' + getColumnWidthSelector(columnIndex) + '{width:' + width + 'px;' + 'position: absolute;' + 'left:' + left + 'px;' + getColumnAlignment(columnIndex) + getColumnColor(columnIndex) + '}'
   }
 
   function createColumnWidthStyleRules(rules) {
@@ -504,7 +512,7 @@ export function grid(root, msgBus) {
       hName.className = 'qg-header-name'
       hName.innerHTML = c.name
 
-      h.append(hType, hName)
+      h.append(hName, hType)
       h.onclick = broadcastColumnName
 
       const handle = document.createElement('div')
@@ -553,6 +561,7 @@ export function grid(root, msgBus) {
     visColumnLo = 0
     visColumnCount = 10
     lastKnownViewportWidth = 0
+    timestampIndex = -1
     enableHover()
   }
 
@@ -1157,6 +1166,7 @@ export function grid(root, msgBus) {
         data.push(m.dataset)
         columns = m.columns
         columnCount = columns.length
+        timestampIndex = m.timestamp
         createHeaderElements()
         computeVisibleColumnWindow()
         // visible position depends on correctness of visColumnCount value

--- a/packages/web-console/src/js/console/grid.js
+++ b/packages/web-console/src/js/console/grid.js
@@ -486,9 +486,6 @@ export function grid(root, msgBus) {
 
     columnResizeGhost.style.visibility = 'hidden';
     columnResizeGhost.style.left = 0;
-    // colResizeDragHandle.style.left = null
-    // colResizeDragHandle.style.backgroundColor = null
-    // colResizeDragHandle.style.marginLeft = colResizeOrigMargin
   }
 
   function getCellWidth(valueLen) {

--- a/packages/web-console/src/styles/_grid.scss
+++ b/packages/web-console/src/styles/_grid.scss
@@ -80,6 +80,10 @@ $row-height: 55px;
   height: 100% !important;
 }
 
+.qg-no-hover {
+  pointer-events: none;
+}
+
 .qg-header {
   padding: 10px 5px 10px 5px;
   cursor: pointer;
@@ -154,7 +158,7 @@ $row-height: 55px;
   text-align: right;
 }
 
-.qg-c:hover, .qg-r-active .qg-c:hover, .qg-c-active {
+.qg-hover .qg-c:hover, .qg-r-active .qg-c:hover, .qg-c-active {
   box-shadow: inset 0 0 0 2px #f1fa8c;
   border-radius: 6px;
 }

--- a/packages/web-console/src/styles/_grid.scss
+++ b/packages/web-console/src/styles/_grid.scss
@@ -91,7 +91,11 @@ $row-height: 55px;
   /* Non-prefixed version, currently
                                    supported by Chrome, Opera and Firefox */
   background: #21222c;
-  border: thin groove black;
+  border-left: thin groove black;
+}
+
+.qg-color-timestamp {
+  color: #50fa7b;
 }
 
 .qg-header-name {
@@ -103,6 +107,7 @@ $row-height: 55px;
   text-align: right;
   padding: 0;
   margin: 0;
+  font-size: medium;
 }
 
 .qg-header-l .qg-header-name {
@@ -110,7 +115,7 @@ $row-height: 55px;
 }
 
 .qg-header-type {
-  color: #6272a4;
+  color: #ff79c6;
   font-size: x-small;
   font-style: italic;
   text-overflow: ellipsis;
@@ -149,21 +154,14 @@ $row-height: 55px;
   text-align: right;
 }
 
-.qg-c:hover {
-  box-shadow: inset 0 0 0 2px #8d95a5;
-}
-
-.qg-r-active .qg-c:hover {
-  box-shadow: inset 0 0 0 2px #f8f8f2;
-}
-
-.qg-c-active {
-  box-shadow: inset 0 0 0 2px #f8f8f2;
+.qg-c:hover, .qg-r-active .qg-c:hover, .qg-c-active {
+  box-shadow: inset 0 0 0 2px #f1fa8c;
+  border-radius: 6px;
 }
 
 .qg-r-active:hover .qg-c-active,
 .qg-r-active:hover .qg-c-active:hover {
-  box-shadow: inset 0 0 0 2px #ffb86c;
+  box-shadow: inset 0 0 0 2px #f1fa8c;
 }
 
 #debug {

--- a/packages/web-console/src/styles/_grid.scss
+++ b/packages/web-console/src/styles/_grid.scss
@@ -75,8 +75,6 @@ $row-height: 55px;
 }
 
 .qg-stub {
-  border: none !important;
-  box-shadow: none !important;
   height: 100% !important;
 }
 
@@ -124,7 +122,6 @@ $visible-drag-handle-margin: 10px;
   width: $visible-drag-handle-margin * 2 !important;
   height: $row-height;
   z-index: 1;
-  //border: 1px dotted red;
 }
 
 .qg-drag-handle:hover {
@@ -140,10 +137,6 @@ $visible-drag-handle-margin: 10px;
   top: 0;
   left: 0;
   cursor: col-resize;
-}
-
-.qg-color-timestamp {
-  color: #50fa7b;
 }
 
 .qg-header-name, .qg-header-type {
@@ -176,9 +169,6 @@ $visible-drag-handle-margin: 10px;
   .qg-header-type {
     text-align: left;
   }
-}
-
-.qg-header-join {
 }
 
 .qg-viewport {

--- a/packages/web-console/src/styles/_grid.scss
+++ b/packages/web-console/src/styles/_grid.scss
@@ -31,10 +31,12 @@
   overflow: hidden;
 }
 
+$row-height: 55px;
+
 .qg-header-row {
   display: flex;
   overflow: hidden;
-  height: 39px;
+  height: $row-height;
   position: relative;
 
   .qg-header:nth-last-child(2) {
@@ -79,7 +81,7 @@
 }
 
 .qg-header {
-  padding: 10px 3px 10px 3px;
+  padding: 10px 5px 10px 5px;
   cursor: pointer;
   -webkit-touch-callout: none; /* iOS Safari */
   -webkit-user-select: none; /* Safari */
@@ -89,7 +91,7 @@
   /* Non-prefixed version, currently
                                    supported by Chrome, Opera and Firefox */
   background: #21222c;
-  border: thin groove rgb(119, 122, 135);
+  border: thin groove black;
 }
 
 .qg-header-name {
@@ -108,31 +110,15 @@
 }
 
 .qg-header-type {
-  visibility: hidden;
   color: #6272a4;
-  vertical-align: sub;
   font-size: x-small;
   font-style: italic;
   text-overflow: ellipsis;
-
-  width: 120px;
-  background-color: #21222c;
-  text-align: center;
-  border-radius: 6px;
-  border-color: yellow;
-  padding: 5px 0;
-
-  /* Position the tooltip */
-  position: absolute;
-  z-index: 1;
-}
-
-.qg-header:hover .qg-header-type {
-  margin-top: 10px;
-  visibility: visible;
-  animation-delay: -5s;
-  animation: 1s fadeIn;
-  animation-fill-mode: forwards;
+  text-align: right;
+  width: 100%;
+  display: block;
+  margin: 0;
+  padding: 0;
 }
 
 .qg-header-l {
@@ -140,6 +126,10 @@
   flex-direction: row-reverse;
   white-space: nowrap;
   text-overflow: ellipsis;
+
+  .qg-header-type{
+    text-align: left;
+  }
 }
 
 .qg-viewport {
@@ -153,7 +143,7 @@
 }
 
 .qg-c {
-  padding: 4px 3px;
+  padding: 4px 5px 4px 5px;
   overflow: hidden;
   text-overflow: ellipsis;
   text-align: right;
@@ -188,7 +178,7 @@
   margin-left: -10px;
   background-color: transparent;
   width: 20px !important;
-  height: 32px;
+  height: $row-height;
   z-index: 1;
 }
 

--- a/packages/web-console/src/styles/_grid.scss
+++ b/packages/web-console/src/styles/_grid.scss
@@ -79,15 +79,8 @@
 }
 
 .qg-header {
-  display: flex;
-  flex-shrink: 0;
-  justify-content: flex-end;
-  flex-direction: row;
-  padding: 8px 10px 5px;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  padding: 10px 3px 10px 3px;
   cursor: pointer;
-  border-bottom: 2px groove #252b3f;
   -webkit-touch-callout: none; /* iOS Safari */
   -webkit-user-select: none; /* Safari */
   -moz-user-select: none; /* Old versions of Firefox */
@@ -96,27 +89,57 @@
   /* Non-prefixed version, currently
                                    supported by Chrome, Opera and Firefox */
   background: #21222c;
-  border-right: 2px groove #252b3f;
-  box-shadow: 4px 1px #252b3f;
+  border: thin groove rgb(119, 122, 135);
 }
 
 .qg-header-name {
   font-weight: 700;
   color: #f1fa8c !important;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: right;
+  padding: 0;
+  margin: 0;
+}
+
+.qg-header-l .qg-header-name {
+  text-align: left;
 }
 
 .qg-header-type {
-  margin: 2px 7px;
+  visibility: hidden;
   color: #6272a4;
   vertical-align: sub;
   font-size: x-small;
   font-style: italic;
+  text-overflow: ellipsis;
+
+  width: 120px;
+  background-color: #21222c;
+  text-align: center;
+  border-radius: 6px;
+  border-color: yellow;
+  padding: 5px 0;
+
+  /* Position the tooltip */
+  position: absolute;
+  z-index: 1;
+}
+
+.qg-header:hover .qg-header-type {
+  margin-top: 10px;
+  visibility: visible;
+  animation-delay: -5s;
+  animation: 1s fadeIn;
+  animation-fill-mode: forwards;
 }
 
 .qg-header-l {
   text-align: left;
   flex-direction: row-reverse;
   white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .qg-viewport {

--- a/packages/web-console/src/styles/_grid.scss
+++ b/packages/web-console/src/styles/_grid.scss
@@ -27,7 +27,7 @@
   width: 100%;
   flex-direction: column;
   font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
-    "Courier New", monospace;
+  "Courier New", monospace;
   overflow: hidden;
 }
 
@@ -80,10 +80,6 @@ $row-height: 55px;
   height: 100% !important;
 }
 
-.qg-no-hover {
-  pointer-events: none;
-}
-
 .qg-header {
   padding: 10px 5px 10px 5px;
   cursor: pointer;
@@ -95,39 +91,80 @@ $row-height: 55px;
   /* Non-prefixed version, currently
                                    supported by Chrome, Opera and Firefox */
   background: #21222c;
-  border-left: thin groove black;
+}
+
+$visible-drag-handle-margin: 10px;
+
+.qg-header-border {
+  width: 100%;
+  position: absolute;
+  margin-top: 10px;
+  margin-left: $visible-drag-handle-margin;
+  height: 25px;
+  border-left: thin dashed #cac30f;
+}
+
+.qg-header-l .qg-header-border {
+  margin-left: 0 !important;
+}
+
+.qg-header-l .qg-header-name, .qg-header-l .qg-header-type {
+  text-align: left;
+}
+
+.qg-drag-handle-l {
+  margin-left: (-$visible-drag-handle-margin/2) !important;
+}
+
+// drag handle is not inside header element, it is next to it (sibling)
+.qg-drag-handle {
+  // place drag handle so that visible "line" is in the middle of it
+  // to add hysteresis for the drag cursor
+  margin-left: $visible-drag-handle-margin/2;
+  width: $visible-drag-handle-margin * 2 !important;
+  height: $row-height;
+  z-index: 1;
+  //border: 1px dotted red;
+}
+
+.qg-drag-handle:hover {
+  cursor: col-resize;
+}
+
+.qg-col-resize-ghost {
+  position: absolute;
+  width: 4px;
+  box-shadow: inset 0 0 0 2px #f1fa8c;
+  height: 0;
+  background: #f1fa8c;
+  top: 0;
+  left: 0;
+  cursor: col-resize;
 }
 
 .qg-color-timestamp {
   color: #50fa7b;
 }
 
+.qg-header-name, .qg-header-type {
+  display: block;
+  margin-left: $visible-drag-handle-margin + 3;
+  padding: 0;
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .qg-header-name {
   font-weight: 700;
   color: #f1fa8c !important;
-  display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  text-align: right;
-  padding: 0;
-  margin: 0;
   font-size: medium;
-}
-
-.qg-header-l .qg-header-name {
-  text-align: left;
 }
 
 .qg-header-type {
   color: #ff79c6;
   font-size: x-small;
   font-style: italic;
-  text-overflow: ellipsis;
-  text-align: right;
-  width: 100%;
-  display: block;
-  margin: 0;
-  padding: 0;
 }
 
 .qg-header-l {
@@ -136,9 +173,12 @@ $row-height: 55px;
   white-space: nowrap;
   text-overflow: ellipsis;
 
-  .qg-header-type{
+  .qg-header-type {
     text-align: left;
   }
+}
+
+.qg-header-join {
 }
 
 .qg-viewport {
@@ -174,16 +214,4 @@ $row-height: 55px;
   height: 300px;
   background: white;
   border: 1px solid red;
-}
-
-.qg-drag-handle {
-  margin-left: -10px;
-  background-color: transparent;
-  width: 20px !important;
-  height: $row-height;
-  z-index: 1;
-}
-
-.qg-drag-handle:hover {
-  cursor: col-resize;
 }

--- a/packages/web-console/src/styles/_navigation.scss
+++ b/packages/web-console/src/styles/_navigation.scss
@@ -472,7 +472,7 @@ body.canvas-menu .nav-header {
 
 body.mini-navbar #page-wrapper {
   margin-left: 45px;
-  overflow: auto;
+  overflow: hidden;
   position: relative;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
- type is subtext in column header
- column header is a little taller
- blank "grooves" around header as drag handles
- designated timestamp columns is highlighted in green
- column resize fixed as in when columns get narrower and by that do not fill entire viewport - the virtual cells are re-rendered and subsequent glitches fixed
- column width is rendered based on first 1000 rows of data

![image](https://user-images.githubusercontent.com/7276403/217344573-6317218c-d44a-4eda-80f0-9a7a24b8d339.png)

![image](https://user-images.githubusercontent.com/7276403/217344622-925708f8-ee41-422a-b567-9fce942c3a45.png)

![image](https://user-images.githubusercontent.com/7276403/217344669-702324f6-a3c5-41ed-9a55-c23e7e0b3f6a.png)
