### PR TITLE
fix(web-console): fix and refactor `handleMouseMove` handler

### DIFF
--- a/packages/web-console/src/scenes/Layout/index.tsx
+++ b/packages/web-console/src/scenes/Layout/index.tsx
@@ -92,16 +92,14 @@ const Layout = () => {
               <Splitter
                 direction="vertical"
                 fallback={editorSplitterBasis}
-                max={300}
-                min={200}
+                min={100}
                 onChange={handleEditorSplitterChange}
               >
                 <Top>
                   <Splitter
                     direction="horizontal"
                     fallback={resultsSplitterBasis}
-                    max={300}
-                    min={200}
+                    max={500}
                     onChange={handleResultsSplitterChange}
                   >
                     {!sm && <Schema />}


### PR DESCRIPTION
This commit simplifies the logic of positioning the splitter in
accordance to min/max setting.

With this fix, the splitter is not able to move past window size, and as
a result this makes split elements (table schema sidebar and grid)
always available for resizing.

closes #36 