### PR TITLE
chore(wal): add wal telemetry to telemetry tracking

### DIFF
--- a/packages/web-console/src/consts/index.ts
+++ b/packages/web-console/src/consts/index.ts
@@ -50,7 +50,7 @@ export enum ModalId {
 export enum TelemetryTable {
   MAIN = "telemetry",
   CONFIG = "telemetry_config",
-  WAL="sys.telemetry_wal"
+  WAL = "sys.telemetry_wal"
 }
 
 const BASE = process.env.NODE_ENV === "production" ? "fara" : "alurin"

--- a/packages/web-console/src/consts/index.ts
+++ b/packages/web-console/src/consts/index.ts
@@ -50,6 +50,7 @@ export enum ModalId {
 export enum TelemetryTable {
   MAIN = "telemetry",
   CONFIG = "telemetry_config",
+  WAL="sys.telemetry_wal"
 }
 
 const BASE = process.env.NODE_ENV === "production" ? "fara" : "alurin"

--- a/packages/web-console/src/store/Telemetry/epics.ts
+++ b/packages/web-console/src/store/Telemetry/epics.ts
@@ -132,13 +132,43 @@ export const startTelemetry: Epic<StoreAction, TelemetryAction, StoreShape> = (
       if (remoteConfig?.lastUpdated) {
         return from(
           quest.queryRaw(
-            `SELECT cast(created as long), event, origin
-                FROM ${TelemetryTable.MAIN}
-                WHERE created > '${new Date(
-                  remoteConfig.lastUpdated,
-                ).toISOString()}'
-                LIMIT -10000
-            `,
+            `with tel as (
+             SELECT cast(created as long), event, origin
+             FROM ${TelemetryTable.MAIN}
+             WHERE created > '${new Date(
+              remoteConfig.lastUpdated,
+             ).toISOString()}'
+             LIMIT -10000 
+            )            
+            SELECT cast(created as long), cast(1000 as short), cast(case when sm >= 0 then sm else 32767 end as short) FROM (
+              SELECT created, cast(ceil(sum(rowCount) / 1000.0) as short) sm
+              FROM ${TelemetryTable.WAL}
+              WHERE created > '${new Date(
+                remoteConfig.lastUpdated,
+              ).toISOString()}' and rowCount > 0
+              SAMPLE BY 1h align to calendar
+            )
+            UNION ALL 
+            SELECT cast(created as long), cast(2000 as short), cast(case when sm >= 0 then sm else 32767 end as short) FROM (
+              SELECT created, cast(ceil(sum(rowCount) / 1000.0) as short) sm
+              FROM ${TelemetryTable.WAL}
+              WHERE created > '${new Date(
+                remoteConfig.lastUpdated,
+              ).toISOString()}' and rowCount > 0
+              SAMPLE BY 1h align to calendar
+            )
+            UNION ALL 
+            SELECT cast(created as long), cast(3000 as short), cast(case when sm >= 0 then sm else 32767 end as short) FROM (
+              SELECT created, cast(max(latency) / 1000.0 as short) sm
+              FROM ${TelemetryTable.WAL}
+              WHERE created > '${new Date(
+                remoteConfig.lastUpdated,
+              ).toISOString()}' and rowCount > 0
+              SAMPLE BY 1h align to calendar
+             )
+             UNION ALL
+             SELECT * FROM tel
+             `,
           ),
         )
       }

--- a/packages/web-console/src/store/Telemetry/epics.ts
+++ b/packages/web-console/src/store/Telemetry/epics.ts
@@ -150,7 +150,7 @@ export const startTelemetry: Epic<StoreAction, TelemetryAction, StoreShape> = (
             )
             UNION ALL 
             SELECT cast(created as long), cast(2000 as short), cast(case when sm >= 0 then sm else 32767 end as short) FROM (
-              SELECT created, cast(ceil(sum(rowCount) / 1000.0) as short) sm
+              SELECT created, cast(count() as short) sm
               FROM ${TelemetryTable.WAL}
               WHERE created > '${new Date(
                 remoteConfig.lastUpdated,


### PR DESCRIPTION
Push WAL write telemetry as aggregated events with different origins

- `origin=1000` total row count written to WAL tables in thousands
- `origin=2000` total commits written to WAL tables
- `origin=3000` max commit write latency in seconds

WAL telemetry is aggregated by hour, so there will be max 3 rows per every hour.
All values are capped to max short 32767 value.

WAL telemetry is described at https://github.com/questdb/questdb/pull/2930