### PR TITLE
fix(web-console): prevent name overlap when narrow

### DIFF
--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/files-to-upload.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/files-to-upload.tsx
@@ -14,6 +14,11 @@ import { RenameTableDialog } from "./rename-table-dialog"
 import { Dialog as TableSchemaDialog } from "./table-schema/dialog"
 import { UploadResultDialog } from "./upload-result-dialog"
 
+const TableWrapper = styled(Box)`
+  width: calc(100vw - 4rem - 2rem - 2rem);
+  overflow-x: auto;
+`
+
 const StyledTable = styled(Table)`
   width: 100%;
   table-layout: fixed;
@@ -78,180 +83,184 @@ export const FilesToUpload = ({
   return (
     <Box flexDirection="column" gap="2rem">
       <Heading level={3}>Upload queue</Heading>
-      <StyledTable<React.FunctionComponent<TableProps<ProcessedFile>>>
-        columns={[
-          {
-            header: "File",
-            align: "flex-start",
-            render: ({ data }) => (
-              <Box align="center" gap="1rem">
-                <FiletypeCsv size="46px" />
-                <Box gap="1rem" align="flex-4tart" flexDirection="column">
-                  <FileTextBox align="center" gap="1rem">
-                    <Text color="foreground">{data.fileObject.name}</Text>
-                    <Text color="gray2" size="sm">
-                      {bytesWithSuffix(data.fileObject.size)}
-                    </Text>
-                  </FileTextBox>
-                  <Box gap="1rem" align="center">
-                    <FileStatus file={data} />
-                    {!data.isUploading && data.uploadResult && (
-                      <UploadResultDialog file={data} />
-                    )}
-                  </Box>
-                  {(data.uploadResult && data.uploadResult.rowsRejected > 0) ||
-                    (data.error && (
-                      <FileTextBox
-                        flexDirection="column"
-                        gap="1rem"
-                        align="flex-start"
-                      >
-                        {data.uploadResult &&
-                          data.uploadResult.rowsRejected > 0 && (
-                            <Text color="orange" size="sm">
-                              {data.uploadResult.rowsRejected.toLocaleString()}{" "}
-                              row
-                              {data.uploadResult.rowsRejected > 1
-                                ? "s"
-                                : ""}{" "}
-                              rejected
+      <TableWrapper>
+        <StyledTable<React.FunctionComponent<TableProps<ProcessedFile>>>
+          columns={[
+            {
+              header: "File",
+              align: "flex-start",
+              ...(files.length > 0 ? { width: "350px" } : {}),
+              render: ({ data }) => (
+                <Box align="center" gap="1rem">
+                  <FiletypeCsv size="46px" />
+                  <Box gap="1rem" align="flex-4tart" flexDirection="column">
+                    <FileTextBox align="center" gap="1rem">
+                      <Text color="foreground">{data.fileObject.name}</Text>
+                      <Text color="gray2" size="sm">
+                        {bytesWithSuffix(data.fileObject.size)}
+                      </Text>
+                    </FileTextBox>
+                    <Box gap="1rem" align="center">
+                      <FileStatus file={data} />
+                      {!data.isUploading && data.uploadResult && (
+                        <UploadResultDialog file={data} />
+                      )}
+                    </Box>
+                    {(data.uploadResult &&
+                      data.uploadResult.rowsRejected > 0) ||
+                      (data.error && (
+                        <FileTextBox
+                          flexDirection="column"
+                          gap="1rem"
+                          align="flex-start"
+                        >
+                          {data.uploadResult &&
+                            data.uploadResult.rowsRejected > 0 && (
+                              <Text color="orange" size="sm">
+                                {data.uploadResult.rowsRejected.toLocaleString()}{" "}
+                                row
+                                {data.uploadResult.rowsRejected > 1
+                                  ? "s"
+                                  : ""}{" "}
+                                rejected
+                              </Text>
+                            )}
+                          {data.error && (
+                            <Text color="red" size="sm">
+                              {data.error}
                             </Text>
                           )}
-                        {data.error && (
-                          <Text color="red" size="sm">
-                            {data.error}
-                          </Text>
-                        )}
-                      </FileTextBox>
-                    ))}
+                        </FileTextBox>
+                      ))}
+                  </Box>
                 </Box>
-              </Box>
-            ),
-          },
-          {
-            header: "Table name",
-            align: "flex-end",
-            width: "200px",
-            render: ({ data }) => {
-              const name = data.table_name ?? data.fileObject.name
-              return (
-                <RenameTableDialog
-                  open={renameDialogOpen === name}
-                  onOpenChange={setRenameDialogOpen}
-                  onNameChange={(name) => {
-                    onFilePropertyChange(data.fileObject.name, {
-                      table_name: name,
-                    })
-                  }}
-                  file={data}
-                />
-              )
+              ),
             },
-          },
-          {
-            header: (
-              <PopperHover
-                placement="top"
-                trigger={
-                  <Box align="center" gap="0.5rem">
-                    Schema
-                    <Information size="16px" />
-                  </Box>
-                }
-              >
-                <Tooltip>
-                  Optional. By default, QuestDB will infer schema from the CSV
-                  file structure
-                </Tooltip>
-              </PopperHover>
-            ),
+            {
+              header: "Table name",
+              align: "flex-end",
+              width: "200px",
+              render: ({ data }) => {
+                const name = data.table_name ?? data.fileObject.name
+                return (
+                  <RenameTableDialog
+                    open={renameDialogOpen === name}
+                    onOpenChange={setRenameDialogOpen}
+                    onNameChange={(name) => {
+                      onFilePropertyChange(data.fileObject.name, {
+                        table_name: name,
+                      })
+                    }}
+                    file={data}
+                  />
+                )
+              },
+            },
+            {
+              header: (
+                <PopperHover
+                  placement="top"
+                  trigger={
+                    <Box align="center" gap="0.5rem">
+                      Schema
+                      <Information size="16px" />
+                    </Box>
+                  }
+                >
+                  <Tooltip>
+                    Optional. By default, QuestDB will infer schema from the CSV
+                    file structure
+                  </Tooltip>
+                </PopperHover>
+              ),
 
-            align: "center",
-            width: "150px",
-            render: ({ data }) => {
-              const name = data.table_name ?? data.fileObject.name
-              return (
-                <TableSchemaDialog
-                  open={schemaDialogOpen === name}
-                  onOpenChange={setSchemaDialogOpen}
-                  onSchemaChange={(schema) => {
+              align: "center",
+              width: "150px",
+              render: ({ data }) => {
+                const name = data.table_name ?? data.fileObject.name
+                return (
+                  <TableSchemaDialog
+                    open={schemaDialogOpen === name}
+                    onOpenChange={setSchemaDialogOpen}
+                    onSchemaChange={(schema) => {
+                      onFilePropertyChange(data.fileObject.name, {
+                        schema: schema.schemaColumns,
+                        partitionBy: schema.partitionBy,
+                        timestamp: schema.timestamp,
+                      })
+                    }}
+                    file={data}
+                  />
+                )
+              },
+            },
+            {
+              header: (
+                <PopperHover
+                  placement="top"
+                  trigger={
+                    <Box align="center" gap="0.5rem">
+                      Write mode
+                      <Information size="16px" />
+                    </Box>
+                  }
+                >
+                  <Tooltip>
+                    <strong>Append</strong>: data will be appended to the set.
+                    <br />
+                    <strong>Overwrite</strong>: any existing data or structure
+                    will be overwritten. Required for partitioning and timestamp
+                    related changes.
+                  </Tooltip>
+                </PopperHover>
+              ),
+              align: "center",
+              width: "150px",
+              render: ({ data }) => (
+                <Select
+                  name="overwrite"
+                  defaultValue={data.settings.overwrite ? "true" : "false"}
+                  onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
                     onFilePropertyChange(data.fileObject.name, {
-                      schema: schema.schemaColumns,
-                      partitionBy: schema.partitionBy,
-                      timestamp: schema.timestamp,
+                      settings: {
+                        ...data.settings,
+                        overwrite: e.target.value === "true",
+                      },
+                    })
+                  }
+                  options={[
+                    {
+                      label: "Append",
+                      value: "false",
+                    },
+                    {
+                      label: "Overwrite",
+                      value: "true",
+                    },
+                  ]}
+                />
+              ),
+            },
+            {
+              align: "flex-end",
+              width: "300px",
+              render: ({ data }) => (
+                <UploadActions
+                  file={data}
+                  onUpload={onFileUpload}
+                  onRemove={onFileRemove}
+                  onSettingsChange={(settings) => {
+                    onFilePropertyChange(data.fileObject.name, {
+                      settings,
                     })
                   }}
-                  file={data}
                 />
-              )
+              ),
             },
-          },
-          {
-            header: (
-              <PopperHover
-                placement="top"
-                trigger={
-                  <Box align="center" gap="0.5rem">
-                    Write mode
-                    <Information size="16px" />
-                  </Box>
-                }
-              >
-                <Tooltip>
-                  <strong>Append</strong>: data will be appended to the set.
-                  <br />
-                  <strong>Overwrite</strong>: any existing data or structure
-                  will be overwritten. Required for partitioning and timestamp
-                  related changes.
-                </Tooltip>
-              </PopperHover>
-            ),
-            align: "center",
-            width: "150px",
-            render: ({ data }) => (
-              <Select
-                name="overwrite"
-                defaultValue={data.settings.overwrite ? "true" : "false"}
-                onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                  onFilePropertyChange(data.fileObject.name, {
-                    settings: {
-                      ...data.settings,
-                      overwrite: e.target.value === "true",
-                    },
-                  })
-                }
-                options={[
-                  {
-                    label: "Append",
-                    value: "false",
-                  },
-                  {
-                    label: "Overwrite",
-                    value: "true",
-                  },
-                ]}
-              />
-            ),
-          },
-          {
-            align: "flex-end",
-            width: "300px",
-            render: ({ data }) => (
-              <UploadActions
-                file={data}
-                onUpload={onFileUpload}
-                onRemove={onFileRemove}
-                onSettingsChange={(settings) => {
-                  onFilePropertyChange(data.fileObject.name, {
-                    settings,
-                  })
-                }}
-              />
-            ),
-          },
-        ]}
-        rows={files}
-      />
+          ]}
+          rows={files}
+        />
+      </TableWrapper>
       {files.length === 0 && (
         <EmptyState>
           <Text color="gray2" align="center">

--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/index.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/index.tsx
@@ -10,6 +10,7 @@ import * as QuestDB from "../../../utils/questdb"
 import { useSelector } from "react-redux"
 import { selectors } from "../../../store"
 import { DEFAULT_TIMESTAMP_FORMAT, MAX_UNCOMMITTED_ROWS } from "./const"
+import styled from "styled-components"
 
 type Props = {
   onImported: (result: UploadResult) => void
@@ -41,6 +42,14 @@ const mapColumnTypeToQuestDB = (column: SchemaColumn) => {
   }
   return column
 }
+
+const Root = styled(Box).attrs({
+  gap: "4rem",
+  alignItems: "flex-start",
+  flexDirection: "column",
+})`
+  width: 100%;
+`
 
 export const ImportCSVFiles = ({ onImported }: Props) => {
   const { quest } = useContext(QuestContext)
@@ -150,7 +159,7 @@ export const ImportCSVFiles = ({ onImported }: Props) => {
   }
 
   return (
-    <Box gap="4rem" flexDirection="column" onPaste={handlePaste}>
+    <Root onPaste={handlePaste}>
       <DropBox onFilesDropped={handleDrop} />
       <FilesToUpload
         files={filesDropped}
@@ -251,6 +260,6 @@ export const ImportCSVFiles = ({ onImported }: Props) => {
           setFilesDropped(processedFiles)
         }}
       />
-    </Box>
+    </Root>
   )
 }

--- a/packages/web-console/src/scenes/Import/index.tsx
+++ b/packages/web-console/src/scenes/Import/index.tsx
@@ -4,13 +4,13 @@ import { Page } from "../../components"
 import { Upload2 } from "styled-icons/remix-line"
 import { ImportCSVFiles } from "./ImportCSVFiles"
 import { BusEvent } from "../../consts"
+import { Box } from "../../components/Box"
 
-const Root = styled.div`
-  display: flex;
-  width: 100%;
+const Root = styled(Box).attrs({ gap: "0" })`
+  width: calc(100vw - 4rem);
   padding: 2rem;
   margin-bottom: 4rem;
-  overflow: auto;
+  overflow: hidden;
 `
 
 const Import = () => {


### PR DESCRIPTION
Fixes https://github.com/questdb/ui/issues/145

The approach is to create both a defined column width for the file details and a parent container with a horizontal overflow, which will show a scrollbar when the screen is too narrow to accommodate the table.

Screen recording:

https://github.com/questdb/ui/assets/1871646/e51e3de5-1cd8-4e2b-8697-83d6c6ceaf6d



