### PR TITLE
chore(web-console): display result zero state at all times

### DIFF
--- a/packages/web-console/src/scenes/Console/zero-state.tsx
+++ b/packages/web-console/src/scenes/Console/zero-state.tsx
@@ -1,9 +1,9 @@
-import React, { useContext, useEffect, useState } from "react"
+import React from "react"
 import styled from "styled-components"
 import { Start } from "../../modules/ZeroState/start"
 import { PaneContent, PaneWrapper } from "../../components"
-import * as QuestDB from "../../utils/questdb"
-import { QuestContext } from "../../providers"
+import { selectors } from "../../store"
+import { useSelector } from "react-redux"
 
 const StyledPaneContent = styled(PaneContent)`
   align-items: center;
@@ -11,32 +11,11 @@ const StyledPaneContent = styled(PaneContent)`
 `
 
 export const ZeroState = () => {
-  const { quest } = useContext(QuestContext)
-  const [loading, setLoading] = useState(true)
-  const [tables, setTables] = useState<QuestDB.Table[]>([])
-
-  const fetchTables = async () => {
-    try {
-      const response = await quest.showTables()
-      if (response && response.type === QuestDB.Type.DQL) {
-        setTables(response.data)
-      }
-    } catch (error) {
-      return
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    void fetchTables()
-  }, [])
+  const { readOnly } = useSelector(selectors.console.getConfig)
 
   return (
     <PaneWrapper>
-      <StyledPaneContent>
-        {!loading && tables.length <= 2 && <Start />}
-      </StyledPaneContent>
+      <StyledPaneContent>{!readOnly && <Start />}</StyledPaneContent>
     </PaneWrapper>
   )
 }


### PR DESCRIPTION
There has been user feedback that finding certain action triggers, like CSV Import, proved to be difficult after the UI refresh.

This change makes the "new user" zero state visible at all times when the Web Console is launched, apart when running in read-only mode.

![CleanShot 2023-12-11 at 18 28 52@2x](https://github.com/questdb/ui/assets/1871646/6c847906-eac1-4b90-b756-2b6b2bd03ba1)
