### PR TITLE
fix(docs): point to correct component READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ interface and surrounding tooling.
 
 Currently there are these packages:
 
-* [`web-console`](./packages/web-console/readme.md) - the GUI tool shipped with QuestDB
-* [`react-components`](./packages/react-components/readme.md) - small component library for internal reuse between QuestDB products
-* [`browser-tests`](./packages/browser-tests/readme.md) - a utility based on cypress that helps to automate interactions and assert zero regressions
-* [`screenshot-tests`](./packages/screenshot-tests/readme.md) - a utility based on puppeteer that helps to automate screenshot taking of a website and compare them between runs
+* [`web-console`](./packages/web-console/README.md) - the GUI tool shipped with QuestDB
+* [`react-components`](./packages/react-components/README.md) - small component library for internal reuse between QuestDB products
+* [`browser-tests`](./packages/browser-tests/README.md) - a utility based on cypress that helps to automate interactions and assert zero regressions
+* [`screenshot-tests`](./packages/screenshot-tests/README.md) - a utility based on puppeteer that helps to automate screenshot taking of a website and compare them between runs
 
 ## Contributing
 


### PR DESCRIPTION
Blobs in GitHub are case sensitive i.e., `readme.md` is not the same as `README.md`. 

Change the links to point to the correct files.

NOTE: This PR Should not break any builds.

closes #93 