### PR TITLE
fix(web-console): do not trigger autocomplete on newlines

### DIFF
--- a/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/createSchemaCompletionProvider.ts
+++ b/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/createSchemaCompletionProvider.ts
@@ -74,12 +74,23 @@ export const createSchemaCompletionProvider = (
           const openQuote = textUntilPosition.substr(-1) === '"'
           const nextCharQuote = nextChar == '"'
 
+          // get text value in the current line
+          const textInLine = model.getValueInRange({
+            startLineNumber: position.lineNumber,
+            startColumn: 1,
+            endLineNumber: position.lineNumber,
+            endColumn: position.column,
+          })
+          // check if `textInLine` contains whitespaces only
+          const isWhitespaceOnly = /^\s*$/.test(textInLine)
+
           if (
-            /(FROM|INTO|(ALTER|BACKUP|DROP|REINDEX|RENAME|TRUNCATE|VACUUM) TABLE|JOIN|UPDATE)\s$/gim.test(
+            (/(FROM|INTO|(ALTER|BACKUP|DROP|REINDEX|RENAME|TRUNCATE|VACUUM) TABLE|JOIN|UPDATE)\s$/gim.test(
               textUntilPosition,
             ) ||
-            (/'$/gim.test(textUntilPosition) &&
-              !textUntilPosition.endsWith("= '"))
+              (/'$/gim.test(textUntilPosition) &&
+                !textUntilPosition.endsWith("= '"))) &&
+            !isWhitespaceOnly
           ) {
             return {
               suggestions: getTableCompletions({
@@ -91,16 +102,6 @@ export const createSchemaCompletionProvider = (
               }),
             }
           }
-
-          // get text value in the current line
-          const textInLine = model.getValueInRange({
-            startLineNumber: position.lineNumber,
-            startColumn: 1,
-            endLineNumber: position.lineNumber,
-            endColumn: position.column,
-          })
-          // check if `textInLine` contains whitespaces only
-          const isWhitespaceOnly = /^\s*$/.test(textInLine)
 
           if (
             /(?:(SELECT|UPDATE).*?(?:(?:,(?:COLUMN )?)|(?:ALTER COLUMN ))?(?:WHERE )?(?: BY )?(?: ON )?(?: SET )?$|ALTER COLUMN )/gim.test(


### PR DESCRIPTION
Disable triggering autocomplete on newlines, when the cursor is either on the beginning of the new line or indented from the previous one.

Before:
![CleanShot 2024-02-29 at 19 36 03@2x](https://github.com/questdb/ui/assets/1871646/0ee495fd-8064-4a45-90f4-d79361c079a2)

After:
![CleanShot 2024-02-29 at 19 36 17@2x](https://github.com/questdb/ui/assets/1871646/028a5a52-1306-4d41-a7ea-a4da381166ae)
