### PR TITLE
fix(web-console): Update version label for local QuestDB package

### DIFF
--- a/packages/web-console/src/scenes/Footer/BuildVersion/index.tsx
+++ b/packages/web-console/src/scenes/Footer/BuildVersion/index.tsx
@@ -155,7 +155,8 @@ const BuildVersion = () => {
           }
         >
           {icon}
-          {`${label} ${buildVersion.version}`}
+          {label}
+          {buildVersion.version ? ` ${buildVersion.version}` : ""}
 
           {!enterpriseVersion && <ExternalLink size="16px" />}
           {upgradeAvailable && (

--- a/packages/web-console/src/scenes/Footer/BuildVersion/services.ts
+++ b/packages/web-console/src/scenes/Footer/BuildVersion/services.ts
@@ -34,7 +34,7 @@ export type Versions = {
     | "enterprise"
     | "enterprise pro"
     | "enterprise ultimate"
-  version: string
+  version?: string
 }
 
 export const formatVersion = (value: string): Versions => {
@@ -53,7 +53,6 @@ export const formatVersion = (value: string): Versions => {
 
   return {
     kind: "dev",
-    version: "0.0.0",
   }
 }
 
@@ -76,8 +75,11 @@ export const getCanUpgrade = (
   const enterpriseVersion = buildVersion.kind.includes("enterprise")
 
   try {
-    const isOlder = compare(buildVersion.version, newestReleaseTag, "<")
-    return !enterpriseVersion && isOlder
+    if (buildVersion.version) {
+      const isOlder = compare(buildVersion.version, newestReleaseTag, "<")
+      return !enterpriseVersion && isOlder
+    }
+    return false
   } catch (e) {
     return false
   }


### PR DESCRIPTION
Update version label for unreleased local QuestDB package

Commit log:

* display `QuestDB Dev` instead of `QuestDB Dev 0.0.0` as version label for unreleased local QuestDB package
