### PR TITLE
chore(web-console): Import: Handle duplicate files

### DIFF
--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/index.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { Box } from "../../../components/Box"
 import { DropBox } from "./dropbox"
 import { FilesToUpload } from "./files-to-upload"
@@ -146,14 +146,6 @@ export const ImportCSVFiles = ({ onImported }: Props) => {
     setFilesDropped((filesDropped) => [...filesDropped, ...fileConfigs])
   }
 
-  const handlePaste = useCallback((event: Event) => {
-    const clipboardEvent = event as ClipboardEvent
-    const files = clipboardEvent.clipboardData?.files
-    if (files) {
-      handleDrop(Array.from(files))
-    }
-  }, [])
-
   const handleVisible = async () => {
     const fileStatusList = await Promise.all(
       filesDropped.map(async (file) => {
@@ -173,23 +165,13 @@ export const ImportCSVFiles = ({ onImported }: Props) => {
     }
   }, [isVisible])
 
-  useEffect(() => {
-    return () => {
-      window.removeEventListener("paste", handlePaste)
-    }
-  }, [])
-
-  useEffect(() => {
-    if (dialogOpen) {
-      window.removeEventListener("paste", handlePaste)
-    } else {
-      window.addEventListener("paste", handlePaste)
-    }
-  }, [dialogOpen])
-
   return (
     <Box gap="4rem" flexDirection="column" ref={rootRef}>
-      <DropBox files={filesDropped} onFilesDropped={handleDrop} />
+      <DropBox
+        files={filesDropped}
+        onFilesDropped={handleDrop}
+        dialogOpen={dialogOpen}
+      />
       <FilesToUpload
         files={filesDropped}
         onDialogToggle={setDialogOpen}

--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/index.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/index.tsx
@@ -71,9 +71,9 @@ export const ImportCSVFiles = ({ onImported }: Props) => {
     setFileProperties(file.table_name, { isUploading })
   }
 
-  const getFileConfigs = async (files: FileList): Promise<ProcessedFile[]> => {
+  const getFileConfigs = async (files: File[]): Promise<ProcessedFile[]> => {
     return await Promise.all(
-      Array.from(files).map(async (file) => {
+      files.map(async (file) => {
         const result = await quest.checkCSVFile(file.name)
 
         const schema =
@@ -140,7 +140,7 @@ export const ImportCSVFiles = ({ onImported }: Props) => {
     )
   }
 
-  const handleDrop = async (files: FileList) => {
+  const handleDrop = async (files: File[]) => {
     const fileConfigs = await getFileConfigs(files)
     setFilesDropped([...filesDropped, ...fileConfigs] as ProcessedFile[])
   }
@@ -149,7 +149,7 @@ export const ImportCSVFiles = ({ onImported }: Props) => {
     const clipboardEvent = event as ClipboardEvent
     const files = clipboardEvent.clipboardData?.files
     if (files) {
-      handleDrop(files)
+      handleDrop(Array.from(files))
     }
   }
 
@@ -182,7 +182,7 @@ export const ImportCSVFiles = ({ onImported }: Props) => {
 
   return (
     <Box gap="4rem" flexDirection="column" ref={rootRef}>
-      <DropBox onFilesDropped={handleDrop} />
+      <DropBox files={filesDropped} onFilesDropped={handleDrop} />
       <FilesToUpload
         files={filesDropped}
         onFileUpload={async (filename) => {

--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/upload-settings-dialog.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/upload-settings-dialog.tsx
@@ -18,6 +18,25 @@ const Row = styled(Box).attrs({ justifyContent: "space-between", gap: "2rem" })`
   width: 100%;
 `
 
+const FormWrapper = styled(Box).attrs({ gap: "0", flexDirection: "column" })`
+  width: 100%;
+  height: calc(100vh - 6.1rem);
+
+  form {
+    height: 100%;
+  }
+`
+
+const Items = styled(Box).attrs({ gap: "0", flexDirection: "column" })`
+  height: 100%;
+`
+
+const Inputs = styled(Box).attrs({ gap: "0", flexDirection: "column" })`
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+`
+
 const InputWrapper = styled.div`
   flex-shrink: 0;
   width: 30%;
@@ -210,95 +229,97 @@ export const UploadSettingsDialog = ({
       }}
       withCloseButton
     >
-      <Box gap="2rem" flexDirection="column">
-        <Box gap="0" flexDirection="column" align="stretch">
-          {options.map((option) => (
-            <Drawer.GroupItem key={option.name}>
-              <Row key={option.name}>
-                <Box
-                  gap="1rem"
-                  flexDirection="column"
-                  align="flex-start"
-                  justifyContent="flex-start"
-                >
-                  <Text color="foreground" weight={600}>
-                    {option.label}
-                  </Text>
-                  {option.description && (
-                    <Text color="gray2" size="sm">
-                      {option.description}
+      <FormWrapper>
+        <Items>
+          <Inputs>
+            {options.map((option) => (
+              <Drawer.GroupItem key={option.name}>
+                <Row key={option.name}>
+                  <Box
+                    gap="1rem"
+                    flexDirection="column"
+                    align="flex-start"
+                    justifyContent="flex-start"
+                  >
+                    <Text color="foreground" weight={600}>
+                      {option.label}
                     </Text>
-                  )}
-                </Box>
-                <InputWrapper>
-                  {option.type === "input" && (
-                    <Input
-                      name={option.name}
-                      defaultValue={option.defaultValue}
-                      placeholder={option.placeholder}
-                      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                        setSettings({
-                          ...settings,
-                          [option.name]: e.target.value,
-                        })
-                      }
-                    />
-                  )}
-                  {option.type === "select" && (
-                    <Select
-                      name={option.name}
-                      defaultValue={option.defaultValue as string}
-                      onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                        setSettings({
-                          ...settings,
-                          [option.name]: e.target.value,
-                        })
-                      }
-                      options={option.options}
-                    />
-                  )}
-                  {option.type === "switch" && (
-                    <Switch
-                      checked={option.defaultValue}
-                      onChange={(value) =>
-                        setSettings({
-                          ...settings,
-                          [option.name]: value,
-                        })
-                      }
-                    />
-                  )}
-                </InputWrapper>
-              </Row>
-            </Drawer.GroupItem>
-          ))}
-        </Box>
+                    {option.description && (
+                      <Text color="gray2" size="sm">
+                        {option.description}
+                      </Text>
+                    )}
+                  </Box>
+                  <InputWrapper>
+                    {option.type === "input" && (
+                      <Input
+                        name={option.name}
+                        defaultValue={option.defaultValue}
+                        placeholder={option.placeholder}
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                          setSettings({
+                            ...settings,
+                            [option.name]: e.target.value,
+                          })
+                        }
+                      />
+                    )}
+                    {option.type === "select" && (
+                      <Select
+                        name={option.name}
+                        defaultValue={option.defaultValue as string}
+                        onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                          setSettings({
+                            ...settings,
+                            [option.name]: e.target.value,
+                          })
+                        }
+                        options={option.options}
+                      />
+                    )}
+                    {option.type === "switch" && (
+                      <Switch
+                        checked={option.defaultValue}
+                        onChange={(value) =>
+                          setSettings({
+                            ...settings,
+                            [option.name]: value,
+                          })
+                        }
+                      />
+                    )}
+                  </InputWrapper>
+                </Row>
+              </Drawer.GroupItem>
+            ))}
+          </Inputs>
 
-        <Drawer.Actions>
-          <Button
-            prefixIcon={<Undo size={18} />}
-            skin="secondary"
-            onClick={() => {
-              setSettings(initialState)
-              onOpenChange(false)
-            }}
-            type="button"
-          >
-            Dismiss
-          </Button>
+          <Drawer.Actions>
+            <Button
+              prefixIcon={<Undo size={18} />}
+              skin="secondary"
+              onClick={() => {
+                setSettings(initialState)
+                onOpenChange(false)
+              }}
+              type="button"
+            >
+              Dismiss
+            </Button>
 
-          <Button
-            prefixIcon={<Settings4 size={18} />}
-            skin="success"
-            onClick={() => {
-              onSubmit(settings)
-              onOpenChange(false)
-            }}
-          >
-            Submit
-          </Button>
-        </Drawer.Actions>
-      </Box>
+            <Button
+              prefixIcon={<Settings4 size={18} />}
+              skin="success"
+              onClick={() => {
+                onSubmit(settings)
+                onOpenChange(false)
+              }}
+            >
+              Submit
+            </Button>
+          </Drawer.Actions>
+        </Items>
+      </FormWrapper>
     </Drawer>
   )
 }


### PR DESCRIPTION
This PR adds handling of adding multiple files of the same name to the upload queue. The current version is buggy and does not inform the user if a duplicate has been detected.

The new behavior is as follows:
- Duplicate file names are allowed as long as the target table name is unique
- If duplicates have been found, a relevant error message is displayed
- Duplicates are filtered out before adding the batch to the queue.

Side changes:
- Paste event handler has been moved to `Dropbox`, so that the de-duplication logic is unified and displays the same error message every time for file browsing, drag & drop and paste.

Screen recording:

https://github.com/questdb/ui/assets/1871646/662764ec-c1e5-48a3-9f66-8a2c6b4c24a4
