### PR TITLE
chore(react-components): disable input on prefix

### DIFF
--- a/packages/react-components/src/components/Button/index.stories.tsx
+++ b/packages/react-components/src/components/Button/index.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { Check } from "@styled-icons/remix-line";
+import styled, { css } from "styled-components";
+import { Check as BaseCheck } from "@styled-icons/remix-line";
 
 import { permutate } from "../../utils/permutate";
 import { permutateDecorator } from "../../utils/permutate-decorator";
@@ -8,6 +9,9 @@ import { sizes, Button } from "./";
 import { skins } from "./skin";
 import { color } from "../../theme/color";
 
+const Check = styled(BaseCheck)`
+  pointer-events: none;
+`;
 export default {
   title: "Button",
   component: Button,

--- a/packages/react-components/src/components/Button/index.tsx
+++ b/packages/react-components/src/components/Button/index.tsx
@@ -28,6 +28,7 @@ const Prefix = styled.div<{ disabled?: boolean }>`
   align-items: center;
   justify-content: center;
   margin-right: 0.5rem;
+  pointer-events: none;
   filter: ${({ disabled }) => (disabled ? "grayscale(100%)" : "none")};
   opacity: ${({ disabled }) => (disabled ? 0.5 : 1)};
 `;


### PR DESCRIPTION
Our Button consists of 3 components typically, A base button that handles the input; A div wrapper ,the Prefix, on top that is used to control the layout of the icon; An optional prefix icon that is used to display an icon when specified. Currently, we do not disable pointer events on the Prefix which results in input events being erroneously captured and attributed to it. This PR addresses the issue by disabling all pointer events on the Prefix so that they get registered by the base button instead.

Verified using #276 

Before: 

https://github.com/questdb/ui/assets/7108642/07de4703-c071-4361-91a0-0371f7bef235

After:

https://github.com/questdb/ui/assets/7108642/7ed0f2c1-1232-4103-abe8-0e22f9a76d26

