### PR TITLE
fix(web-console): get rid of autocomplete duplicates

### DIFF
--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -104,6 +104,7 @@ const MonacoEditor = () => {
   const [request, setRequest] = useState<Request | undefined>()
   const [editorReady, setEditorReady] = useState<boolean>(false)
   const [lastExecutedQuery, setLastExecutedQuery] = useState("")
+  const [refreshingTables, setRefreshingTables] = useState(false)
   const dispatch = useDispatch()
   const running = useSelector(selectors.query.getRunning)
   const tables = useSelector(selectors.query.getTables)
@@ -376,6 +377,7 @@ const MonacoEditor = () => {
   const setCompletionProvider = async () => {
     if (editorReady && monacoRef?.current && editorRef?.current) {
       schemaCompletionHandle?.dispose()
+      setRefreshingTables(true)
       try {
         const response = await quest.query<InformationSchemaColumn>(
           "information_schema.columns()",
@@ -399,12 +401,16 @@ const MonacoEditor = () => {
             createSchemaCompletionProvider(editorRef.current, tables),
           ),
         )
+      } finally {
+        setRefreshingTables(false)
       }
     }
   }
 
   useEffect(() => {
-    setCompletionProvider()
+    if (!refreshingTables) {
+      setCompletionProvider()
+    }
   }, [tables, monacoRef, editorReady])
 
   return (


### PR DESCRIPTION
When QuestDB instance is down and then restarted, clicking the "Refresh" icon on the `Tables` menu bar will result in getting duplicates (or, in some cases, triplicates) of autocomplete suggestions.

Steps to replicate and test the correct behavior:
1. Load the Web Console.
2. Stop the running QuestDB instance.
3. Run any query or click "Refresh" icon on the `Tables` menu bar.
4. Start QuestDB instance again.
5. Run any query again or refresh the table list. Autocomplete should not show any duplicates (it will show up duplicates on `main`).

Screenshot of the issue:
<img width="635" alt="Screenshot 2024-03-13 at 14 36 04" src="https://github.com/questdb/ui/assets/1871646/a88fc728-6a66-4092-9c4b-69e3c56702bf">
