### PR TITLE
fix(web-console): keep table when 431 raised

### DIFF
--- a/packages/web-console/src/scenes/Schema/index.tsx
+++ b/packages/web-console/src/scenes/Schema/index.tsx
@@ -55,7 +55,7 @@ import {
   VirtualList,
 } from "../../components"
 import { actions, selectors } from "../../store"
-import { color, ErrorResult } from "../../utils"
+import { color, ErrorResult, isServerError } from "../../utils"
 import * as QuestDB from "../../utils/questdb"
 import Table from "./Table"
 import LoadingError from "./LoadingError"
@@ -192,7 +192,9 @@ const Schema = ({
         }
       },
       (error) => {
-        setLoadingError(error)
+        if (isServerError(error)) {
+          setLoadingError(error)
+        }
       },
       () => {
         setLoading(false)

--- a/packages/web-console/src/utils/index.ts
+++ b/packages/web-console/src/utils/index.ts
@@ -23,6 +23,7 @@
  ******************************************************************************/
 
 export * from "./copyToClipboard"
+export * from "./isServerError"
 export * from "./fetch"
 export * from "./fromFetch"
 export * from "./questdb"

--- a/packages/web-console/src/utils/isServerError.ts
+++ b/packages/web-console/src/utils/isServerError.ts
@@ -1,0 +1,5 @@
+// isServerError takes api response and checks if the error is of type server error or timeout
+// returns true if server error type
+export const isServerError = (response: Response): boolean => {
+    return response.status === 408 || response.status >= 500;
+};

--- a/packages/web-console/src/utils/questdb.ts
+++ b/packages/web-console/src/utils/questdb.ts
@@ -21,6 +21,7 @@
  *  limitations under the License.
  *
  ******************************************************************************/
+import { isServerError } from "utils";
 import { BusEvent } from "../consts"
 import { TelemetryConfigShape } from "./../store/Telemetry/types"
 
@@ -77,6 +78,7 @@ type RawResult = RawDqlResult | RawDdlResult | RawErrorResult
 
 export type ErrorResult = RawErrorResult & {
   type: Type.ERROR
+  status: number
 }
 
 export type QueryRawResult =
@@ -328,17 +330,18 @@ export class Client {
       }
     }
 
-    const errorPayload = {
-      error: `QuestDB is not reachable [${response.status}]`,
-      position: -1,
-      query,
-      type: Type.ERROR,
+    const errorPayload: Record<string, string | number> = {
+      status: response.status,
+      error: response.statusText,
     }
 
-    bus.trigger(BusEvent.MSG_CONNECTION_ERROR, {
-      ...errorPayload,
-      status: response.status,
-    })
+    if (isServerError(response)) {
+      errorPayload.error = `QuestDB is not reachable [${response.status}]`;
+      errorPayload.position = -1;
+      errorPayload.query = query;
+      errorPayload.type = Type.ERROR;
+      bus.trigger(BusEvent.MSG_CONNECTION_ERROR, errorPayload)
+    }
 
     // eslint-disable-next-line prefer-promise-reject-errors
     return await Promise.reject(errorPayload)


### PR DESCRIPTION
431 raised from too long query no longer removes table

closes: https://github.com/questdb/ui/issues/97

solution implemented: check for 431 for too large query and don't set error if so, since the only thing the error was doing in this component is conditionally rendering error message there shouldn't be side-effects