### PR TITLE
chore(web-console): Import UI fixes + timestamp input update

### DIFF
--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/files-to-upload.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/files-to-upload.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect } from "react"
 import styled from "styled-components"
 import { Heading, Table, Select } from "@questdb/react-components"
 import type { Props as TableProps } from "@questdb/react-components/dist/components/Table"
@@ -57,6 +57,7 @@ const FileTextBox = styled(Box)`
 
 type Props = {
   files: ProcessedFile[]
+  onDialogToggle: (open: boolean) => void
   onFileRemove: (filename: string) => void
   onFileUpload: (filename: string) => void
   onFilePropertyChange: (filename: string, file: Partial<ProcessedFile>) => void
@@ -64,6 +65,7 @@ type Props = {
 
 export const FilesToUpload = ({
   files,
+  onDialogToggle,
   onFileRemove,
   onFilePropertyChange,
   onFileUpload,
@@ -75,6 +77,12 @@ export const FilesToUpload = ({
   const [schemaDialogOpen, setSchemaDialogOpen] = React.useState<
     string | null
   >()
+
+  useEffect(() => {
+    onDialogToggle(
+      renameDialogOpen !== undefined || schemaDialogOpen !== undefined,
+    )
+  }, [renameDialogOpen, schemaDialogOpen])
 
   return (
     <Box flexDirection="column" gap="2rem">

--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/index.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/index.tsx
@@ -143,7 +143,7 @@ export const ImportCSVFiles = ({ onImported }: Props) => {
 
   const handleDrop = async (files: FileList) => {
     const fileConfigs = await getFileConfigs(files)
-    setFilesDropped([...filesDropped, ...fileConfigs] as ProcessedFile[])
+    setFilesDropped((filesDropped) => [...filesDropped, ...fileConfigs])
   }
 
   const handlePaste = useCallback((event: Event) => {

--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/index.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react"
+import React, { useCallback, useEffect, useRef, useState } from "react"
 import { Box } from "../../../components/Box"
 import { DropBox } from "./dropbox"
 import { FilesToUpload } from "./files-to-upload"
@@ -46,6 +46,7 @@ const mapColumnTypeToQuestDB = (column: SchemaColumn) => {
 export const ImportCSVFiles = ({ onImported }: Props) => {
   const { quest } = useContext(QuestContext)
   const [filesDropped, setFilesDropped] = useState<ProcessedFile[]>([])
+  const [dialogOpen, setDialogOpen] = useState(false)
   const tables = useSelector(selectors.query.getTables)
   const rootRef = useRef<HTMLDivElement>(null)
   const isVisible = useIsVisible(rootRef)
@@ -145,13 +146,13 @@ export const ImportCSVFiles = ({ onImported }: Props) => {
     setFilesDropped([...filesDropped, ...fileConfigs] as ProcessedFile[])
   }
 
-  const handlePaste = (event: Event) => {
+  const handlePaste = useCallback((event: Event) => {
     const clipboardEvent = event as ClipboardEvent
     const files = clipboardEvent.clipboardData?.files
     if (files) {
       handleDrop(files)
     }
-  }
+  }, [])
 
   const handleVisible = async () => {
     const fileStatusList = await Promise.all(
@@ -173,18 +174,25 @@ export const ImportCSVFiles = ({ onImported }: Props) => {
   }, [isVisible])
 
   useEffect(() => {
-    window.addEventListener("paste", handlePaste)
-
     return () => {
       window.removeEventListener("paste", handlePaste)
     }
   }, [])
+
+  useEffect(() => {
+    if (dialogOpen) {
+      window.removeEventListener("paste", handlePaste)
+    } else {
+      window.addEventListener("paste", handlePaste)
+    }
+  }, [dialogOpen])
 
   return (
     <Box gap="4rem" flexDirection="column" ref={rootRef}>
       <DropBox onFilesDropped={handleDrop} />
       <FilesToUpload
         files={filesDropped}
+        onDialogToggle={setDialogOpen}
         onFileUpload={async (filename) => {
           const file = filesDropped.find(
             (f) => f.table_name === filename,

--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/table-schema/column.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/table-schema/column.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Form } from "../../../../components/Form"
-import { IconWithTooltip } from "../../../../components"
+import { IconWithTooltip, Text } from "../../../../components"
+import { Box } from "../../../../components/Box"
 import { Button } from "@questdb/react-components"
 import { Close } from "styled-icons/remix-line"
 import { Book } from "styled-icons/boxicons-regular"
@@ -93,50 +94,53 @@ export const Column = ({
       </Controls>
 
       {column.type === "TIMESTAMP" && (
-        <Controls>
-          <Form.Item name={`schemaColumns.${index}.pattern`} label="Pattern">
-            <Form.Input
-              name={`schemaColumns.${index}.pattern`}
-              placeholder={DEFAULT_TIMESTAMP_FORMAT}
-              defaultValue={
-                column.pattern !== ""
-                  ? column.pattern
-                  : DEFAULT_TIMESTAMP_FORMAT
-              }
-              required
-            />
-          </Form.Item>
+        <Box flexDirection="column" align="flex-start" gap="1rem">
+          <Controls>
+            <Form.Item name={`schemaColumns.${index}.pattern`} label="Pattern">
+              <Form.Input
+                name={`schemaColumns.${index}.pattern`}
+                placeholder={DEFAULT_TIMESTAMP_FORMAT}
+                defaultValue={
+                  column.pattern !== ""
+                    ? column.pattern
+                    : DEFAULT_TIMESTAMP_FORMAT
+                }
+                required
+              />
+            </Form.Item>
 
-          <IconWithTooltip
-            icon={
-              <Button
-                skin={
-                  timestamp !== "" &&
-                  column.name !== "" &&
-                  timestamp === column.name
-                    ? "success"
-                    : "secondary"
-                }
-                onClick={() => onSetTimestamp(column.name)}
-                type="button"
-                prefixIcon={
-                  <input
-                    type="checkbox"
-                    checked={
-                      timestamp !== "" &&
-                      column.name !== "" &&
-                      timestamp === column.name
-                    }
-                  />
-                }
-              >
-                Designated
-              </Button>
-            }
-            tooltip="Mark this column as a designated timestamp"
-            placement="top"
-          />
-        </Controls>
+            <IconWithTooltip
+              icon={
+                <Button
+                  skin={
+                    timestamp !== "" &&
+                    column.name !== "" &&
+                    timestamp === column.name
+                      ? "success"
+                      : "secondary"
+                  }
+                  onClick={() => onSetTimestamp(column.name)}
+                  type="button"
+                  prefixIcon={
+                    <input
+                      type="checkbox"
+                      checked={
+                        timestamp !== "" &&
+                        column.name !== "" &&
+                        timestamp === column.name
+                      }
+                    />
+                  }
+                >
+                  Designated
+                </Button>
+              }
+              tooltip="Mark this column as a designated timestamp"
+              placement="top"
+            />
+          </Controls>
+          <Text color="comment">Example: {DEFAULT_TIMESTAMP_FORMAT}</Text>
+        </Box>
       )}
 
       {column.type === "GEOHASH" && (


### PR DESCRIPTION
- Fixed an issue when the user could not paste text (i.e. timestamp format) into form inputs because this action would close them and reset their state.
- Fixed an issue when pasting a file to an already existing list would overwrite the queue.
- Added a sample timestamp format text that stays below the pattern input all the time.
<img width="535" alt="CleanShot 2023-05-30 at 16 58 45@2x" src="https://github.com/questdb/ui/assets/1871646/48757233-c097-4bf7-ba71-117b3e2ef16d">
