### PR TITLE
fix(web-console): align displayed timings with real fetch time

### DIFF
--- a/packages/web-console/package.json
+++ b/packages/web-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@questdb/web-console",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "Apache-2.0",
   "description": "QuestDB Console",
   "files": [

--- a/packages/web-console/src/utils/questdb.ts
+++ b/packages/web-console/src/utils/questdb.ts
@@ -277,7 +277,7 @@ export class Client {
           Client.refreshTokenPending = false
           return resolve(true)
         }
-      }, 100)
+      }, 50)
     })
   }
 
@@ -355,7 +355,7 @@ export class Client {
             clearInterval(interval)
             return resolve(true)
           }
-        }, 100)
+        }, 50)
       })
     }
 

--- a/packages/web-console/src/utils/questdb.ts
+++ b/packages/web-console/src/utils/questdb.ts
@@ -343,23 +343,25 @@ export class Client {
 
     this._controllers.push(controller)
     let response: Response
-    const start = new Date()
 
     if (this.tokenNeedsRefresh() && !Client.refreshTokenPending) {
       await this.refreshAuthToken()
     }
 
-    await new Promise((resolve) => {
-      const interval = setInterval(() => {
-        if (!Client.refreshTokenPending) {
-          clearInterval(interval)
-          return resolve(true)
-        }
-      }, 100)
-    })
+    if (Client.refreshTokenPending) {
+      await new Promise((resolve) => {
+        const interval = setInterval(() => {
+          if (!Client.refreshTokenPending) {
+            clearInterval(interval)
+            return resolve(true)
+          }
+        }, 100)
+      })
+    }
 
     Client.numOfPendingQueries++
 
+    const start = new Date()
     try {
       response = await fetch(
         `${this._host}/exec?${Client.encodeParams(payload)}`,

--- a/packages/web-console/src/utils/questdb.ts
+++ b/packages/web-console/src/utils/questdb.ts
@@ -381,7 +381,7 @@ export class Client {
 
       if (error instanceof DOMException) {
         // eslint-disable-next-line prefer-promise-reject-errors
-        return await Promise.reject({
+        return Promise.reject({
           ...err,
           error:
             error.code === 20
@@ -393,7 +393,7 @@ export class Client {
       eventBus.publish(EventType.MSG_CONNECTION_ERROR, genericErrorPayload)
 
       // eslint-disable-next-line prefer-promise-reject-errors
-      return await Promise.reject(genericErrorPayload)
+      return Promise.reject(genericErrorPayload)
     } finally {
       const index = this._controllers.indexOf(controller)
 
@@ -427,7 +427,7 @@ export class Client {
 
       if (data.error) {
         // eslint-disable-next-line prefer-promise-reject-errors
-        return await Promise.reject({
+        return Promise.reject({
           ...data,
           type: Type.ERROR,
         })
@@ -473,7 +473,7 @@ export class Client {
     }
 
     // eslint-disable-next-line prefer-promise-reject-errors
-    return await Promise.reject(errorPayload)
+    return Promise.reject(errorPayload)
   }
 
   async showTables(): Promise<QueryResult<Table>> {


### PR DESCRIPTION
- excluding token refresh from query execution time
- schedule the wait for token refresh only if there is a pending token refresh

Not sure if we should also display token refresh time (only if there was token refresh)?
Raised an issue, it can be implemented later if we think it is needed:
https://github.com/questdb/ui/issues/283