### PR TITLE
chore(web-console): Only check for new releases on OSS

### DIFF
--- a/packages/web-console/src/scenes/Footer/BuildVersion/index.tsx
+++ b/packages/web-console/src/scenes/Footer/BuildVersion/index.tsx
@@ -106,7 +106,7 @@ const BuildVersion = () => {
   }, [])
 
   useEffect(() => {
-    if (buildVersion && buildVersion.kind.includes("open-source")) {
+    if (buildVersion.version && buildVersion.kind.includes("open-source")) {
       void quest.getLatestRelease().then((release: Release) => {
         if (release.name) {
           setNewestRelease(release)

--- a/packages/web-console/src/scenes/Footer/BuildVersion/index.tsx
+++ b/packages/web-console/src/scenes/Footer/BuildVersion/index.tsx
@@ -106,7 +106,7 @@ const BuildVersion = () => {
   }, [])
 
   useEffect(() => {
-    if (buildVersion) {
+    if (buildVersion && buildVersion.kind.includes("open-source")) {
       void quest.getLatestRelease().then((release: Release) => {
         if (release.name) {
           setNewestRelease(release)


### PR DESCRIPTION
- Ensure we are only checking for new releases if the user is on an open-source version.
- Fix an issue causing the check to fire twice, firing first when the `useState` default is set, and, subsequently, when build info is parsed.