### PR TITLE
fix(web-console): Fix issues with `Run` button in editor gutter

### DIFF
--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -86,7 +86,7 @@ const Content = styled(PaneContent)`
   }
 `
 
-const LINE_NUMBERS_MIN_CHARS = 5
+const DEFAULT_LINE_CHARS = 5
 
 const MonacoEditor = () => {
   const editorContext = useEditor()
@@ -111,8 +111,12 @@ const MonacoEditor = () => {
   const decorationsRef = useRef<IEditorDecorationsCollection>()
   const errorRef = useRef<ErrorResult | undefined>()
   const errorRangeRef = useRef<IRange | undefined>()
+
+  // Set the initial line number width in chars based on the number of lines in the active buffer
   const [lineNumbersMinChars, setLineNumbersMinChars] = useState(
-    LINE_NUMBERS_MIN_CHARS,
+    DEFAULT_LINE_CHARS +
+      activeBuffer.value.split("\n").length.toString().length -
+      1,
   )
 
   const toggleRunning = (isRefresh: boolean = false) => {
@@ -123,6 +127,17 @@ const MonacoEditor = () => {
     registerLanguageAddons(monaco)
 
     monaco.editor.defineTheme("dracula", dracula)
+  }
+
+  // To ensure the fixed position of the "run query" glyph we adjust the width of the line count element.
+  // This width is represented in char numbers.
+  const setLineCharsWidth = () => {
+    const lineCount = editorRef.current?.getModel()?.getLineCount()
+    if (lineCount) {
+      setLineNumbersMinChars(
+        DEFAULT_LINE_CHARS + (lineCount.toString().length - 1),
+      )
+    }
   }
 
   const handleEditorClick = (e: BaseSyntheticEvent) => {
@@ -206,7 +221,6 @@ const MonacoEditor = () => {
     editor.setModel(
       monaco.editor.createModel(activeBuffer.value, QuestDBLanguageName),
     )
-
     setEditorReady(true)
     editorReadyTrigger(editor)
 
@@ -226,7 +240,7 @@ const MonacoEditor = () => {
       const lineCount = editorRef.current?.getModel()?.getLineCount()
       if (lineCount) {
         setLineNumbersMinChars(
-          LINE_NUMBERS_MIN_CHARS + (lineCount.toString().length - 1),
+          DEFAULT_LINE_CHARS + (lineCount.toString().length - 1),
         )
       }
       renderLineMarkings(monaco, editor)

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -67,11 +67,11 @@ const Content = styled(PaneContent)`
     cursor: pointer;
 
     &:after {
-      content: "◃";
-      font-size: 1.6rem;
-      font-weight: 600;
-      transform: rotate(180deg) scaleX(0.8);
-      color: ${color("green")};
+      display: block;
+      content: "";
+      background-image: url("data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIGhlaWdodD0iMThweCIgd2lkdGg9IjE4cHgiIGFyaWEtaGlkZGVuPSJ0cnVlIiBmb2N1c2FibGU9ImZhbHNlIiBmaWxsPSIjNTBmYTdiIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGNsYXNzPSJTdHlsZWRJY29uQmFzZS1zYy1lYTl1bGotMCBrZkRiTmwiPjxwYXRoIGZpbGw9Im5vbmUiIGQ9Ik0wIDBoMjR2MjRIMHoiPjwvcGF0aD48cGF0aCBkPSJNMTYuMzk0IDEyIDEwIDcuNzM3djguNTI2TDE2LjM5NCAxMnptMi45ODIuNDE2TDguNzc3IDE5LjQ4MkEuNS41IDAgMCAxIDggMTkuMDY2VjQuOTM0YS41LjUgMCAwIDEgLjc3Ny0uNDE2bDEwLjU5OSA3LjA2NmEuNS41IDAgMCAxIDAgLjgzMnoiPjwvcGF0aD48L3N2Zz4K");
+      width: 18px;
+      height: 18px;
     }
   }
 

--- a/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/createSchemaCompletionProvider.ts
+++ b/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/createSchemaCompletionProvider.ts
@@ -8,6 +8,10 @@ import { getTableCompletions } from "./getTableCompletions"
 import { getColumnCompletions } from "./getColumnCompletions"
 import { getLanguageCompletions } from "./getLanguageCompletions"
 
+const trimQuotesFromTableName = (tableName: string) => {
+  return tableName.replace(/(^")|("$)/g, "")
+}
+
 export const createSchemaCompletionProvider = (
   editor: IStandaloneCodeEditor,
   tables: Table[] = [],
@@ -43,6 +47,8 @@ export const createSchemaCompletionProvider = (
           if (joinMatch && joinMatch[2]) {
             tableContext.push(joinMatch[2])
           }
+
+          tableContext = tableContext.map(trimQuotesFromTableName)
 
           const textUntilPosition = model.getValueInRange({
             startLineNumber: cursorMatch?.range.startLineNumber ?? 1,

--- a/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/createSchemaCompletionProvider.ts
+++ b/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/createSchemaCompletionProvider.ts
@@ -86,11 +86,21 @@ export const createSchemaCompletionProvider = (
             }
           }
 
+          // get text value in the current line
+          const textInLine = model.getValueInRange({
+            startLineNumber: position.lineNumber,
+            startColumn: 1,
+            endLineNumber: position.lineNumber,
+            endColumn: position.column,
+          })
+          // check if `textInLine` contains whitespaces only
+          const isWhitespaceOnly = /^\s*$/.test(textInLine)
+
           if (
             /(?:(SELECT|UPDATE).*?(?:(?:,(?:COLUMN )?)|(?:ALTER COLUMN ))?(?:WHERE )?(?: BY )?(?: ON )?(?: SET )?$|ALTER COLUMN )/gim.test(
               textUntilPosition,
             ) &&
-            position.column !== 1
+            !isWhitespaceOnly
           ) {
             if (tableContext.length > 0) {
               const withTableName =


### PR DESCRIPTION
This PR addresses two issues:
1. By dynamically adjusting the left gutter (the space with line numbers and decoration glyphs) it ensures the green "Run" button stays in a fixed position no matter how many lines in the editor there are. When the line number changes in digit count (i.e. from 99 to 100), gutter width expands or contracts accordingly to ensure visual consistency.
2. The way the green "Run" (play) is rendered has been changed to ensure it always looks the same no matter the browser and operating system.  

Fixes https://github.com/questdb/ui/issues/251