### PR TITLE
Fix BuildVersion button crash on unexpected value

### DIFF
--- a/packages/web-console/src/scenes/Footer/BuildVersion/index.tsx
+++ b/packages/web-console/src/scenes/Footer/BuildVersion/index.tsx
@@ -27,10 +27,14 @@ import React, { useContext, useEffect, useState } from "react"
 import styled from "styled-components"
 import * as QuestDB from "../../../utils/questdb"
 import { SecondaryButton } from "../../../components"
-import { formatCommitHash, formatVersion, Versions } from "./services"
+import {
+  getCanUpgrade,
+  formatCommitHash,
+  formatVersion,
+  Versions,
+} from "./services"
 import { ExternalLink, ArrowUpCircle } from "styled-icons/remix-line"
 import { Release } from "../../../utils/questdb"
-import { compare } from "compare-versions"
 import { Team } from "styled-icons/remix-line"
 import { BuildingMultiple } from "styled-icons/fluentui-system-filled"
 import { ShieldLockFill } from "styled-icons/bootstrap"
@@ -116,14 +120,10 @@ const BuildVersion = () => {
   }
 
   const enterpriseVersion = buildVersion.kind.includes("enterprise")
-
-  const upgradeAvailable =
-    !enterpriseVersion &&
-    newestRelease &&
-    compare(buildVersion.version, newestRelease.name, "<")
+  const upgradeAvailable = getCanUpgrade(buildVersion, newestRelease?.name)
 
   const releaseUrl = upgradeAvailable
-    ? newestRelease.html_url
+    ? newestRelease?.html_url
     : `https://github.com/questdb/questdb${
         buildVersion
           ? `/releases/tag/${buildVersion.version}`
@@ -157,7 +157,7 @@ const BuildVersion = () => {
           {upgradeAvailable && (
             <>
               <UpgradeIcon size="18px" />
-              <NewestRelease>{newestRelease.name}</NewestRelease>
+              <NewestRelease>{newestRelease?.name}</NewestRelease>
             </>
           )}
         </ReleaseNotesButton>

--- a/packages/web-console/src/scenes/Footer/BuildVersion/services.ts
+++ b/packages/web-console/src/scenes/Footer/BuildVersion/services.ts
@@ -22,6 +22,8 @@
  *
  ******************************************************************************/
 
+import { compare } from "compare-versions"
+
 const buildVersionRegex =
   /Build Information: QuestDB ([\w- ]+ )?([0-9A-Za-z.-]*),/
 
@@ -51,7 +53,7 @@ export const formatVersion = (value: string): Versions => {
 
   return {
     kind: "dev",
-    version: "x.x.x",
+    version: "0.0.0",
   }
 }
 
@@ -61,4 +63,22 @@ export const formatCommitHash = (value: string | number | boolean) => {
   const matches = commitHashRegex.exec(value.toString())
 
   return matches ? matches[1] : ""
+}
+
+export const getCanUpgrade = (
+  buildVersion: Versions,
+  newestReleaseTag?: string,
+): boolean => {
+  if (typeof newestReleaseTag === "undefined") {
+    return false
+  }
+
+  const enterpriseVersion = buildVersion.kind.includes("enterprise")
+
+  try {
+    const isOlder = compare(buildVersion.version, newestReleaseTag, "<")
+    return !enterpriseVersion && isOlder
+  } catch (e) {
+    return false
+  }
 }


### PR DESCRIPTION
Refactored `BuildVersion` button to prevent crashes on unexpected values and improved preventative measures. Used `0.0.0` instead of invalid semver `x.x.x` as fallback. Fixes potential crash of entire web console.

Commit log:

* refactor `BuildVersion` button to prevent crash on unexpected value
    previous change in #165 made `BuildVersion` button show different view
    depending on the value of `select build`.
    
    If `select build` returns unexpected value, a fallback version `x.x.x`
    was used, which is not valid semver according to `compare-versions`
    util.
    
    Moreover, if `select build` returns an unexpected value, say, while
    developing QuestDB locally, it was possible for the entire web console
    to crash.
    
    This commit fixes this problem by using `0.0.0` instead of `x.x.x` as a
    fallback, and in addition has more preventative measures to reduce the
    chance of needing to use fallback value.
