### PR TITLE
feat(web-console): add `DEDUP` support in `Copy schema to clipboard`

### DIFF
--- a/packages/web-console/src/components/CreateTableDialog/index.tsx
+++ b/packages/web-console/src/components/CreateTableDialog/index.tsx
@@ -31,6 +31,7 @@ export const CreateTableDialog = () => {
         column: column.name,
         type: column.type,
       })),
+      dedup: false,
     })
     appendQuery(tableSchemaQuery, { appendAt: "end" })
     dispatch(actions.query.toggleRunning())

--- a/packages/web-console/src/scenes/Schema/Table/ContextualMenu/index.tsx
+++ b/packages/web-console/src/scenes/Schema/Table/ContextualMenu/index.tsx
@@ -33,25 +33,26 @@ type Props = {
   name: string
   partitionBy: string
   walEnabled: boolean
+  dedup: boolean
 }
 
-const ContextualMenu = ({ name, partitionBy, walEnabled }: Props) => {
+const ContextualMenu = ({ name, partitionBy, walEnabled, dedup }: Props) => {
   const { quest } = useContext(QuestContext)
   const [schema, setSchema] = React.useState<string | undefined>()
 
-  const handleShow = useCallback(() => {
-    void quest.queryRaw(`table_columns('${name}')`).then((result) => {
-      if (result.type === QuestDB.Type.DQL && result.count > 0) {
-        const formattedResult = formatTableSchemaQueryResult(
-          name,
-          partitionBy,
-          result,
-          walEnabled,
-        )
-        setSchema(formattedResult)
-      }
-    })
-  }, [quest, name, partitionBy])
+  const handleShow = async () => {
+    const response = await quest.showColumns(name)
+    if (response.type === QuestDB.Type.DQL && response.data.length > 0) {
+      const formattedResult = formatTableSchemaQueryResult(
+        name,
+        partitionBy,
+        response.data,
+        walEnabled,
+        dedup,
+      )
+      setSchema(formattedResult)
+    }
+  }
 
   const handleCopySchemaToClipboard = useCallback(() => {
     if (schema) {

--- a/packages/web-console/src/scenes/Schema/Table/ContextualMenu/services.ts
+++ b/packages/web-console/src/scenes/Schema/Table/ContextualMenu/services.ts
@@ -1,3 +1,4 @@
+import { pick } from "./../../../../utils/pick"
 import { Column } from "./../../../../utils/questdb"
 import { formatTableSchemaQuery } from "./../../../../utils/formatTableSchemaQuery"
 /*******************************************************************************
@@ -29,30 +30,28 @@ import * as QuestDB from "../../../../utils/questdb"
 export const formatTableSchemaQueryResult = (
   name: string,
   partitionBy: string,
-  result: QuestDB.QueryRawResult,
+  columns: QuestDB.Column[],
   walEnabled: boolean,
+  dedup: boolean,
 ): string => {
-  if (result.type === QuestDB.Type.DQL) {
-    const findTimestampRow = result.dataset.find((row) => row[6] === true)
-    return formatTableSchemaQuery({
-      name,
-      partitionBy,
-      timestamp: findTimestampRow ? (findTimestampRow[0] as string) : "",
-      walEnabled,
-      schemaColumns: result.dataset.map(
-        (row) =>
-          ({
-            column: row[0],
-            type: row[1],
-            indexed: row[2],
-            indexBlockCapacity: row[3],
-            symbolCached: row[4],
-            symbolCapacity: row[5],
-            designated: row[6],
-          } as Column),
-      ),
-    })
-  } else {
-    throw new Error("Could not format table schema")
-  }
+  const findTimestampColumn = columns.find((c) => c.designated)
+  return formatTableSchemaQuery({
+    name,
+    partitionBy,
+    timestamp: findTimestampColumn ? findTimestampColumn.column : "",
+    walEnabled,
+    dedup,
+    schemaColumns: columns.map((c) => {
+      return pick(c, [
+        "column",
+        "type",
+        "indexed",
+        "indexBlockCapacity",
+        "symbolCached",
+        "symbolCapacity",
+        "designated",
+        "upsertKey",
+      ])
+    }),
+  })
 }

--- a/packages/web-console/src/scenes/Schema/Table/index.tsx
+++ b/packages/web-console/src/scenes/Schema/Table/index.tsx
@@ -118,6 +118,7 @@ const Table = ({
   expanded = false,
   walEnabled,
   onChange,
+  dedup,
 }: Props) => {
   const [quest] = useState(new QuestDB.Client())
   const [columns, setColumns] = useState<QuestDB.Column[]>()
@@ -205,6 +206,7 @@ const Table = ({
           name={table_name}
           partitionBy={partitionBy}
           walEnabled={walEnabled}
+          dedup={dedup}
         />
       )}
 

--- a/packages/web-console/src/scenes/Schema/index.tsx
+++ b/packages/web-console/src/scenes/Schema/index.tsx
@@ -207,6 +207,7 @@ const Schema = ({
               onChange={handleChange}
               partitionBy={table.partitionBy}
               walEnabled={table.walEnabled}
+              dedup={table.dedup}
             />
           ))
         )}

--- a/packages/web-console/src/utils/formatTableSchemaQuery.ts
+++ b/packages/web-console/src/utils/formatTableSchemaQuery.ts
@@ -9,12 +9,14 @@ type Column = {
   symbolCached?: boolean
   symbolCapacity?: number
   type: string
+  upsertKey?: boolean
 }
 
 type Props = {
   name: string
   partitionBy: string
   timestamp: string
+  dedup: boolean
   walEnabled: boolean
   schemaColumns: Column[]
 }
@@ -24,8 +26,13 @@ export const formatTableSchemaQuery = ({
   partitionBy,
   timestamp,
   walEnabled,
+  dedup,
   schemaColumns,
 }: Props) => {
+  const hasValidTimestamp =
+    timestamp &&
+    schemaColumns.find((c) => c.column === timestamp && c.type === "TIMESTAMP")
+
   let query = `CREATE TABLE '${name}' (`
 
   for (let i = 0; i < schemaColumns.length; i++) {
@@ -63,12 +70,30 @@ export const formatTableSchemaQuery = ({
 
   query += ")"
 
-  if (timestamp) {
+  if (hasValidTimestamp) {
     query += ` timestamp (${timestamp})`
   }
 
   if (partitionBy !== "NONE") {
     query += ` PARTITION BY ${partitionBy} ${walEnabled ? "WAL" : "BYPASS WAL"}`
+  }
+
+  // For deduplication keys to work, WAL has to be enabled and a designated timestamp has to be set.
+  if (walEnabled && dedup && hasValidTimestamp) {
+    const upsertColumns = schemaColumns.filter((c) => c.upsertKey)
+    if (upsertColumns.length > 0) {
+      // Designated timestamp has to be part of the deduplication keys. We add it if user forgot.
+      const hasTimestampInKeys = upsertColumns.find(
+        (c) => c.column === timestamp,
+      )
+      const keyColumns = hasTimestampInKeys
+        ? upsertColumns
+        : [...upsertColumns, { column: timestamp }]
+
+      query += ` DEDUP UPSERT KEYS(${keyColumns
+        .map((c) => c.column)
+        .join(",")})`
+    }
   }
 
   return `${formatSql(query)};`

--- a/packages/web-console/src/utils/pick.ts
+++ b/packages/web-console/src/utils/pick.ts
@@ -1,5 +1,8 @@
-export const pick = (obj: object, keys: string[]) => {
-  return Object.entries(obj)
-    .filter(([key]) => keys.includes(key))
-    .reduce((obj, [key, val]) => Object.assign(obj, { [key]: val }), {})
+export function pick<T, K extends keyof T>(obj: T, keys: K[]): Pick<T, K> {
+  return keys.reduce((acc, key) => {
+    if (key in obj) {
+      acc[key] = obj[key]
+    }
+    return acc
+  }, {} as Pick<T, K>)
 }

--- a/packages/web-console/src/utils/questdb.ts
+++ b/packages/web-console/src/utils/questdb.ts
@@ -21,7 +21,7 @@
  *  limitations under the License.
  *
  ******************************************************************************/
-import { isServerError } from "../utils";
+import { isServerError } from "../utils"
 import { BusEvent } from "../consts"
 import { TelemetryConfigShape } from "./../store/Telemetry/types"
 
@@ -103,6 +103,7 @@ export type Table = {
   partitionBy: string
   designatedTimestamp: string
   walEnabled: boolean
+  dedup: boolean
 }
 
 export type Column = {
@@ -113,6 +114,7 @@ export type Column = {
   symbolCached: boolean
   symbolCapacity: number
   type: string
+  upsertKey: boolean
 }
 
 export type Options = {
@@ -181,6 +183,7 @@ export type SchemaColumn = {
   name: string
   type: string
   pattern?: string
+  upsertKey?: boolean
 }
 
 type UploadOptions = {
@@ -363,10 +366,10 @@ export class Client {
     }
 
     if (isServerError(response)) {
-      errorPayload.error = `QuestDB is not reachable [${response.status}]`;
-      errorPayload.position = -1;
-      errorPayload.query = query;
-      errorPayload.type = Type.ERROR;
+      errorPayload.error = `QuestDB is not reachable [${response.status}]`
+      errorPayload.position = -1
+      errorPayload.query = query
+      errorPayload.type = Type.ERROR
       bus.trigger(BusEvent.MSG_CONNECTION_ERROR, errorPayload)
     }
 


### PR DESCRIPTION
Closes https://github.com/questdb/ui/issues/184

### Adding dedup configuration to table schema

If [`DEDUP UPSERT KEYS(key1, key2)`](https://questdb.io/docs/concept/deduplication/#example) has been used when creating a table, it should also be included in the generated DDL statement in `Copy schema to clipboard`.

Steps to test:

1. Create a table that has deduplication enabled
```sql
CREATE TABLE TICKS (
    ts TIMESTAMP,
    tk SYMBOL,
    p DOUBLE
) TIMESTAMP(ts) PARTITION BY DAY WAL
DEDUP UPSERT KEYS(ts, tk);

INSERT INTO TICKS VALUES ('2023-07-14', 'QQQ', 78.56);
INSERT INTO TICKS VALUES ('2023-07-14', 'AAA', 78.56);
INSERT INTO TICKS VALUES ('2023-07-14', 'QQQ', 78.56); -- this is a dupe, won't be inserted
SELECT * FROM TICKS; -- should show 2 records
```