### PR TITLE
Enable HMR for CSS and improve overflow behaviour of bottom panel

### DIFF
--- a/packages/web-console/src/components/Splitter/index.tsx
+++ b/packages/web-console/src/components/Splitter/index.tsx
@@ -244,7 +244,7 @@ export const Splitter = ({
     display: "flex",
     flexGrow: 0,
     flexBasis: basis ?? fallback,
-    flexShrink: 0,
+    flexShrink: 1,
   }
 
   if (children.length === 1) {

--- a/packages/web-console/src/scenes/Console/index.tsx
+++ b/packages/web-console/src/scenes/Console/index.tsx
@@ -35,12 +35,14 @@ const Top = styled.div`
 const Bottom = styled.div`
   display: flex;
   flex: 1;
+  min-height: 0px;
 `
 
 const Tab = styled.div`
   display: flex;
   width: calc(100% - 4.5rem);
   height: 100%;
+  overflow: auto;
 `
 
 const viewModes: {

--- a/packages/web-console/src/scenes/Layout/index.tsx
+++ b/packages/web-console/src/scenes/Layout/index.tsx
@@ -41,7 +41,7 @@ import { Help } from "./help"
 const Page = styled.div`
   display: flex;
   width: 100%;
-  height: calc(100% - 4rem);
+  height: 100%;
   flex-direction: column;
   flex: 1;
   overflow: hidden;
@@ -56,11 +56,13 @@ const Page = styled.div`
 const Root = styled.div`
   display: flex;
   width: 100%;
-  height: 100%;
+  flex: 1;
+  overflow-y: auto;
 `
 
 const Main = styled.div<{ sideOpened: boolean }>`
   flex: 1;
+  display: flex;
   width: ${({ sideOpened }) =>
     sideOpened ? "calc(100% - 50rem - 4.5rem)" : "calc(100% - 4.5rem)"};
 `

--- a/packages/web-console/src/styles/_base.scss
+++ b/packages/web-console/src/styles/_base.scss
@@ -239,6 +239,7 @@ ol.unstyled {
 /* FOOTER */
 
 #footer {
+  position: relative;
   display: flex;
   background: #21222c;
   flex: 0 0 4rem;

--- a/packages/web-console/webpack.config.js
+++ b/packages/web-console/webpack.config.js
@@ -167,7 +167,7 @@ module.exports = {
     }),
 
     new MiniCssExtractPlugin({
-      filename: "[name].[chunkhash:5].css",
+      filename: config.isProduction ? "[name].[chunkhash:5].css" : "[name].css",
     }),
 
     new Webpack.DefinePlugin({


### PR DESCRIPTION
| Before | After |
|:-:|:-:|
| ![Screen Shot 2023-10-30 at 17 24 44](https://github.com/questdb/ui/assets/17235417/5ff73105-1172-4ec7-bc56-902b0ebc7d0f) | ![Screen Shot 2023-10-30 at 17 25 01](https://github.com/questdb/ui/assets/17235417/042f0c86-8c8e-4a2d-a3eb-c0f4713cd934) |

(viewport height: `330px`)

Also harder to show, but the **File queue** view is now scrollable in both axes on sufficiently small viewports/panel sizes.

The strangest "hack" of these changes is the addition of:


```js
const Bottom = styled.div`
  display: flex;
  flex: 1;
  + min-height: 0px;
`
```

But, doing so allows each panel of the editor to handle its own resizing strategy in a way that should be appropriate.