### PR TITLE
fix(web-console): allow ampersand in the grid output

### DIFF
--- a/packages/web-console/src/js/console/grid.js
+++ b/packages/web-console/src/js/console/grid.js
@@ -34,14 +34,13 @@ const hashString = (str) => {
 
 const escapeHtml = (text) => {
   const map = {
-    "&": "&amp;",
     "<": "&lt;",
     ">": "&gt;",
     '"': "&quot;",
     "'": "&#039;",
   }
 
-  return text.replace(/[&<>"']/g, (m) => map[m])
+  return text.replace(/[<>"']/g, (m) => map[m])
 }
 
 export function grid(rootElement, _paginationFn, id) {


### PR DESCRIPTION
This PR allows ampersands in the grid cells, thus ensuring `explain` will be rendered properly.

| Before | After |
|--------|--------|
| ![CleanShot 2023-11-08 at 17 58 18@2x](https://github.com/questdb/ui/assets/1871646/fb8cdf23-abe6-4437-bbdc-ff28cb3c1f36) | ![CleanShot 2023-11-08 at 17 56 59@2x](https://github.com/questdb/ui/assets/1871646/824e45ac-d3f1-4876-98ea-ff6a27ec6962) | 