### PR TITLE
chore(web-console): use relative URLs

### DIFF
--- a/packages/web-console/src/index.html
+++ b/packages/web-console/src/index.html
@@ -3,8 +3,8 @@
 
 <head>
   <meta charset="utf-8">
-  <link rel="icon" href="/assets/favicon.ico">
-  <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="assets/favicon.ico">
+  <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description"
     content="QuestDB live demo. Query three large datasets and more than 2 billion rows in milliseconds with SQL" />

--- a/packages/web-console/src/js/console/quick-vis.ts
+++ b/packages/web-console/src/js/console/quick-vis.ts
@@ -265,7 +265,7 @@ export function quickVis(
       requestParams.src = "vis"
       // time the query because control that displays query success expected time delta
       queryExecutionTimestamp = new Date().getTime()
-      hActiveRequest = $.get("/exec", requestParams)
+      hActiveRequest = $.get("exec", requestParams)
       eventBus.publish(EventType.MSG_QUERY_RUNNING)
       hActiveRequest.done(handleServerResponse).fail(handleServerError)
     }

--- a/packages/web-console/src/modules/OAuth2/views/login.tsx
+++ b/packages/web-console/src/modules/OAuth2/views/login.tsx
@@ -7,7 +7,7 @@ import Joi from "joi"
 import { Text } from "../../../components"
 import { setValue } from "../../../utils/localStorage"
 import { StoreKey } from "../../../utils/localStorage/types"
-import { useSettings } from "../../../providers/SettingsProvider"
+import { useSettings } from "../../../providers"
 
 const Header = styled.div`
   position: absolute;
@@ -208,7 +208,7 @@ export const Login = ({
     const { username, password } = values
     try {
       const response = await fetch(
-        `${window.location.origin}/exec?query=alter user '${username}' create token type rest with ttl '1d' refresh transient`,
+        `exec?query=alter user '${username}' create token type rest with ttl '1d' refresh transient`,
         {
           headers: {
             Authorization: `Basic ${btoa(`${username}:${password}`)}`,
@@ -244,7 +244,7 @@ export const Login = ({
           <img
             alt="QuestDB logotype"
             height="20"
-            src="/assets/questdb-logotype.svg"
+            src="assets/questdb-logotype.svg"
           />
         </a>
       </Header>

--- a/packages/web-console/src/modules/ZeroState/start.tsx
+++ b/packages/web-console/src/modules/ZeroState/start.tsx
@@ -74,7 +74,7 @@ export const Start = () => {
             alt="File upload icon"
             width="60"
             height="80"
-            src="/assets/upload.svg"
+            src="assets/upload.svg"
           />
           <Heading level={5}>Import CSV</Heading>
         </Action>
@@ -85,7 +85,7 @@ export const Start = () => {
             alt="Create table icon"
             width="60"
             height="80"
-            src="/assets/create-table.svg"
+            src="assets/create-table.svg"
           />
           <Heading level={5}>Create table</Heading>
         </Action>

--- a/packages/web-console/src/providers/AuthProvider.tsx
+++ b/packages/web-console/src/providers/AuthProvider.tsx
@@ -228,7 +228,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const basicAuthLogin = async () => {
     // run a simple query to force basic auth by browser
     const response = await fetch(
-      `${window.location.origin}/exec?query=select 42`,
+      `exec?query=select 42`,
     )
     if (response.status === 200) {
       dispatch({ view: View.ready })
@@ -255,7 +255,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       config: settings,
       code_challenge,
       login,
-      redirect_uri: window.location.origin,
+      redirect_uri: window.location.href,
     })
   }
 
@@ -265,7 +265,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     if (noRedirect) {
       dispatch({ view: View.loggedOut })
     } else {
-      window.location.href = window.location.origin
+      window.location.reload()
     }
   }
 

--- a/packages/web-console/src/providers/SettingsProvider/index.tsx
+++ b/packages/web-console/src/providers/SettingsProvider/index.tsx
@@ -61,7 +61,7 @@ export const SettingsProvider = ({
               alt="QuestDB logotype"
               width="95"
               height="23"
-              src="/assets/questdb-logotype.svg"
+              src="assets/questdb-logotype.svg"
             />
           </a>
           <Text align="center" size="lg">
@@ -83,7 +83,7 @@ export const SettingsProvider = ({
 
   const fetchSettings = async () => {
     try {
-      const response = await fetch(`${window.location.origin}/settings`)
+      const response = await fetch(`settings`)
       if (response.status === 200) {
         const settings = await response.json()
         setSettings(settings)
@@ -98,7 +98,7 @@ export const SettingsProvider = ({
   const fetchConsoleConfig = async () => {
     try {
       const response = await fetch(
-        `${window.location.origin}/assets/console-configuration.json`,
+        `assets/console-configuration.json`
       )
       if (response.status === 200) {
         const consoleConfig = await response.json()

--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/upload.tsx
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/upload.tsx
@@ -81,7 +81,7 @@ export const Upload = ({ files, onFilesDropped, dialogOpen }: Props) => {
               alt="File upload icon"
               width="60"
               height="80"
-              src="/assets/upload.svg"
+              src="assets/upload.svg"
             />
             <Heading level={3}>
               Drag CSV files here or paste from clipboard

--- a/packages/web-console/src/utils/questdb.ts
+++ b/packages/web-console/src/utils/questdb.ts
@@ -243,7 +243,6 @@ export type Parameter = {
 }
 
 export class Client {
-  private readonly _host: string
   private _controllers: AbortController[] = []
   private commonHeaders: Record<string, string> = {}
   private static refreshTokenPending = false
@@ -262,14 +261,6 @@ export class Client {
         new Date(parsed.expires_at).getTime() - new Date().getTime() < 30000 &&
         refreshToken !== ""
       )
-    }
-  }
-
-  constructor(host?: string) {
-    if (!host) {
-      this._host = window.location.origin
-    } else {
-      this._host = host
     }
   }
 
@@ -380,7 +371,7 @@ export class Client {
     const start = new Date()
     try {
       response = await fetch(
-        `${this._host}/exec?${Client.encodeParams(payload)}`,
+        `exec?${Client.encodeParams(payload)}`,
         { signal: controller.signal, headers: this.commonHeaders },
       )
     } catch (error) {
@@ -544,7 +535,7 @@ export class Client {
   async checkCSVFile(name: string): Promise<FileCheckResponse> {
     try {
       const response: Response = await fetch(
-        `${this._host}/chk?${Client.encodeParams({
+        `chk?${Client.encodeParams({
           f: "json",
           j: name,
         })}`,
@@ -589,7 +580,7 @@ export class Client {
 
     return new Promise((resolve, reject) => {
       let request = new XMLHttpRequest()
-      request.open("POST", `${this._host}/imp?${new URLSearchParams(params)}`)
+      request.open("POST", `imp?${new URLSearchParams(params)}`)
       Object.keys(this.commonHeaders).forEach((key) => {
         request.setRequestHeader(key, this.commonHeaders[key])
       })
@@ -620,7 +611,7 @@ export class Client {
   async exportQueryToCsv(query: string) {
     try {
       const response: Response = await fetch(
-        `${this._host}/exp?${Client.encodeParams({ query })}`,
+        `exp?${Client.encodeParams({ query })}`,
         { headers: this.commonHeaders },
       )
       const blob = await response.blob()

--- a/packages/web-console/webpack.config.js
+++ b/packages/web-console/webpack.config.js
@@ -51,7 +51,7 @@ module.exports = {
 
   output: {
     filename: "[name].[chunkhash:5].js",
-    publicPath: config.assetPath,
+    publicPath: "auto",
     path: path.resolve(__dirname, "dist"),
   },
 

--- a/packages/web-console/webpack.config.js
+++ b/packages/web-console/webpack.config.js
@@ -40,7 +40,6 @@ if (!process.env.NODE_ENV) {
 const config = {
   port: 9999,
   backendUrl: "http://127.0.0.1:9000",
-  assetPath: process.env.ASSET_PATH || "/",
   isProduction: process.env.NODE_ENV === "production",
 }
 


### PR DESCRIPTION
The web console to use relative URLs to make it possible deploying it under a context path.

The change consists of 2 parts:
- changing webpack config not to use ASSET_PATH (publicPath: "auto" means webpack will generate relative URLs)
- changing the code not to prefix URLs with `window.location`, this makes them relative