### PR TITLE
test(web-console): run browser-tests in CI

### DIFF
--- a/.github/workflows/web-console.yml
+++ b/.github/workflows/web-console.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16.13.1'
-          cache: '$(Build.SourcesDirectory)/.yarn'
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache

--- a/.github/workflows/web-console.yml
+++ b/.github/workflows/web-console.yml
@@ -30,11 +30,7 @@ jobs:
         run: yarn workspace @questdb/web-console run test:prod
 
       - name: Run Cypress
-        uses: cypress-io/github-action@v5
-        with:
-          install: false
-          start: python -m http.server --directory dist 9999
-          command: yarn workspace browser-tests test       
+        run: python -m http.server --directory dist 9999 & yarn workspace browser-tests test       
 
       - name: Publish @questdb/web-console to npm
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/web-console.yml
+++ b/.github/workflows/web-console.yml
@@ -30,7 +30,7 @@ jobs:
         run: yarn workspace @questdb/web-console run test:prod
 
       - name: Run Cypress
-        run: python -m http.server --directory packages/web-console/dist 9999 & yarn workspace browser-tests test       
+        run: node packages/web-console/serve-dist.js & yarn workspace browser-tests test
 
       - name: Publish @questdb/web-console to npm
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/web-console.yml
+++ b/.github/workflows/web-console.yml
@@ -30,7 +30,7 @@ jobs:
         run: yarn workspace @questdb/web-console run test:prod
 
       - name: Run Cypress
-        run: python -m http.server --directory dist 9999 & yarn workspace browser-tests test       
+        run: python -m http.server --directory packages/web-console/dist 9999 & yarn workspace browser-tests test       
 
       - name: Publish @questdb/web-console to npm
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/web-console.yml
+++ b/.github/workflows/web-console.yml
@@ -29,13 +29,11 @@ jobs:
       - name: Run unit tests
         run: yarn workspace @questdb/web-console run test:prod
 
-      - name: run cypress tests
-        run: yarn workspace browser-tests test       
-
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:
           start: python -m http.server --directory dist 9999
+          command: yarn workspace browser-tests test       
 
       - name: Publish @questdb/web-console to npm
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/web-console.yml
+++ b/.github/workflows/web-console.yml
@@ -29,9 +29,10 @@ jobs:
       - name: Run unit tests
         run: yarn workspace @questdb/web-console run test:prod
 
-      - name: Cypress run
+      - name: Run Cypress
         uses: cypress-io/github-action@v5
         with:
+          install: false
           start: python -m http.server --directory dist 9999
           command: yarn workspace browser-tests test       
 

--- a/.github/workflows/web-console.yml
+++ b/.github/workflows/web-console.yml
@@ -13,17 +13,29 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16.13.1'
-          cache: 'yarn'
+          cache: '$(Build.SourcesDirectory)/.yarn'
+
+      - task: Cache@2
+        inputs:
+          key: '"questdb_ui" | "$(Agent.OS)" | "yarn"'
+          restoreKeys: |
+            "questdb_ui" | "$(Agent.OS)" | "yarn"
+          path: $(.yarn)
 
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache
 
-      - name: build
+      - name: Build
         run: yarn workspace @questdb/web-console run build
 
-      - name: test
+      - name: Run unit tests
         run: yarn workspace @questdb/web-console run test:prod
 
+      - name: start QuestDB docker
+        run: docker run -d --rm -p 9000:9000 questdb/questdb:nightly
+
+      - name: start node and run cypress tests
+        run: yarn workspace @questdb/web-console start & yarn workspace browser-tests test       
       - name: Publish @questdb/web-console to npm
         if: github.ref == 'refs/heads/main'
         uses: JS-DevTools/npm-publish@v1

--- a/.github/workflows/web-console.yml
+++ b/.github/workflows/web-console.yml
@@ -15,13 +15,6 @@ jobs:
           node-version: '16.13.1'
           cache: '$(Build.SourcesDirectory)/.yarn'
 
-      - task: Cache@2
-        inputs:
-          key: '"questdb_ui" | "$(Agent.OS)" | "yarn"'
-          restoreKeys: |
-            "questdb_ui" | "$(Agent.OS)" | "yarn"
-          path: $(.yarn)
-
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache
 

--- a/.github/workflows/web-console.yml
+++ b/.github/workflows/web-console.yml
@@ -4,9 +4,13 @@ on:
   push:
 
 jobs:
-  build:
+  CI:
     name: Build packages/web-console
     runs-on: ubuntu-latest
+    services:
+      questdb:
+        image: questdb/questdb:nightly
+        ports: 9000:9000
 
     steps:
       - uses: actions/checkout@v3
@@ -24,11 +28,14 @@ jobs:
       - name: Run unit tests
         run: yarn workspace @questdb/web-console run test:prod
 
-      - name: start QuestDB docker
-        run: docker run -d --rm -p 9000:9000 questdb/questdb:nightly
+      - name: run cypress tests
+        run: yarn workspace browser-tests test       
 
-      - name: start node and run cypress tests
-        run: yarn workspace @questdb/web-console start & yarn workspace browser-tests test       
+      - name: Cypress run
+        uses: cypress-io/github-action@v5
+        with:
+          start: python -m http.server --directory dist 9999
+
       - name: Publish @questdb/web-console to npm
         if: github.ref == 'refs/heads/main'
         uses: JS-DevTools/npm-publish@v1

--- a/.github/workflows/web-console.yml
+++ b/.github/workflows/web-console.yml
@@ -10,7 +10,8 @@ jobs:
     services:
       questdb:
         image: questdb/questdb:nightly
-        ports: 9000:9000
+        ports:
+          - 9000:9000
 
     steps:
       - uses: actions/checkout@v3

--- a/packages/browser-tests/cypress.config.js
+++ b/packages/browser-tests/cypress.config.js
@@ -2,6 +2,8 @@ const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
   e2e: {
+    screenshotOnRunFailure: false,
+    video: false,
     baseUrl: "http://localhost:9999",
     viewportWidth: 1280,
     viewportHeight: 720,

--- a/packages/browser-tests/cypress/commands.js
+++ b/packages/browser-tests/cypress/commands.js
@@ -52,6 +52,27 @@ Cypress.Commands.add("getAutocomplete", () =>
 
 Cypress.Commands.add("getErrorMarker", () => cy.get(".squiggly-error"));
 
+const numberRangeRegexp = (n, width = 3) => {
+  const [min, max] = [n - width, n + width];
+  const numbers = Array.from(
+    { length: Math.abs(max - min) },
+    (_, i) => min + i
+  );
+  return `(${numbers.join("|")})`;
+};
+
+Cypress.Commands.add("matchErrorMarkerPosition", ({ left, width }) =>
+  cy
+    .getErrorMarker()
+    .should("have.attr", "style")
+    .and(
+      "match",
+      new RegExp(
+        `left:${numberRangeRegexp(left)}px;width:${numberRangeRegexp(width)}px;`
+      )
+    )
+);
+
 Cypress.Commands.add("F9", () =>
   cy.getEditor().trigger("keydown", {
     keyCode: 120,

--- a/packages/browser-tests/cypress/integration/console/editor.spec.js
+++ b/packages/browser-tests/cypress/integration/console/editor.spec.js
@@ -229,8 +229,7 @@ describe("errors", () => {
   it("should mark date position as error", () => {
     const query = `select * from long_sequence(1) where cast(x as timestamp) = '2012-04-12T12:00:00A'`;
     cy.runQuery(query);
-    cy.matchErrorMarkerPosition({ left: 506, width: 185 });
-
+    cy.matchErrorMarkerPosition({ left: 506, width: 42 });
     cy.getNotifications().should("contain", "Invalid date");
   });
 });

--- a/packages/browser-tests/cypress/integration/console/editor.spec.js
+++ b/packages/browser-tests/cypress/integration/console/editor.spec.js
@@ -194,7 +194,7 @@ describe("autocomplete", () => {
   it("should work when tables list is not empty", () => {
     cy.runQuery('create table "my_secrets" ("secret" string)');
     cy.runQuery('create table "my_publics" ("public" string)');
-    cy.reload();
+    cy.visit(baseUrl);
     cy.typeQuery("select * from ");
     cy.getAutocomplete().should("not.contain", "telemetry");
     cy.getAutocomplete().should("contain", "my_secrets");

--- a/packages/browser-tests/cypress/integration/console/editor.spec.js
+++ b/packages/browser-tests/cypress/integration/console/editor.spec.js
@@ -2,15 +2,6 @@
 
 const baseUrl = "http://localhost:9999";
 
-const numberRangeRegexp = (n, width = 3) => {
-  const [min, max] = [n - width, n + width];
-  const numbers = Array.from(
-    { length: Math.abs(max - min) },
-    (_, i) => min + i
-  );
-  return numbers.join("|");
-};
-
 describe("appendQuery", () => {
   const consoleConfiguration = {
     savedQueries: [
@@ -226,40 +217,19 @@ describe("errors", () => {
   it("should mark '(200000)' as error", () => {
     const query = `create table test (\ncol symbol index CAPACITY (200000)`;
     cy.runQuery(query);
-    cy.getErrorMarker()
-      .should("have.attr", "style")
-      .and(
-        "match",
-        new RegExp(
-          `left:${numberRangeRegexp(237)}px;width:${numberRangeRegexp(67)}px;`
-        )
-      );
+    cy.matchErrorMarkerPosition({ left: 237, width: 67 });
   });
 
   it("should mark 'telemetry' as error", () => {
     const query = `CREATE TABLE 'telemetry' (id LONG256)`;
     cy.runQuery(query);
-    cy.getErrorMarker()
-      .should("have.attr", "style")
-      .and(
-        "match",
-        new RegExp(
-          `left:${numberRangeRegexp(111)}px;width:${numberRangeRegexp(93)}px;`
-        )
-      );
+    cy.matchErrorMarkerPosition({ left: 111, width: 93 });
   });
 
   it("should mark date position as error", () => {
     const query = `select * from long_sequence(1) where cast(x as timestamp) = '2012-04-12T12:00:00A'`;
     cy.runQuery(query);
-    cy.getErrorMarker()
-      .should("have.attr", "style")
-      .and(
-        "match",
-        new RegExp(
-          `left:${numberRangeRegexp(506)}px;width:${numberRangeRegexp(42)}px;`
-        )
-      );
+    cy.matchErrorMarkerPosition({ left: 506, width: 185 });
 
     cy.getNotifications().should("contain", "Invalid date");
   });

--- a/packages/web-console/serve-dist.js
+++ b/packages/web-console/serve-dist.js
@@ -1,0 +1,56 @@
+const http = require("http")
+const url = require("url")
+const fs = require("fs")
+const path = require("path")
+
+const server = http.createServer((req, res) => {
+  const { method } = req
+  const urlData = url.parse(req.url)
+
+  if (urlData.pathname.startsWith("/exec")) {
+    // proxy /exec requests to localhost:9000
+    const options = {
+      hostname: "localhost",
+      port: 9000,
+      path: urlData.path,
+      method,
+      headers: req.headers,
+    }
+
+    const proxyReq = http.request(options, (proxyRes) => {
+      res.writeHead(proxyRes.statusCode, proxyRes.headers)
+      proxyRes.pipe(res, { end: true })
+    })
+
+    req.pipe(proxyReq, { end: true })
+  } else {
+    // serve static files from /dist folder
+    const filePath = path.join(
+      process.cwd(),
+      "packages",
+      "web-console",
+      "dist",
+      ["", "/"].some((p) => urlData.pathname === p)
+        ? "index.html"
+        : urlData.pathname,
+    )
+    const fileStream = fs.createReadStream(filePath)
+
+    fileStream.on("error", (err) => {
+      if (err.code === "ENOENT") {
+        res.statusCode = 404
+        res.end(`File not found: ${urlData}`)
+      } else {
+        res.statusCode = 500
+        res.end(`Server error: ${err}`)
+      }
+    })
+
+    fileStream.pipe(res)
+  }
+})
+
+const PORT = process.env.PORT || 9999
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`)
+})


### PR DESCRIPTION
This PR makes cypress tests written in `packages/browser-tests` to run in CI during PR builds.

<img width="744" alt="Screenshot 2023-02-15 at 02 32 33" src="https://user-images.githubusercontent.com/4284659/218894825-b540668c-236f-4d88-85f0-079570e2ad3e.png">

Example run can be seen on
* [`checks` of this PR](https://github.com/questdb/ui/pull/103/checks)
* https://github.com/questdb/ui/actions/runs/4179369686/jobs/7239237886