### PR TITLE
release(web-console): 0.4.4

### DIFF
--- a/packages/web-console/CHANGELOG.md
+++ b/packages/web-console/CHANGELOG.md
@@ -16,6 +16,27 @@ and this project adheres to
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## 0.4.4 - 2024.06.19
+
+### Added
+
+- Start EE telemetry [#294](https://github.com/questdb/ui/pull/294)
+- Use relative URLs [#299](https://github.com/questdb/ui/pull/299)
+
+### Fixed
+
+- Include link to timestamp formats docs in CSV import schema editor
+  [#295](https://github.com/questdb/ui/pull/295)
+- Copy grid cell content to clipboard on MacOS
+  [#297](https://github.com/questdb/ui/pull/297)
+
+## 0.4.3 - 2024.05.30
+
+### Fixed
+
+- Start OSS telemetry
+  [#292](https://github.com/questdb/ui/pull/292)
+
 ## 0.4.2 - 2024.05.16
 
 ### Added

--- a/packages/web-console/package.json
+++ b/packages/web-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@questdb/web-console",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "license": "Apache-2.0",
   "description": "QuestDB Console",
   "files": [


### PR DESCRIPTION
releasing v0.4.4

### Added

- Start EE telemetry [#294](https://github.com/questdb/ui/pull/294)
- Use relative URLs [#299](https://github.com/questdb/ui/pull/299)

### Fixed

- Include link to timestamp formats docs in CSV import schema editor
  [#295](https://github.com/questdb/ui/pull/295)
- Copy grid cell content to clipboard on MacOS
  [#297](https://github.com/questdb/ui/pull/297)