### PR TITLE
chore(web-console): add meta description

### DIFF
--- a/packages/web-console/src/index.hbs
+++ b/packages/web-console/src/index.hbs
@@ -5,6 +5,7 @@
     <link rel="icon" href="/assets/favicon.ico">
     <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="QuestDB live demo. Query three large datasets and more than 2 billion rows in milliseconds with SQL" />
     <title>QuestDB · Console</title>
 </head>
 


### PR DESCRIPTION
This PR adds this code to web-console HTML template:

```html
<meta
  name="description"
  content="QuestDB live demo. Query three large datasets and more than 2 billion rows in milliseconds with SQL"
/>
```

Web console is used not only as part of QuestDB distributable for users
to run locally (or on cloud.questdb.com) but also on demo.questdb.io

demo.questdb.io is indexed by google and comes up in search results.
Currently, it looks like this:

image

The description added here will eventually be picked up by google.

Although this same description would be used for both demo.questdb.io and local web console, I think it's fine to use the same description for both.
This is because only demo.questdb.io is indexed by google and the description is not used for local or cloud web console.
