### PR TITLE
chore(web-console): allow editing column types on existing tables

### DIFF
--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/table-schema/column.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/table-schema/column.tsx
@@ -127,7 +127,7 @@ export const Column = ({
                       column.name !== "" &&
                       timestamp === column.name
                         ? "success"
-                        : "transparent"
+                        : "secondary"
                     }
                     onClick={() => {
                       onSetTimestamp(column.name)

--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/table-schema/column.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/table-schema/column.tsx
@@ -186,7 +186,6 @@ export const Column = ({
                 }
               >
                 <Form.Input
-                  disabled={isEditLocked}
                   name={`schemaColumns.${index}.precision`}
                   required
                 />

--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/table-schema/column.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/table-schema/column.tsx
@@ -111,7 +111,6 @@ export const Column = ({
               </Form.Item>
               <Form.Item name={`schemaColumns.${index}.type`} label="Type">
                 <Form.Select
-                  disabled={isEditLocked}
                   defaultValue={column.type}
                   name={`schemaColumns.${index}.type`}
                   options={supportedColumnTypes}
@@ -122,7 +121,7 @@ export const Column = ({
               <IconWithTooltip
                 icon={
                   <Button
-                    disabled={type !== "TIMESTAMP" || isEditLocked}
+                    disabled={column.type !== "TIMESTAMP"}
                     skin={
                       timestamp !== "" &&
                       column.name !== "" &&
@@ -161,7 +160,6 @@ export const Column = ({
                 helperText="Required when using the TIMESTAMP type"
               >
                 <Form.Input
-                  disabled={isEditLocked}
                   name={`schemaColumns.${index}.pattern`}
                   placeholder={DEFAULT_TIMESTAMP_FORMAT}
                   defaultValue={

--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/table-schema/columns.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/table-schema/columns.tsx
@@ -127,16 +127,6 @@ export const Columns = ({
 
   return (
     <>
-      {isEditLocked && (
-        <Disclaimer isEditLocked={true}>
-          <Alert size="20px" />
-          <Text color="orange">
-            Schema is read-only when importing to an existing table.
-            <br />
-            To edit, change the target table name and try again.
-          </Text>
-        </Disclaimer>
-      )}
       {!isEditLocked && (
         <Disclaimer isEditLocked={false}>
           <Information size="20px" />


### PR DESCRIPTION
Previously, all schema edits have been locked on existing tables. This PR allows user to change column type and associated properties (designated timestamp etc)>

Existing table schema:
<img width="1430" alt="CleanShot 2023-05-16 at 11 42 42@2x" src="https://github.com/questdb/ui/assets/1871646/f8c9ae00-c1b1-4633-8c29-8b62a51ca27e">
