### PR TITLE
release(web-console): 0.3.2

### DIFF
--- a/packages/web-console/CHANGELOG.md
+++ b/packages/web-console/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## 0.3.2 - 2023.11.16
+
+### Added
+- Add `DEDUP` support in `Copy schema to clipboard` [#235](https://github.com/questdb/ui/pull/235)
+
+### Fixed
+- Fix table schema form on already existing tables [#236](https://github.com/questdb/ui/pull/236)
+- Fix query execution when line comments are present [#231](https://github.com/questdb/ui/pull/231)
+
 ## 0.3.1 - 2023.11.15
 
 ### Added

--- a/packages/web-console/package.json
+++ b/packages/web-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@questdb/web-console",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "Apache-2.0",
   "description": "QuestDB Console",
   "files": [


### PR DESCRIPTION
## 0.3.2 - 2023.11.16

### Added
- Add `DEDUP` support in `Copy schema to clipboard` [#235](https://github.com/questdb/ui/pull/235)

### Fixed
- Fix table schema form on already existing tables [#236](https://github.com/questdb/ui/pull/236)
- Fix query execution when line comments are present [#231](https://github.com/questdb/ui/pull/231)