### PR TITLE
fix(web-console): copy grid cell content to clipboard on MacOS

### DIFF
--- a/packages/browser-tests/cypress.config.js
+++ b/packages/browser-tests/cypress.config.js
@@ -5,6 +5,7 @@ const {
 
 module.exports = defineConfig({
   e2e: {
+    defaultCommandTimeout: 10000,
     screenshotOnRunFailure: false,
     video: false,
     baseUrl: "http://localhost:9999",

--- a/packages/browser-tests/cypress/commands.js
+++ b/packages/browser-tests/cypress/commands.js
@@ -43,6 +43,10 @@ Cypress.Commands.add("getGridRow", (n) =>
   cy.get(".qg-r").filter(":visible").eq(n)
 );
 
+Cypress.Commands.add("getGridCol", (n) =>
+  cy.get(".qg-c").filter(":visible").eq(n)
+);
+
 Cypress.Commands.add("getGridRows", () => cy.get(".qg-r").filter(":visible"));
 
 Cypress.Commands.add("typeQuery", (query) =>

--- a/packages/browser-tests/cypress/integration/console/grid.spec.js
+++ b/packages/browser-tests/cypress/integration/console/grid.spec.js
@@ -47,4 +47,9 @@ describe("questdb grid", () => {
 
     cy.getGridViewport().scrollTo("bottom");
   });
+
+  it.only("copy cell into the clipboard", () => {
+    cy.typeQuery("select x from long_sequence(10)").runLine();
+    cy.getGridCol(0).type("{ctrl}c").should("have.class", "qg-c-active-pulse");
+  });
 });

--- a/packages/web-console/src/js/console/grid.js
+++ b/packages/web-console/src/js/console/grid.js
@@ -462,7 +462,7 @@ export function grid(rootElement, _paginationFn, id) {
   function computeRowBounds() {
     let t = Math.max(0, Math.floor(y / rh))
     let b = Math.min(yMax / rh, Math.ceil((y + viewportHeight) / rh))
-    return {t: t, b: b}
+    return { t: t, b: b }
   }
 
   function renderRows(direction) {
@@ -626,7 +626,7 @@ export function grid(rootElement, _paginationFn, id) {
     const columnSet = []
     for (let i = 0; i < columnCount; i++) {
       const col = getColumn(i)
-      columnSet.push({name: col.name, type: col.type})
+      columnSet.push({ name: col.name, type: col.type })
     }
     layoutStoreColumnSetKey = JSON.stringify(columnSet)
     layoutStoreColumnSetSha256 = hashString(layoutStoreColumnSetKey)
@@ -651,7 +651,7 @@ export function grid(rootElement, _paginationFn, id) {
     let entry = layoutStoreCache[layoutStoreColumnSetSha256]
     if (entry === undefined) {
       const deviants = {}
-      entry = {key: layoutStoreColumnSetKey, deviants: deviants}
+      entry = { key: layoutStoreColumnSetKey, deviants: deviants }
       layoutStoreCache[layoutStoreColumnSetSha256] = entry
     }
     return entry
@@ -819,8 +819,8 @@ export function grid(rootElement, _paginationFn, id) {
       panelLeftGhostHandle.style.top =
         Math.min(
           viewportHeight -
-          panelLeftGhostHandle.getBoundingClientRect().height -
-          (isHorizontalScroller() ? scrollerGirth : 0),
+            panelLeftGhostHandle.getBoundingClientRect().height -
+            (isHorizontalScroller() ? scrollerGirth : 0),
           Math.max(0, panelLeftGhostHandleTop + d),
         ) + "px"
     }
@@ -1590,7 +1590,7 @@ export function grid(rootElement, _paginationFn, id) {
   }
 
   function isCtrlOrCmd() {
-    return downKey[17] || downKey[91]
+    return downKey[17] || downKey[91] || downKey[224]
   }
 
   function onKeyDown(e) {
@@ -1882,7 +1882,7 @@ export function grid(rootElement, _paginationFn, id) {
 
   function setFreezeLeft0(_freezeLeft) {
     freezeLeft = _freezeLeft !== undefined ? _freezeLeft : 0
-    triggerEvent("freeze.state", {freezeLeft: freezeLeft})
+    triggerEvent("freeze.state", { freezeLeft: freezeLeft })
   }
 
   function setFreezeLeft(nextFreezeLeft) {
@@ -1976,7 +1976,7 @@ export function grid(rootElement, _paginationFn, id) {
   }
 
   function triggerEvent(eventName, data) {
-    grid.dispatchEvent(new CustomEvent(eventName, {detail: data}))
+    grid.dispatchEvent(new CustomEvent(eventName, { detail: data }))
   }
 
   function bind() {
@@ -2070,8 +2070,11 @@ export function grid(rootElement, _paginationFn, id) {
 
     const resizeObserver = new ResizeObserver(function () {
       // ignore resize calls when grid is not visible
-      if (grid.getBoundingClientRect().height > 0 && grid.getBoundingClientRect().width > 0) {
-        render();
+      if (
+        grid.getBoundingClientRect().height > 0 &&
+        grid.getBoundingClientRect().width > 0
+      ) {
+        render()
       }
     })
     resizeObserver.observe(grid)


### PR DESCRIPTION
Currently copying the grid cell content to clipboard doesn't work on Mac, with the usual `CMD + C` shortcut.
This PR makes sure the Command key for Mac is added to the `isCtrlOrCmd()` conditional check.