### PR TITLE
fix(web-console): show an icon next to non-designated timestamp columns

### DIFF
--- a/packages/web-console/src/scenes/Schema/Row/index.tsx
+++ b/packages/web-console/src/scenes/Schema/Row/index.tsx
@@ -223,7 +223,7 @@ const Row = ({
           />
         )}
 
-        {kind === "column" && !indexed && type !== "TIMESTAMP" && (
+        {kind === "column" && !indexed && name !== designatedTimestamp && (
           <DotIcon size="12px" />
         )}
 


### PR DESCRIPTION
Before:
<img width="452" alt="image" src="https://github.com/questdb/ui/assets/158619/ad421a39-a533-451b-baff-d325ce324d8b">



After:
<img width="452" alt="image" src="https://github.com/questdb/ui/assets/158619/b4dc001e-7ea3-4fc1-bb74-834f0f51ad8f">
