### PR TITLE
fix(web-console): fix executing selects after import

### DIFF
--- a/packages/browser-tests/cypress/commands.js
+++ b/packages/browser-tests/cypress/commands.js
@@ -106,4 +106,6 @@ Cypress.Commands.add("F9", () => {
 
 Cypress.Commands.add("getSelectedLines", () => cy.get(".selected-text"));
 
+Cypress.Commands.add("getVisibleLines", () => cy.get(".view-lines"));
+
 Cypress.Commands.add("getNotifications", () => cy.get(".notifications"));

--- a/packages/browser-tests/cypress/integration/console/editor.spec.js
+++ b/packages/browser-tests/cypress/integration/console/editor.spec.js
@@ -162,6 +162,23 @@ describe("&query URL param", () => {
     cy.visit(`${baseUrl}?query=${encodeURIComponent(query)}&executeQuery=true`);
     cy.getEditor().should("have.value", query);
   });
+
+  it("should append query and scroll to it", () => {
+    cy.visit(baseUrl);
+
+    cy.typeQuery("--\n".repeat(20)); // take space so that query is not visible later
+    const query = "select x from long_sequence(1);";
+    cy.typeQuery(query).clickRun(); // save by running
+
+    const appendedQuery = "-- hello world";
+    cy.visit(
+      `${baseUrl}?query=${encodeURIComponent(appendedQuery)}&executeQuery=true`
+    );
+    cy.getVisibleLines()
+      .invoke("text")
+      .should("match", /hello.world$/); // not matching on appendedQuery, because query should be selected for which Monaco adds special chars between words
+    cy.clearEditor();
+  });
 });
 
 describe("autocomplete", () => {

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -17,6 +17,7 @@ import {
   clearModelMarkers,
   getQueryFromCursor,
   findMatches,
+  AppendQueryOptions,
 } from "./utils"
 import type { Request } from "./utils"
 import { PaneContent, Text } from "../../../components"
@@ -248,11 +249,14 @@ const MonacoEditor = () => {
         insertTextAtCursor(column)
       })
 
-      window.bus.on(BusEvent.MSG_QUERY_FIND_N_EXEC, (_event, query: string) => {
-        const text = `${query};`
-        appendQuery(editor, text)
-        toggleRunning()
-      })
+      window.bus.on(
+        BusEvent.MSG_QUERY_FIND_N_EXEC,
+        (_event, payload: { query: string; options?: AppendQueryOptions }) => {
+          const text = `${payload.query};`
+          appendQuery(editor, text, payload.options)
+          toggleRunning()
+        },
+      )
 
       window.bus.on(BusEvent.MSG_QUERY_EXEC, (_event, query: { q: string }) => {
         // TODO: Display a query marker on correct line

--- a/packages/web-console/src/scenes/Editor/Monaco/utils.ts
+++ b/packages/web-console/src/scenes/Editor/Monaco/utils.ts
@@ -426,7 +426,7 @@ const getInsertPosition = ({
   }
 }
 
-type AppendQueryOptions = {
+export type AppendQueryOptions = {
   appendAt: "cursor" | "end"
 }
 
@@ -484,6 +484,10 @@ export const appendQuery = (
     }
 
     editor.focus()
+
+    if (options.appendAt === "end") {
+      editor.revealLine(model.getLineCount())
+    }
   }
 }
 

--- a/packages/web-console/src/scenes/Import/index.tsx
+++ b/packages/web-console/src/scenes/Import/index.tsx
@@ -21,10 +21,10 @@ const Import = () => {
           onImported={(result) => {
             if (result.status === "OK") {
               bus.trigger(BusEvent.MSG_QUERY_SCHEMA)
-              bus.trigger(
-                BusEvent.MSG_QUERY_FIND_N_EXEC,
-                `"${result.location}"`,
-              )
+              bus.trigger(BusEvent.MSG_QUERY_FIND_N_EXEC, {
+                query: `"${result.location}"`,
+                options: { appendAt: "end" },
+              })
             }
           }}
         />


### PR DESCRIPTION
After a successful import is performed we refresh the table list and execute a select query from the newly created/updated table. If an editor cursor is within a query before going to the Import page, the query execution might break.

Fixes:
- Expose `AppendQueryOptions` to the bus event
- Append query at the end of the editor buffer.