### PR TITLE
fix(web-console): fix table schema form on already existing tables

### DIFF
--- a/packages/web-console/src/components/TableSchemaDialog/dialog.tsx
+++ b/packages/web-console/src/components/TableSchemaDialog/dialog.tsx
@@ -111,7 +111,10 @@ export const Dialog = ({
         if (!isValidTableName(value)) {
           return helpers.error("string.validTableName")
         }
-        if (action === "add" && tables?.find((table) => table.table_name === value)) {
+        if (
+          action === "add" &&
+          tables?.find((table) => table.table_name === value)
+        ) {
           return helpers.error("string.uniqueTableName")
         }
         return value
@@ -144,7 +147,7 @@ export const Dialog = ({
         }
         return value
       })
-      .unique((a, b) => a.table_name === b.table_name)
+      .unique((a, b) => a.name === b.name)
       .messages({
         "array.required": "Please add at least one column",
         "array.unique": "Column names must be unique",


### PR DESCRIPTION
Closes [#3966](https://github.com/questdb/questdb/issues/3966)

The root cause of this issue was the automated code refactoring during changing `name` to `table_name` column in `tables()` query, which erroneously replaced the column name comparator in schema edit form:

https://github.com/questdb/ui/pull/212/files#diff-97f13119f61120692e5d36c4a5ced7f17163d6b7e531c0918a74372ef03bb713R145
```diff
- .unique((a, b) => a.name === b.name)
+ .unique((a, b) => a.table_name === b.table_name)
```