### PR TITLE
fix(web-console): file settings not being passed to API

### DIFF
--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/files-to-upload.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/files-to-upload.tsx
@@ -345,7 +345,7 @@ export const FilesToUpload = ({
                     onUpload={onFileUpload}
                     onRemove={onFileRemove}
                     onSettingsChange={(settings) => {
-                      onFilePropertyChange(data.fileObject.name, {
+                      onFilePropertyChange(data.id, {
                         settings,
                       })
                     }}


### PR DESCRIPTION
Fixes https://github.com/questdb/ui/issues/270

Since CSV Import allows importing files with the same names multiple times, we've stopped using filenames as their identifier, which means this is what we check against when updating their settings when user changes them. The following bug was a leftover from the older times.

Steps to replicate:
1. Upload the file attached in the original issue.
2. Select "Force header" in the `Settings` drawer to.
3. The table should be created with proper column names, inferred from the CSV file header.