### PR TITLE
chore(web-console): allow pasting without page focus in import

### DIFF
--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/index.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { Box } from "../../../components/Box"
 import { DropBox } from "./dropbox"
 import { FilesToUpload } from "./files-to-upload"
@@ -142,15 +142,24 @@ export const ImportCSVFiles = ({ onImported }: Props) => {
     setFilesDropped([...filesDropped, ...fileConfigs] as ProcessedFile[])
   }
 
-  const handlePaste = (event: React.ClipboardEvent<HTMLDivElement>) => {
-    const files = event.clipboardData?.files
+  const handlePaste = (event: Event) => {
+    const clipboardEvent = event as ClipboardEvent
+    const files = clipboardEvent.clipboardData?.files
     if (files) {
       handleDrop(files)
     }
   }
 
+  useEffect(() => {
+    window.addEventListener("paste", handlePaste)
+
+    return () => {
+      window.removeEventListener("paste", handlePaste)
+    }
+  }, [])
+
   return (
-    <Box gap="4rem" flexDirection="column" onPaste={handlePaste}>
+    <Box gap="4rem" flexDirection="column">
       <DropBox onFilesDropped={handleDrop} />
       <FilesToUpload
         files={filesDropped}


### PR DESCRIPTION
Previous "paste" implementation required the page wrapper to be in focus, i.e. user had to click within it first.

This more general approach works right upon clicking the "Import" button on the navbar, going back to browser tab, etc.