### PR TITLE
chore(web-console): remove cloud info

### DIFF
--- a/packages/web-console/src/modules/ZeroState/start.tsx
+++ b/packages/web-console/src/modules/ZeroState/start.tsx
@@ -90,18 +90,6 @@ export const Start = () => {
           <Heading level={5}>Create table</Heading>
         </Action>
       </Actions>
-      <StyledText color="gray2">
-        Get $200 in free credits when you sign up for{" "}
-        <a
-          href="https://questdb.io/cloud"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          QuestDB Cloud
-        </a>
-        .<br />
-        No credit card required.
-      </StyledText>
     </Items>
   )
 }


### PR DESCRIPTION
Remove QuestDB Cloud info from web console.

We might use the real estate to communicate other things, but that will probably require more thinking - like rotating a bunch of tips, "did you know that .. ?", etc.