### PR TITLE
fix(web-console): fix sql editor error highlighting and code completions

### DIFF
--- a/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/createSchemaCompletionProvider.ts
+++ b/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/createSchemaCompletionProvider.ts
@@ -4,7 +4,7 @@ import { CompletionItemKind } from "./types"
 
 export const createSchemaCompletionProvider = (questDBTables: Table[] = []) => {
   const completionProvider: monaco.languages.CompletionItemProvider = {
-    triggerCharacters: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz '".split(
+    triggerCharacters: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz \"".split(
       "",
     ),
     provideCompletionItems(model, position) {
@@ -14,7 +14,7 @@ export const createSchemaCompletionProvider = (questDBTables: Table[] = []) => {
         startLineNumber: 1,
         startColumn: 1,
         endLineNumber: position.lineNumber,
-        endColumn: word.endColumn,
+        endColumn: word.startColumn,
       })
 
       const range = {
@@ -36,7 +36,7 @@ export const createSchemaCompletionProvider = (questDBTables: Table[] = []) => {
         /(FROM|INTO|TABLE) $/gim.test(textUntilPosition) ||
         (/'$/gim.test(textUntilPosition) && !textUntilPosition.endsWith("= '"))
       ) {
-        const openQuote = textUntilPosition.substr(-1 - word.word.length, 1) === "\"";
+        const openQuote = textUntilPosition.substr(-1) === "\"";
         const nextCharQuote = nextChar == "\"";
         return {
           suggestions: questDBTables.map((item) => {

--- a/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/createSchemaCompletionProvider.ts
+++ b/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/createSchemaCompletionProvider.ts
@@ -8,14 +8,14 @@ export const createSchemaCompletionProvider = (questDBTables: Table[] = []) => {
       "",
     ),
     provideCompletionItems(model, position) {
+      const word = model.getWordUntilPosition(position)
+
       const textUntilPosition = model.getValueInRange({
         startLineNumber: 1,
         startColumn: 1,
         endLineNumber: position.lineNumber,
-        endColumn: position.column,
+        endColumn: word.endColumn,
       })
-
-      const word = model.getWordUntilPosition(position)
 
       const range = {
         startLineNumber: position.lineNumber,
@@ -24,20 +24,29 @@ export const createSchemaCompletionProvider = (questDBTables: Table[] = []) => {
         endColumn: word.endColumn,
       }
 
+      const nextChar = model.getValueInRange({
+        startLineNumber: position.lineNumber,
+        startColumn: word.endColumn,
+        endLineNumber: position.lineNumber,
+        endColumn: word.endColumn + 1,
+      })
+
       if (
         word.word ||
         /(FROM|INTO|TABLE) $/gim.test(textUntilPosition) ||
         (/'$/gim.test(textUntilPosition) && !textUntilPosition.endsWith("= '"))
       ) {
+        const openQuote = textUntilPosition.substr(-1 - word.word.length, 1) === "\"";
+        const nextCharQuote = nextChar == "\"";
         return {
           suggestions: questDBTables.map((item) => {
             return {
               label: item.name,
               kind: CompletionItemKind.Class,
               insertText:
-                textUntilPosition.substr(-1) === "'"
-                  ? item.name
-                  : `'${item.name}'`,
+              openQuote
+                  ? item.name + (nextCharQuote ? "" : "\"")
+                  :  /^[a-z0-9_]+$/i.test(item.name) ? item.name : `"${item.name}"`,
               range,
             }
           }),

--- a/packages/web-console/src/scenes/Editor/Monaco/utils.ts
+++ b/packages/web-console/src/scenes/Editor/Monaco/utils.ts
@@ -216,8 +216,8 @@ export const getErrorRange = (
     let wordAtPosition
     if (selection && selectedText) {
       wordAtPosition = model.getWordAtPosition({
-        column: selection.startColumn + errorPosition,
-        lineNumber: selection.startLineNumber,
+        column: selection.startColumn + position.column,
+        lineNumber: position.lineNumber,
       })
     } else {
       wordAtPosition = model.getWordAtPosition(position)

--- a/packages/web-console/src/scenes/Schema/Row/index.tsx
+++ b/packages/web-console/src/scenes/Schema/Row/index.tsx
@@ -191,7 +191,7 @@ const Row = ({
   const handlePlusButtonClick = useCallback(
     (event: MouseEvent) => {
       event.stopPropagation()
-      insertTextAtCursor(kind === "table" ? `'${name}'` : name)
+      insertTextAtCursor(kind === "table" && !/^[a-z0-9_]+$/i.test(name) ? `"${name}"` : name)
     },
     [name, kind],
   )


### PR DESCRIPTION
Fixes #71

Fixes https://github.com/questdb/questdb/issues/1917

Also double quotes the table name on schema completion, as it's correct Postgres syntax and should be preferable. Single quoting works but it's QuestDB specific and confusing with string literals. 
