### PR TITLE
chore(web-console): product button as reported by the database

### DIFF
--- a/packages/web-console/src/scenes/Footer/BuildVersion/index.tsx
+++ b/packages/web-console/src/scenes/Footer/BuildVersion/index.tsx
@@ -130,7 +130,10 @@ const BuildVersion = () => {
           : `/commit/${commitHash}`
       }`
 
-  const { label, icon } = versionButtons[buildVersion.kind]
+  const { label, icon } =
+    versionButtons[buildVersion.kind] ??
+    /* fallback to `dev` if `.kind` is something unexpected */
+    versionButtons.dev
 
   return (
     <Wrapper>

--- a/packages/web-console/src/scenes/Footer/BuildVersion/index.tsx
+++ b/packages/web-console/src/scenes/Footer/BuildVersion/index.tsx
@@ -33,7 +33,6 @@ import { Release } from "../../../utils/questdb"
 import { compare } from "compare-versions"
 import { Team } from "styled-icons/remix-line"
 import { BuildingMultiple } from "styled-icons/fluentui-system-filled"
-import { BuildingRetailShield } from "styled-icons/fluentui-system-filled"
 import { ShieldLockFill } from "styled-icons/bootstrap"
 
 const Wrapper = styled.div`
@@ -123,14 +122,13 @@ const BuildVersion = () => {
     newestRelease &&
     compare(buildVersion.version, newestRelease.name, "<")
 
-  const releaseUrl =
-    upgradeAvailable && newestRelease
-      ? newestRelease.html_url
-      : `https://github.com/questdb/questdb${
-          buildVersion
-            ? `/releases/tag/${buildVersion.version}`
-            : `/commit/${commitHash}`
-        }`
+  const releaseUrl = upgradeAvailable
+    ? newestRelease.html_url
+    : `https://github.com/questdb/questdb${
+        buildVersion
+          ? `/releases/tag/${buildVersion.version}`
+          : `/commit/${commitHash}`
+      }`
 
   const { label, icon } = versionButtons[buildVersion.kind]
 
@@ -153,8 +151,11 @@ const BuildVersion = () => {
           {`${label} ${buildVersion.version}`}
 
           {!enterpriseVersion && <ExternalLink size="16px" />}
-          {upgradeAvailable && newestRelease && (
-            <NewestRelease>{newestRelease.name}</NewestRelease>
+          {upgradeAvailable && (
+            <>
+              <UpgradeIcon size="18px" />
+              <NewestRelease>{newestRelease.name}</NewestRelease>
+            </>
           )}
         </ReleaseNotesButton>
       </a>

--- a/packages/web-console/src/scenes/Footer/BuildVersion/index.tsx
+++ b/packages/web-console/src/scenes/Footer/BuildVersion/index.tsx
@@ -94,15 +94,12 @@ const BuildVersion = () => {
   const [newestRelease, setNewestRelease] = useState<Release | null>(null)
 
   useEffect(() => {
-    // void quest.queryRaw("select build", { limit: "0,1000" }).then((result) => {
-    void quest
-      .queryRaw("select * from test limit 4,5;", { limit: "0,1000" })
-      .then((result) => {
-        if (result.type === QuestDB.Type.DQL && result.count === 1) {
-          setBuildVersion(formatVersion(result.dataset[0][0] as string))
-          setCommitHash(formatCommitHash(result.dataset[0][0]))
-        }
-      })
+    void quest.queryRaw("select build", { limit: "0,1000" }).then((result) => {
+      if (result.type === QuestDB.Type.DQL && result.count === 1) {
+        setBuildVersion(formatVersion(result.dataset[0][0] as string))
+        setCommitHash(formatCommitHash(result.dataset[0][0]))
+      }
+    })
   }, [])
 
   useEffect(() => {

--- a/packages/web-console/src/scenes/Footer/BuildVersion/services.ts
+++ b/packages/web-console/src/scenes/Footer/BuildVersion/services.ts
@@ -22,15 +22,40 @@
  *
  ******************************************************************************/
 
-const buildVersionRegex = /Build Information: (QuestDB [0-9A-Za-z.]*),/
+const buildVersionRegex =
+  /Build Information: QuestDB ([\w- ]+ )?([0-9A-Za-z.]*),/
 
-const commitHashRegex = /Commit Hash ([0-9A-Za-z]*)/
+export type Versions = {
+  kind:
+    | "dev"
+    | "open-source"
+    | "enterprise"
+    | "enterprise pro"
+    | "enterprise ultimate"
+  version: string
+}
 
-export const formatVersion = (value: string | number | boolean) => {
+export const formatVersion = (value: string): Versions => {
   const matches = buildVersionRegex.exec(value.toString())
 
-  return matches ? matches[1].replace("QuestDB ", "") : ""
+  if (matches) {
+    const kind = (
+      matches[1] ? matches[1].trim().toLowerCase() : "open-source"
+    ) as Versions["kind"]
+
+    return {
+      kind,
+      version: matches[2],
+    }
+  }
+
+  return {
+    kind: "dev",
+    version: "",
+  }
 }
+
+const commitHashRegex = /Commit Hash ([0-9A-Za-z]*)/
 
 export const formatCommitHash = (value: string | number | boolean) => {
   const matches = commitHashRegex.exec(value.toString())

--- a/packages/web-console/src/scenes/Footer/BuildVersion/services.ts
+++ b/packages/web-console/src/scenes/Footer/BuildVersion/services.ts
@@ -23,7 +23,7 @@
  ******************************************************************************/
 
 const buildVersionRegex =
-  /Build Information: QuestDB ([\w- ]+ )?([0-9A-Za-z.]*),/
+  /Build Information: QuestDB ([\w- ]+ )?([0-9A-Za-z.-]*),/
 
 export type Versions = {
   kind:
@@ -51,7 +51,7 @@ export const formatVersion = (value: string): Versions => {
 
   return {
     kind: "dev",
-    version: "",
+    version: "x.x.x",
   }
 }
 


### PR DESCRIPTION
Added variations of enterprise versions for the build button visible at the lower right corner.

# Examples
button display depends on the output of `select build` command.

```
Build Information: QuestDB 7.2, JDK 17.0.7, Commit Hash da47b26f74125e28a5685c174390f7704f88b21a
```
<img width="365" alt="Screenshot 2023-06-22 at 23 16 41" src="https://github.com/questdb/ui/assets/4284659/cf43552c-86a1-4940-830d-93943e5f546f">

---

```
  Build Information: QuestDB Enterprise 1.1.0, JDK 17.0.7, Commit Hash da47b26f74125e28a5685c174390f7704f88b21a
```
<img width="365" alt="Screenshot 2023-06-22 at 23 20 24" src="https://github.com/questdb/ui/assets/4284659/a42e3a9f-5f9e-4324-bef2-3cfbf65c5ecf">

---

```
Build Information: QuestDB Enterprise Pro 1.1.0, JDK 17.0.7, Commit Hash da47b26f74125e28a5685c174390f7704f88b21a
```
<img width="387" alt="Screenshot 2023-06-22 at 20 10 06" src="https://github.com/questdb/ui/assets/4284659/96caf0f6-cbc3-40be-a96c-3d1270869496">


---

```
Build Information: QuestDB Enterprise Ultimate 1.1.0, JDK 17.0.7, Commit Hash da47b26f74125e28a5685c174390f7704f88b21a
```
<img width="477" alt="Screenshot 2023-06-22 at 20 14 52" src="https://github.com/questdb/ui/assets/4284659/2a27fc44-9c49-4b65-9a7e-60208ba69cfe">

Commit log:

* display different button for enterprise versions
