### PR TITLE
chore(web-console) Add react-component builds to instructions

### DIFF
--- a/docs/local-development-setup.md
+++ b/docs/local-development-setup.md
@@ -84,6 +84,7 @@ If you want to work on `@questdb/web-console` package, you can start its develop
 ```
 yarn workspace @questdb/web-console start
 ```
+_You might need to run_ `yarn workspace @questdb/react-components build` _first._
 
 [localhost:9999](http://localhost:9999) should show web console.
 


### PR DESCRIPTION
I have no idea if that's the best way. but just following the guide did not work for me, the web-console build was missing the react-components and I figured out this could help. It did.