### PR TITLE
chore(web-console): update ui of columns in CSV import schema edit dialog

### DIFF
--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/table-schema/column.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/table-schema/column.tsx
@@ -80,103 +80,115 @@ export const Column = ({
 
   return (
     <Root key={column.name} odd={index % 2 !== 0}>
-      <MainControl>
-        <Form.Item name={`schemaColumns.${index}.name`} label="Name">
-          <Form.Input
-            disabled={isEditLocked}
-            defaultValue={column.name}
-            name={`schemaColumns.${index}.name`}
-            onChange={(e) => {
-              onNameChange(e.target.value)
-            }}
-            autoComplete="off"
-          />
-        </Form.Item>
+      <Row>
+        <Columns>
+          <Item>
+            <MainControl>
+              <Form.Item name={`schemaColumns.${index}.name`} label="Name">
+                <Form.Input
+                  disabled={isEditLocked}
+                  defaultValue={column.name}
+                  name={`schemaColumns.${index}.name`}
+                  onChange={(e) => {
+                    onNameChange(e.target.value)
+                  }}
+                  autoComplete="off"
+                />
+              </Form.Item>
 
-        <Form.Item name={`schemaColumns.${index}.type`} label="Type">
-          <Form.Select
-            defaultValue={column.type}
-            name={`schemaColumns.${index}.type`}
-            options={supportedColumnTypes}
-            onChange={handleTypeChange}
-          />
-        </Form.Item>
+              <Form.Item name={`schemaColumns.${index}.type`} label="Type">
+                <Form.Select
+                  defaultValue={column.type}
+                  name={`schemaColumns.${index}.type`}
+                  options={supportedColumnTypes}
+                  onChange={handleTypeChange}
+                />
+              </Form.Item>
 
-        {!isEditLocked && (
-          <Button
-            skin="transparent"
-            onClick={() => onRemove(index)}
-            type="button"
-          >
-            <Close size="18px" />
-          </Button>
-        )}
-      </MainControl>
+              {!isEditLocked && (
+                <Button
+                  skin="transparent"
+                  onClick={() => onRemove(index)}
+                  type="button"
+                >
+                  <Close size="18px" />
+                </Button>
+              )}
+            </MainControl>
 
-      {type === "TIMESTAMP" && (
-        <Timestamp>
-          <Form.Item name={`schemaColumns.${index}.pattern`} label="Pattern">
-            <Form.Input
-              name={`schemaColumns.${index}.pattern`}
-              placeholder={DEFAULT_TIMESTAMP_FORMAT}
-              defaultValue={
-                column.pattern !== ""
-                  ? column.pattern
-                  : DEFAULT_TIMESTAMP_FORMAT
-              }
-              required
-            />
-          </Form.Item>
-
-          <IconWithTooltip
-            icon={
-              <Button
-                skin={
-                  timestamp !== "" &&
-                  column.name !== "" &&
-                  timestamp === column.name
-                    ? "success"
-                    : "secondary"
-                }
-                onClick={() => onSetTimestamp(column.name)}
-                type="button"
-                prefixIcon={
-                  <input
-                    type="checkbox"
-                    checked={
-                      timestamp !== "" &&
-                      column.name !== "" &&
-                      timestamp === column.name
+            {type === "TIMESTAMP" && (
+              <Timestamp>
+                <Form.Item
+                  name={`schemaColumns.${index}.pattern`}
+                  label="Pattern"
+                >
+                  <Form.Input
+                    name={`schemaColumns.${index}.pattern`}
+                    placeholder={DEFAULT_TIMESTAMP_FORMAT}
+                    defaultValue={
+                      column.pattern !== ""
+                        ? column.pattern
+                        : DEFAULT_TIMESTAMP_FORMAT
                     }
+                    required
                   />
+                </Form.Item>
+
+                <IconWithTooltip
+                  icon={
+                    <Button
+                      skin={
+                        timestamp !== "" &&
+                        column.name !== "" &&
+                        timestamp === column.name
+                          ? "success"
+                          : "secondary"
+                      }
+                      onClick={() => onSetTimestamp(column.name)}
+                      type="button"
+                      prefixIcon={
+                        <input
+                          type="checkbox"
+                          checked={
+                            timestamp !== "" &&
+                            column.name !== "" &&
+                            timestamp === column.name
+                          }
+                        />
+                      }
+                    >
+                      Designated
+                    </Button>
+                  }
+                  tooltip="Mark this column as a designated timestamp"
+                  placement="top"
+                />
+              </Timestamp>
+            )}
+
+            {type === "GEOHASH" && (
+              <Form.Item
+                name={`schemaColumns.${index}.precision`}
+                label="Precision"
+                helperText={
+                  <a
+                    href="https://questdb.io/docs/concept/geohashes/#specifying-geohash-precision"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Docs on QuestDB geohash precision
+                  </a>
                 }
               >
-                Designated
-              </Button>
-            }
-            tooltip="Mark this column as a designated timestamp"
-            placement="top"
-          />
-        </Timestamp>
-      )}
-
-      {type === "GEOHASH" && (
-        <Form.Item
-          name={`schemaColumns.${index}.precision`}
-          label="Precision"
-          helperText={
-            <a
-              href="https://questdb.io/docs/concept/geohashes/#specifying-geohash-precision"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Docs on QuestDB geohash precision
-            </a>
-          }
-        >
-          <Form.Input name={`schemaColumns.${index}.precision`} required />
-        </Form.Item>
-      )}
+                <Form.Input
+                  name={`schemaColumns.${index}.precision`}
+                  required
+                />
+              </Form.Item>
+            )}
+          </Item>
+        </Columns>
+      </Row>
     </Root>
   )
 }

--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/table-schema/column.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/table-schema/column.tsx
@@ -151,9 +151,12 @@ export const Column = ({
             href="https://questdb.io/docs/concept/geohashes/#specifying-geohash-precision"
             target="_blank"
             rel="noopener noreferrer"
-            style={{ height: "100%" }}
           >
-            <Button skin="transparent" prefixIcon={<Book size="14" />}>
+            <Button
+              skin="transparent"
+              prefixIcon={<Book size="14" />}
+              type="button"
+            >
               Docs
             </Button>
           </a>

--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/table-schema/column.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/table-schema/column.tsx
@@ -3,6 +3,7 @@ import { Form } from "../../../../components/Form"
 import { IconWithTooltip } from "../../../../components"
 import { Button } from "@questdb/react-components"
 import { Close } from "styled-icons/remix-line"
+import { Book } from "styled-icons/boxicons-regular"
 import { DEFAULT_TIMESTAMP_FORMAT } from "../const"
 import styled from "styled-components"
 import { SchemaColumn } from "utils"
@@ -32,20 +33,13 @@ const Root = styled.div<{ odd: boolean }>`
   ${({ odd }) => odd && "background-color: #272833;"};
 `
 
-const MainControl = styled.div`
+const Controls = styled.div`
   display: grid;
   grid-template-columns: var(--columns);
   gap: 1rem;
   width: 100%;
   align-items: flex-end;
-`
-
-const Timestamp = styled.div`
-  display: grid;
-  grid-template-columns: var(--columns);
-  gap: 1rem;
-  width: 100%;
-  align-items: flex-end;
+  justify-items: center;
 `
 
 export const Column = ({
@@ -69,7 +63,7 @@ export const Column = ({
 
   return (
     <Root key={column.name} odd={index % 2 !== 0}>
-      <MainControl>
+      <Controls>
         <Form.Item name={`schemaColumns.${index}.name`} label="Name">
           <Form.Input
             disabled={disabled}
@@ -96,10 +90,10 @@ export const Column = ({
             <Close size="18px" />
           </Button>
         )}
-      </MainControl>
+      </Controls>
 
       {column.type === "TIMESTAMP" && (
-        <Timestamp>
+        <Controls>
           <Form.Item name={`schemaColumns.${index}.pattern`} label="Pattern">
             <Form.Input
               name={`schemaColumns.${index}.pattern`}
@@ -142,41 +136,28 @@ export const Column = ({
             tooltip="Mark this column as a designated timestamp"
             placement="top"
           />
-        </Timestamp>
+        </Controls>
       )}
 
-      {column.type === "TIMESTAMP" && (
-        <Form.Item
-          name={`schemaColumns.${index}.pattern`}
-          label="Timestamp pattern"
-          helperText="Required when using the TIMESTAMP type"
-        >
-          <Form.Input
-            name={`schemaColumns.${index}.pattern`}
-            placeholder={DEFAULT_TIMESTAMP_FORMAT}
-            defaultValue={
-              column.pattern !== "" ? column.pattern : DEFAULT_TIMESTAMP_FORMAT
-            }
-            required
-          />
-        </Form.Item>
-      )}
       {column.type === "GEOHASH" && (
-        <Form.Item
-          name={`schemaColumns.${index}.precision`}
-          label="Precision"
-          helperText={
-            <a
-              href="https://questdb.io/docs/concept/geohashes/#specifying-geohash-precision"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Docs on QuestDB geohash precision
-            </a>
-          }
-        >
-          <Form.Input name={`schemaColumns.${index}.precision`} required />
-        </Form.Item>
+        <Controls>
+          <Form.Item
+            name={`schemaColumns.${index}.precision`}
+            label="Precision"
+          >
+            <Form.Input name={`schemaColumns.${index}.precision`} required />
+          </Form.Item>
+          <a
+            href="https://questdb.io/docs/concept/geohashes/#specifying-geohash-precision"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ height: "100%" }}
+          >
+            <Button skin="transparent" prefixIcon={<Book size="14" />}>
+              Docs
+            </Button>
+          </a>
+        </Controls>
       )}
     </Root>
   )

--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/table-schema/column.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/table-schema/column.tsx
@@ -1,12 +1,9 @@
 import React from "react"
 import { useState } from "react"
-import { Box } from "../../../../components/Box"
 import { Form } from "../../../../components/Form"
 import { IconWithTooltip } from "../../../../components"
 import { Button } from "@questdb/react-components"
 import { Close } from "styled-icons/remix-line"
-import { SortDown } from "styled-icons/boxicons-regular"
-import { Drawer } from "../../../../components/Drawer"
 import { DEFAULT_TIMESTAMP_FORMAT } from "../const"
 import { SchemaColumn } from "../types"
 import { ProcessedFile } from "../types"
@@ -29,39 +26,28 @@ const supportedColumnTypes: { label: string; value: string }[] = [
   { label: "TIMESTAMP", value: "TIMESTAMP" },
 ]
 
-const Row = styled(Box).attrs({
-  flexDirection: "column",
-  align: "flex-start",
-  gap: "2rem",
-})`
-  width: 100%;
+const Root = styled.div<{ odd: boolean }>`
+  --columns: auto 120px 40px; /* magic numbers to fit input, type dropdown and remove button nicely */
+  display: grid;
+  gap: 1rem;
+  padding: 2rem;
+  ${({ odd }) => odd && "background-color: #272833;"};
 `
 
-const Columns = styled(Box).attrs({
-  align: "flex-start",
-  justifyContent: "space-between",
-  gap: 0,
-})`
+const MainControl = styled.div`
+  display: grid;
+  grid-template-columns: var(--columns);
+  gap: 1rem;
   width: 100%;
-
-  > button {
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
-  }
+  align-items: flex-end;
 `
 
-const Item = styled(Box).attrs({
-  gap: "1rem",
-  flexDirection: "column",
-})`
+const Timestamp = styled.div`
+  display: grid;
+  grid-template-columns: var(--columns);
+  gap: 1rem;
   width: 100%;
-`
-
-const Inputs = styled(Box).attrs({
-  align: "flex-end",
-  gap: "1rem",
-})`
-  width: 100%;
+  align-items: flex-end;
 `
 
 export const Column = ({
@@ -93,110 +79,111 @@ export const Column = ({
   const isEditLocked = file.exists && file.table_name === file.fileObject.name
 
   return (
-    <Drawer.GroupItem direction="column" key={column.name}>
-      <Row>
-        <Columns>
-          <Item>
-            <Inputs>
-              <Form.Item name={`schemaColumns.${index}.name`} label="Name">
-                <Form.Input
-                  disabled={isEditLocked}
-                  defaultValue={column.name}
-                  name={`schemaColumns.${index}.name`}
-                  onChange={(e) => {
-                    onNameChange(e.target.value)
-                  }}
-                  autoComplete="off"
-                />
-              </Form.Item>
-              <Form.Item name={`schemaColumns.${index}.type`} label="Type">
-                <Form.Select
-                  disabled={isEditLocked}
-                  defaultValue={column.type}
-                  name={`schemaColumns.${index}.type`}
-                  options={supportedColumnTypes}
-                  onChange={handleTypeChange}
-                />
-              </Form.Item>
+    <Root key={column.name} odd={index % 2 !== 0}>
+      <MainControl>
+        <Form.Item name={`schemaColumns.${index}.name`} label="Name">
+          <Form.Input
+            disabled={isEditLocked}
+            defaultValue={column.name}
+            name={`schemaColumns.${index}.name`}
+            onChange={(e) => {
+              onNameChange(e.target.value)
+            }}
+            autoComplete="off"
+          />
+        </Form.Item>
 
-              <IconWithTooltip
-                icon={
-                  <Button
-                    disabled={type !== "TIMESTAMP" || isEditLocked}
-                    skin={
+        <Form.Item name={`schemaColumns.${index}.type`} label="Type">
+          <Form.Select
+            disabled={isEditLocked}
+            defaultValue={column.type}
+            name={`schemaColumns.${index}.type`}
+            options={supportedColumnTypes}
+            onChange={handleTypeChange}
+          />
+        </Form.Item>
+
+        {!isEditLocked && (
+          <Button
+            skin="transparent"
+            onClick={() => onRemove(index)}
+            type="button"
+          >
+            <Close size="18px" />
+          </Button>
+        )}
+      </MainControl>
+
+      {type === "TIMESTAMP" && (
+        <Timestamp>
+          <Form.Item name={`schemaColumns.${index}.pattern`} label="Pattern">
+            <Form.Input
+              disabled={isEditLocked}
+              name={`schemaColumns.${index}.pattern`}
+              placeholder={DEFAULT_TIMESTAMP_FORMAT}
+              defaultValue={
+                column.pattern !== ""
+                  ? column.pattern
+                  : DEFAULT_TIMESTAMP_FORMAT
+              }
+              required
+            />
+          </Form.Item>
+
+          <IconWithTooltip
+            icon={
+              <Button
+                disabled={isEditLocked}
+                skin={
+                  timestamp !== "" &&
+                  column.name !== "" &&
+                  timestamp === column.name
+                    ? "success"
+                    : "secondary"
+                }
+                onClick={() => onSetTimestamp(column.name)}
+                type="button"
+                prefixIcon={
+                  <input
+                    type="checkbox"
+                    checked={
                       timestamp !== "" &&
                       column.name !== "" &&
                       timestamp === column.name
-                        ? "success"
-                        : "transparent"
                     }
-                    onClick={() => {
-                      onSetTimestamp(column.name)
-                    }}
-                    type="button"
-                  >
-                    <SortDown size="18px" />
-                  </Button>
+                  />
                 }
-                tooltip="Set as designated timestamp"
-                placement="bottom"
-              />
+              >
+                Designated
+              </Button>
+            }
+            tooltip="Mark this column as a designated timestamp"
+            placement="top"
+          />
+        </Timestamp>
+      )}
 
-              {!isEditLocked && (
-                <Button
-                  skin="transparent"
-                  onClick={() => {
-                    onRemove(index)
-                  }}
-                  type="button"
-                >
-                  <Close size="18px" />
-                </Button>
-              )}
-            </Inputs>
-            {type === "TIMESTAMP" && (
-              <Form.Item
-                name={`schemaColumns.${index}.pattern`}
-                label="Timestamp pattern"
-                helperText="Required when using the TIMESTAMP type"
-              >
-                <Form.Input
-                  disabled={isEditLocked}
-                  name={`schemaColumns.${index}.pattern`}
-                  placeholder={DEFAULT_TIMESTAMP_FORMAT}
-                  defaultValue={
-                    column.pattern !== ""
-                      ? column.pattern
-                      : DEFAULT_TIMESTAMP_FORMAT
-                  }
-                  required
-                />
-              </Form.Item>
-            )}
-            {type === "GEOHASH" && (
-              <Form.Item
-                name={`schemaColumns.${index}.precision`}
-                label="Precision"
-                helperText={
-                  <a
-                    href="https://questdb.io/docs/concept/geohashes/#specifying-geohash-precision"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Docs on QuestDB geohash precision
-                  </a>
-                }
-              >
-                <Form.Input
-                  disabled={isEditLocked}
-                  name={`schemaColumns.${index}.precision`}
-                  required
-                />
-              </Form.Item>
-            )}
-          </Item>
-        </Columns>
-      </Row>
-    </Drawer.GroupItem>
+      {type === "GEOHASH" && (
+        <Form.Item
+          name={`schemaColumns.${index}.precision`}
+          label="Precision"
+          helperText={
+            <a
+              href="https://questdb.io/docs/concept/geohashes/#specifying-geohash-precision"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Docs on QuestDB geohash precision
+            </a>
+          }
+        >
+          <Form.Input
+            disabled={isEditLocked}
+            name={`schemaColumns.${index}.precision`}
+            required
+          />
+        </Form.Item>
+      )}
+    </Root>
   )
 }


### PR DESCRIPTION
This PR updates the Columns editor shown in CSV import schema edit drawer.

* show `designated` timestamp button only for `column.type === 'TIMESTAMP` (previously shown for all)
* instead of button with icon, use button with checkmark and text. This is to make it more obvious that the button acts as a toggle
* add zebra colors to make it easier to visually distinguish between rows
* tweak layout: make `name` field wider than fixed-width `type` field


| Before | After |
| --- | --- |
| ![image](https://github.com/questdb/ui/assets/4284659/32309319-ab1b-46a4-a21a-9f3feef79032) | <img width="380" alt="Screenshot 2023-05-18 at 11 49 27" src="https://github.com/questdb/ui/assets/4284659/460b33e8-6f63-4276-98db-1a5f7040725e"> |




