### PR TITLE
chore(web-console): Adjust the SVG syntax of Import icon

### DIFF
--- a/packages/web-console/src/components/icons/import.tsx
+++ b/packages/web-console/src/components/icons/import.tsx
@@ -5,17 +5,17 @@ export const Import = ({ size }: { size: string }) => (
     width={size}
     height={size}
     viewBox="0 0 26 26"
-    fill="none"
+    fill="currentColor"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <path d="M25 22.3704H1V24.1481H25V22.3704Z" fill="white" />
+    <path d="M25 22.3704H1V24.1481H25V22.3704Z" fill="currentColor" />
     <path
       d="M1 19.2593V21.037H25V19.7037L21.8889 13.4815H16.1111V16.5926H9.88889V13.4815H4.11111L1 19.2593Z"
-      fill="white"
+      fill="currentColor"
     />
     <path
       d="M13 1.92593L6.33337 8.59259H11.2223V14.8148H14.3334V8.59259H19.6667L13 1.92593Z"
-      fill="white"
+      fill="currentColor"
     />
   </svg>
 )


### PR DESCRIPTION
Adjust the syntax of the new Import icon so that it reacts to the fill definition of the parent accordingly.