### PR TITLE
chore(web-console): rename Table.name to Table.table_name

### DIFF
--- a/packages/web-console/src/components/TableSchemaDialog/dialog.tsx
+++ b/packages/web-console/src/components/TableSchemaDialog/dialog.tsx
@@ -109,7 +109,7 @@ export const Dialog = ({
         if (!isValidTableName(value)) {
           return helpers.error("string.validTableName")
         }
-        if (action === "add" && tables?.find((table) => table.name === value)) {
+        if (action === "add" && tables?.find((table) => table.table_name === value)) {
           return helpers.error("string.uniqueTableName")
         }
         return value
@@ -142,7 +142,7 @@ export const Dialog = ({
         }
         return value
       })
-      .unique((a, b) => a.name === b.name)
+      .unique((a, b) => a.table_name === b.table_name)
       .messages({
         "array.required": "Please add at least one column",
         "array.unique": "Column names must be unique",

--- a/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/createSchemaCompletionProvider.ts
+++ b/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/createSchemaCompletionProvider.ts
@@ -41,12 +41,12 @@ export const createSchemaCompletionProvider = (questDBTables: Table[] = []) => {
         return {
           suggestions: questDBTables.map((item) => {
             return {
-              label: item.name,
+              label: item.table_name,
               kind: CompletionItemKind.Class,
               insertText:
               openQuote
-                  ? item.name + (nextCharQuote ? "" : "\"")
-                  :  /^[a-z0-9_]+$/i.test(item.name) ? item.name : `"${item.name}"`,
+                  ? item.table_name + (nextCharQuote ? "" : "\"")
+                  :  /^[a-z0-9_]+$/i.test(item.table_name) ? item.table_name : `"${item.table_name}"`,
               range,
             }
           }),

--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/index.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/index.tsx
@@ -80,7 +80,7 @@ export const ImportCSVFiles = ({ onImported }: Props) => {
         const partitionBy =
           result.status === FileCheckStatus.EXISTS && tables
             ? await (async () => {
-                const table = tables.find((t) => t.name === file.name)
+                const table = tables.find((t) => t.table_name === file.name)
                 return table?.partitionBy ?? "NONE"
               })()
             : "NONE"
@@ -88,7 +88,7 @@ export const ImportCSVFiles = ({ onImported }: Props) => {
         const timestamp =
           result.status === FileCheckStatus.EXISTS && tables
             ? await (async () => {
-                const table = tables.find((t) => t.name === file.name)
+                const table = tables.find((t) => t.table_name === file.name)
                 return table?.designatedTimestamp ?? ""
               })()
             : ""

--- a/packages/web-console/src/scenes/Schema/Table/index.tsx
+++ b/packages/web-console/src/scenes/Schema/Table/index.tsx
@@ -41,7 +41,7 @@ type Props = QuestDB.Table &
     description?: string
     isScrolling: boolean
     refresh: number
-    name: string
+    table_name: string
     partitionBy: string
     expanded?: boolean
     onChange?: (name: string) => void
@@ -115,13 +115,13 @@ const Table = ({
   isScrolling,
   refresh,
   designatedTimestamp,
-  name,
+  table_name,
   partitionBy,
   expanded = false,
   walEnabled,
   onChange = () => {},
 }: Props) => {
-  const currentName = useRef(name)
+  const currentName = useRef(table_name)
   const [quest] = useState(new QuestDB.Client())
   const [columns, setColumns] = useState<QuestDB.Column[]>()
 
@@ -129,22 +129,22 @@ const Table = ({
   // Currently it is loading columns, but that's already covered by `onOpen` in <Tree/> below.
   // however, it can only be removed once `refresh` is handled elsewhere.
   useEffect(() => {
-    if (name === currentName.current) {
+    if (table_name === currentName.current) {
       return
     }
     combineLatest(
-      from(quest.showColumns(name)).pipe(startWith(null)),
+      from(quest.showColumns(table_name)).pipe(startWith(null)),
       of(true).pipe(delay(1000), startWith(false)),
     ).subscribe(([response]) => {
       if (response && response.type === QuestDB.Type.DQL) {
         setColumns(response.data)
       }
     })
-  }, [refresh, quest, name])
+  }, [refresh, quest, table_name])
 
   const tree: TreeNode[] = [
     {
-      name,
+      name: table_name,
       kind: "table",
       initiallyOpen: expanded,
       children: [
@@ -153,8 +153,8 @@ const Table = ({
           initiallyOpen: true,
           wrapper: Columns,
           async onOpen({ setChildren }) {
-            onChange(name)
-            const response = (await quest.showColumns(name)) ?? []
+            onChange(table_name)
+            const response = (await quest.showColumns(table_name)) ?? []
 
             if (response && response.type === QuestDB.Type.DQL) {
               setColumns(response.data)
@@ -184,11 +184,11 @@ const Table = ({
 
       render({ toggleOpen, isLoading }) {
         return (
-          <ContextMenuTrigger id={name}>
+          <ContextMenuTrigger id={table_name}>
             <Title
               description={description}
               kind="table"
-              name={name}
+              name={table_name  }
               onClick={() => toggleOpen()}
               partitionBy={partitionBy}
               walEnabled={walEnabled}
@@ -205,7 +205,7 @@ const Table = ({
     <Wrapper _height={columns ? columns.length * 30 : 0}>
       {!isScrolling && (
         <ContextualMenu
-          name={name}
+          name={table_name}
           partitionBy={partitionBy}
           walEnabled={walEnabled}
         />

--- a/packages/web-console/src/scenes/Schema/index.tsx
+++ b/packages/web-console/src/scenes/Schema/index.tsx
@@ -159,10 +159,10 @@ const Schema = ({
         return (
           <Table
             designatedTimestamp={table.designatedTimestamp}
-            expanded={table.name === opened}
+            expanded={table.table_name === opened}
             isScrolling={isScrolling}
-            key={table.name}
-            name={table.name}
+            key={table.table_name}
+            table_name={table.table_name}
             onChange={handleChange}
             partitionBy={table.partitionBy}
             refresh={refresh}

--- a/packages/web-console/src/utils/questdb.ts
+++ b/packages/web-console/src/utils/questdb.ts
@@ -99,7 +99,7 @@ export type QueryResult<T extends Record<string, any>> =
   | DdlResult
 
 export type Table = {
-  name: string
+  table_name: string
   partitionBy: string
   designatedTimestamp: string
   walEnabled: boolean
@@ -354,11 +354,11 @@ export class Client {
       return {
         ...response,
         data: response.data.slice().sort((a, b) => {
-          if (a.name > b.name) {
+          if (a.table_name > b.table_name) {
             return 1
           }
 
-          if (a.name < b.name) {
+          if (a.table_name < b.table_name) {
             return -1
           }
 


### PR DESCRIPTION

linked to https://github.com/questdb/questdb/pull/3857 

QuestDB's `tables()` returns now `table_name` instead of `table`. This PR addresses this conundrum 