### PR TITLE
chore(web-console): include link to timestamp formats docs in CSV import schema editor

### DIFF
--- a/packages/web-console/src/components/TableSchemaDialog/column.tsx
+++ b/packages/web-console/src/components/TableSchemaDialog/column.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react"
 import { Form } from "../../components/Form"
-import { IconWithTooltip, Text } from "../../components"
+import {IconWithTooltip, Link, Text} from "../../components"
 import { Box } from "../../components/Box"
 import { Button } from "@questdb/react-components"
 import { DEFAULT_TIMESTAMP_FORMAT } from "./const"
@@ -168,7 +168,15 @@ export const Column = ({
               />
             </TimestampControls>
             {action === "import" && (
-              <Text color="gray2">Example: {DEFAULT_TIMESTAMP_FORMAT}</Text>
+              <Text color="gray2">
+                  Example: {DEFAULT_TIMESTAMP_FORMAT}
+                  <br/>
+                  <DocsLink
+                      url="https://questdb.io/docs/reference/function/date-time/#timestamp-format"
+                      text="Timestamp format docs"
+                      tooltipText="Timestamp format documentation"
+                  />
+              </Text>
             )}
           </Box>
         )}


### PR DESCRIPTION
Timestamp formating is non-trivial. Link should help to users.
Styling isn't great, so some adjustments is welcome. I couldn't figure out the right component/class to make the docs link icon aligned with the text above it :(

Before:
<img width="470" alt="image" src="https://github.com/questdb/ui/assets/158619/21270250-9797-4862-83f6-7d82d152e790">


After:
<img width="470" alt="image" src="https://github.com/questdb/ui/assets/158619/e93eb0be-64c8-4f4e-b954-5a355651c455">
