### PR TITLE
fix(grid): fix render crash when grid is empty

### DIFF
--- a/packages/web-console/src/js/console/grid.js
+++ b/packages/web-console/src/js/console/grid.js
@@ -1312,10 +1312,20 @@ export function grid(rootElement, _paginationFn, id) {
     viewport.scrollTop = viewportLeft.scrollTop
   }
 
-  function render() {
+  function noData() {
     if (data.length === 0) {
+      return true
+    }
+    return data[0].length === 0;
+  }
+
+  function render() {
+    if (noData()) {
+      renderColumns()
+      renderRows(0)
       return;
     }
+
     // If viewport is invisible when grid is updated it is not possible
     // to calculate column width correctly. When grid becomes visible again, resize()
     // is called where we continue calculating column widths. resize() can also be

--- a/packages/web-console/src/js/console/grid.js
+++ b/packages/web-console/src/js/console/grid.js
@@ -1313,6 +1313,9 @@ export function grid(rootElement, _paginationFn, id) {
   }
 
   function render() {
+    if (data.length === 0) {
+      return;
+    }
     // If viewport is invisible when grid is updated it is not possible
     // to calculate column width correctly. When grid becomes visible again, resize()
     // is called where we continue calculating column widths. resize() can also be


### PR DESCRIPTION

fixes:

https://github.com/questdb/ui/assets/7276403/7b4b95cb-d69a-4e01-a3af-1dd34073b762

