### PR TITLE
chore(web-console): update release info API call code

### DIFF
--- a/packages/web-console/src/scenes/Footer/BuildVersion/index.tsx
+++ b/packages/web-console/src/scenes/Footer/BuildVersion/index.tsx
@@ -111,11 +111,16 @@ const BuildVersion = () => {
 
   useEffect(() => {
     if (buildVersion.version && buildVersion.kind.includes("open-source")) {
-      void quest.getLatestRelease().then((release: Release) => {
-        if (release.name) {
-          setNewestRelease(release)
-        }
-      })
+      void quest
+        .getLatestRelease()
+        .then((release: Release) => {
+          if (release.name) {
+            setNewestRelease(release)
+          }
+        })
+        .catch((e) => {
+          console.error(e)
+        })
     }
   }, [buildVersion])
 

--- a/packages/web-console/src/utils/questdb.ts
+++ b/packages/web-console/src/utils/questdb.ts
@@ -504,12 +504,11 @@ export class Client {
   async getLatestRelease() {
     try {
       const response: Response = await fetch(
-        `https://api.github.com/repos/questdb/questdb/releases/latest`,
+        `https://github-api.questdb.io/github/latest`,
       )
       return (await response.json()) as Release
     } catch (error) {
-      // eslint-disable-next-line prefer-promise-reject-errors
-      throw error
+      return Promise.reject(error)
     }
   }
 
@@ -558,8 +557,7 @@ export class Client {
       )
       return (await response.json()) as NewsItem[]
     } catch (error) {
-      // eslint-disable-next-line prefer-promise-reject-errors
-      throw error
+      return Promise.reject(error)
     }
   }
 }


### PR DESCRIPTION
- Use the AWS Lambda endpoint to fetch the latest QuestDB OSS release info instead of calling Github API directly.
- Make sure the error is caught when the call cannot be made.
- The same for News API.