### PR TITLE
feat(react-components): add dialog component

### DIFF
--- a/packages/react-components/src/components/Dialog/index.tsx
+++ b/packages/react-components/src/components/Dialog/index.tsx
@@ -1,0 +1,85 @@
+import * as RadixDialog from "@radix-ui/react-dialog";
+import styled, { css } from "styled-components";
+
+const dialogShow = css`
+  @keyframes dialogShow {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+`;
+
+const dialogHide = css`
+  @keyframes dialogHide {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+    }
+  }
+`;
+
+export const Dialog = {
+  Root: RadixDialog.Root,
+  Overlay: RadixDialog.Overlay,
+  Trigger: RadixDialog.Trigger,
+  Portal: RadixDialog.Portal,
+  Content: styled(RadixDialog.Content)<{ maxwidth?: string }>`
+    background-color: ${({ theme }) => theme.color.background};
+    border-radius: ${({ theme }) => theme.borderRadius};
+    box-shadow: 0 7px 30px -10px ${({ theme }) => theme.color.black};
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 90vw;
+    max-width: ${({ maxwidth }) => maxwidth ?? "50rem"};
+    max-height: 85vh;
+    padding: 0 0 2rem 0;
+    border: 1px ${({ theme }) => theme.color.selection} solid;
+    z-index: 101;
+
+    ${dialogShow}
+    ${dialogHide}
+    
+    &[data-state="open"] {
+      animation: dialogShow 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    &[data-state="closed"] {
+      animation: dialogHide 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    &:focus {
+      outline: none;
+    }
+  `,
+  Title: styled(RadixDialog.Title)`
+    margin: 0;
+    padding: 2rem;
+    font-size: 1.6rem;
+    color: ${({ theme }) => theme.color.foreground};
+    border-bottom: 1px ${({ theme }) => theme.color.backgroundLighter} solid;
+  `,
+  Description: styled.div`
+    margin-top: 2rem;
+    padding: 0 2rem;
+    color: ${({ theme }) => theme.color.foreground};
+  `,
+  ActionButtons: styled.div`
+    display: flex;
+    width: 100%;
+    justify-content: flex-end;
+    padding: 0 2rem;
+    margin-top: 2rem;
+
+    > button:not(:last-child) {
+      margin-right: 1rem;
+    }
+  `,
+  Close: RadixDialog.Close,
+};

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -2,6 +2,7 @@ export { AlertDialog } from "./components/AlertDialog";
 export { Badge } from "./components/Badge";
 export { Button } from "./components/Button";
 export { Checkbox } from "./components/Checkbox";
+export { Dialog } from "./components/Dialog";
 export { ForwardRef } from "./components/ForwardRef";
 export { Heading } from "./components/Heading";
 export { Input } from "./components/Input";


### PR DESCRIPTION
According to Radix docs, `AlertDialog` should be only used for actions that need to be acted upon, therefore it doesn't have certain features by default (i.e. dismiss on ESC / backdrop click).

Therefore, for things like `Rename table`, regular `Dialog` should be used.