### PR TITLE
Deprecate `durable` upload setting

### DIFF
--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/index.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/index.tsx
@@ -129,7 +129,6 @@ export const ImportCSVFiles = ({ onImported }: Props) => {
             skipLev: false,
             delimiter: "",
             atomicity: "skipCol",
-            durable: false,
             maxUncommitedRows: MAX_UNCOMMITTED_ROWS,
           },
           isUploading: false,

--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/upload-settings-dialog.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/upload-settings-dialog.tsx
@@ -84,7 +84,6 @@ export const UploadSettingsDialog = ({
     forceHeader,
     skipLev,
     atomicity,
-    durable,
     maxUncommitedRows,
   } = file.settings
 
@@ -94,7 +93,6 @@ export const UploadSettingsDialog = ({
     forceHeader,
     skipLev,
     atomicity,
-    durable,
     maxUncommitedRows,
   }
 
@@ -189,19 +187,6 @@ export const UploadSettingsDialog = ({
         </>
       ),
       defaultValue: settings.skipLev,
-    },
-    {
-      type: "switch",
-      name: "durable",
-      label: "Durable",
-      description: (
-        <>
-          When set to <strong>true</strong>, import will be resilient against OS
-          errors or power losses by forcing the data to be fully persisted
-          before sending a response back to the user.
-        </>
-      ),
-      defaultValue: settings.durable,
     },
   ]
 

--- a/packages/web-console/src/utils/questdb.ts
+++ b/packages/web-console/src/utils/questdb.ts
@@ -145,7 +145,6 @@ export type UploadModeSettings = {
   skipLev: boolean
   delimiter: string
   atomicity: string
-  durable: boolean
   maxUncommitedRows: number
 }
 


### PR DESCRIPTION
`Durable` upload setting for REST API CSV Import is deprecated and should not be used.

Associated Docs PR: https://github.com/questdb/questdb.io/pull/1854