### PR TITLE
add publish script for `react-components` package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
-name: web-console
+name: CI
 
 on:
   push:
 
 jobs:
   CI:
-    name: Build packages/web-console
+    name: Monorepo CI flow
     runs-on: ubuntu-latest
     services:
       questdb:
@@ -31,10 +31,10 @@ jobs:
       - name: Build @questdb/web-console
         run: yarn workspace @questdb/web-console run build
 
-      - name: Run unit tests
+      - name: Run @questdb/web-console unit tests
         run: yarn workspace @questdb/web-console run test:prod
 
-      - name: Run Cypress
+      - name: Run browser-tests test
         run: node packages/web-console/serve-dist.js & yarn workspace browser-tests test
 
       - name: Publish @questdb/web-console to npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,12 @@ jobs:
           access: public
           check-version: true
           package: ./packages/web-console/package.json
+
+      - name: Publish @questdb/react-components to npm
+        if: github.ref == 'refs/heads/main'
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          access: public
+          check-version: true
+          package: ./packages/react-components/package.json


### PR DESCRIPTION
This PR updates `.github/workflows/ci.yml file to:

* use generic names for CI steps, to fit monorepo and not only web-console package
* add publish script for react-components package, to allow automated publish when bumping version in `packages/react-components/package.json`