### PR TITLE
chore(browser-tests): Refactor waiting for editor ready state

### DIFF
--- a/packages/browser-tests/cypress/commands.js
+++ b/packages/browser-tests/cypress/commands.js
@@ -82,7 +82,9 @@ beforeEach(() => {
 
   cy.request({
     method: "GET",
-    url: `${baseUrl}/exec?query=${encodeURIComponent(`select simulate_warnings('', '');`)}`,
+    url: `${baseUrl}/exec?query=${encodeURIComponent(
+      `select simulate_warnings('', '');`
+    )}`,
   });
 });
 
@@ -107,7 +109,9 @@ Cypress.Commands.add("getGridCol", (n) =>
 Cypress.Commands.add("getGridRows", () => cy.get(".qg-r").filter(":visible"));
 
 Cypress.Commands.add("typeQuery", (query) =>
-  cy.getEditor().realClick().type(query)
+  cy.getEditor().realClick().type(query, {
+    delay: 25,
+  })
 );
 
 Cypress.Commands.add("runLine", () => {
@@ -116,11 +120,10 @@ Cypress.Commands.add("runLine", () => {
   cy.wait("@exec");
 });
 
-Cypress.Commands.add("clickRun",
-  () => {
-    cy.intercept("/exec*").as("exec");
-    return cy.get("button").contains("Run").click().wait("@exec");
-  });
+Cypress.Commands.add("clickRun", () => {
+  cy.intercept("/exec*").as("exec");
+  return cy.get("button").contains("Run").click().wait("@exec");
+});
 
 Cypress.Commands.add("clearEditor", () =>
   cy.typeQuery(`${ctrlOrCmd}a{backspace}`)
@@ -136,8 +139,8 @@ Cypress.Commands.add("selectQuery", (n) =>
     .click()
 );
 
-Cypress.Commands.add("getMountedEditor", () =>
-  cy.get(".monaco-scrollable-element")
+Cypress.Commands.add("waitForEditorLoad", () =>
+  cy.window().should("have.property", "editor_loaded", true)
 );
 
 Cypress.Commands.add("getEditor", () => cy.get(".monaco-editor[role='code'] "));

--- a/packages/browser-tests/cypress/integration/console/editor.spec.js
+++ b/packages/browser-tests/cypress/integration/console/editor.spec.js
@@ -191,7 +191,10 @@ describe("autocomplete", () => {
       'create table "my_secrets" ("secret" string);',
       'create table "my_secrets2" ("secret" string);',
     ].forEach((query) => {
-      cy.typeQuery(query).runLine().clearEditor();
+      cy.request({
+        method: "GET",
+        url: `${baseUrl}/exec?query=${encodeURIComponent(query)};`,
+      });
     });
   });
 

--- a/packages/browser-tests/cypress/integration/console/editor.spec.js
+++ b/packages/browser-tests/cypress/integration/console/editor.spec.js
@@ -26,11 +26,11 @@ describe("appendQuery", () => {
     ).as("getConsoleConfiguration");
 
     cy.visit(baseUrl);
-    cy.getEditorContent().should("be.visible");
+    cy.waitForEditorLoad();
   });
 
   beforeEach(() => {
-    cy.getEditorContent().should("be.visible");
+    cy.waitForEditorLoad();
     cy.clearEditor();
   });
 
@@ -130,7 +130,7 @@ describe("appendQuery", () => {
 describe("&query URL param", () => {
   beforeEach(() => {
     cy.visit(baseUrl);
-    cy.getEditorContent().should("be.visible");
+    cy.waitForEditorLoad();
     cy.clearEditor();
   });
 
@@ -138,7 +138,7 @@ describe("&query URL param", () => {
     cy.typeQuery("select x from long_sequence(1)"); // running query caches it, it's available after refresh
     const query = encodeURIComponent("select x+1 from long_sequence(1)");
     cy.visit(`${baseUrl}/?query=${query}&executeQuery=true`);
-    cy.getEditorContent().should("be.visible");
+    cy.waitForEditorLoad();
     cy.getGridRow(0).should("contain", "2");
     cy.getSelectedLines().should("have.length", 1);
   });
@@ -151,7 +151,7 @@ describe("&query URL param", () => {
     );
     const query = encodeURIComponent("select x+1\nfrom\nlong_sequence(1);");
     cy.visit(`${baseUrl}?query=${query}&executeQuery=true`);
-    cy.getEditorContent().should("be.visible");
+    cy.waitForEditorLoad();
     cy.getGridRow(0).should("contain", "2");
     cy.getSelectedLines().should("have.length", 4);
   });
@@ -161,7 +161,7 @@ describe("&query URL param", () => {
     cy.typeQuery(query);
     cy.clickRun();
     cy.visit(`${baseUrl}?query=${encodeURIComponent(query)}&executeQuery=true`);
-    cy.getEditorContent().should("be.visible");
+    cy.waitForEditorLoad();
     cy.getEditorContent().should("have.value", query);
   });
 
@@ -172,7 +172,7 @@ describe("&query URL param", () => {
 
     const appendedQuery = "-- hello world";
     cy.visit(`${baseUrl}?query=${encodeURIComponent(appendedQuery)}`);
-    cy.getEditorContent().should("be.visible");
+    cy.waitForEditorLoad();
     cy.getVisibleLines()
       .invoke("text")
       .should("match", /hello.world$/); // not matching on appendedQuery, because query should be selected for which Monaco adds special chars between words
@@ -182,7 +182,7 @@ describe("&query URL param", () => {
 describe("autocomplete", () => {
   before(() => {
     cy.visit(baseUrl);
-    cy.getEditorContent().should("be.visible");
+    cy.waitForEditorLoad();
     [
       'create table "my_publics" ("public" string);',
       // We're creating another table with the same column name.
@@ -197,7 +197,7 @@ describe("autocomplete", () => {
 
   beforeEach(() => {
     cy.visit(baseUrl);
-    cy.getEditorContent().should("be.visible");
+    cy.waitForEditorLoad();
     cy.clearEditor();
   });
 
@@ -253,7 +253,7 @@ describe("errors", () => {
   });
 
   beforeEach(() => {
-    cy.getEditorContent().should("be.visible");
+    cy.waitForEditorLoad();
     cy.clearEditor();
   });
 
@@ -281,7 +281,7 @@ describe("running query with F9", () => {
   });
 
   beforeEach(() => {
-    cy.getEditorContent().should("be.visible");
+    cy.waitForEditorLoad();
     cy.clearEditor();
   });
 

--- a/packages/browser-tests/cypress/integration/console/grid.spec.js
+++ b/packages/browser-tests/cypress/integration/console/grid.spec.js
@@ -5,7 +5,7 @@ const baseUrl = "http://localhost:9999";
 describe("questdb grid", () => {
   beforeEach(() => {
     cy.visit(baseUrl);
-    cy.getEditorContent().should("be.visible");
+    cy.waitForEditorLoad();
     cy.clearEditor();
   });
 

--- a/packages/browser-tests/cypress/integration/console/schema.spec.js
+++ b/packages/browser-tests/cypress/integration/console/schema.spec.js
@@ -66,7 +66,7 @@ describe("questdb schema with working tables", () => {
 describe("questdb schema with suspended tables with Linux OS error codes", () => {
   before(() => {
     cy.visit(baseUrl);
-    cy.getEditorContent().should("be.visible");
+    cy.waitForEditorLoad();
     cy.clearEditor();
     tables.forEach((table) => {
       cy.createTable(table);

--- a/packages/browser-tests/cypress/integration/console/warnings.spec.js
+++ b/packages/browser-tests/cypress/integration/console/warnings.spec.js
@@ -19,14 +19,17 @@ describe("System configuration - 3 warnings", () => {
 
   before(() => {
     cy.visit(baseUrl);
-    cy.getEditorContent().should("be.visible");
+    cy.waitForEditorLoad();
     cy.clearEditor();
     [
       "select simulate_warnings('UNSUPPORTED FILE SYSTEM', 'Unsupported file system [dir=/questdb/path/dbRoot, magic=0x6400A468]');",
       "select simulate_warnings('TOO MANY OPEN FILES', 'fs.file-max limit is too low [current=1024, recommended=1048576]');",
       "select simulate_warnings('OUT OF MMAP AREAS', 'vm.max_map_count limit is too low [current=4096, recommended=1048576]');",
     ].forEach((query) => {
-      cy.typeQuery(query).runLine().clearEditor();
+      cy.request({
+        method: "GET",
+        url: `${baseUrl}/exec?query=${encodeURIComponent(query)};`,
+      });
     });
     cy.visit(baseUrl);
   });

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -384,6 +384,7 @@ const MonacoEditor = () => {
         ),
       )
       setRefreshingTables(false)
+      window.editor_loaded = true
     }
   }
 

--- a/packages/web-console/src/scenes/Result/index.tsx
+++ b/packages/web-console/src/scenes/Result/index.tsx
@@ -113,7 +113,7 @@ const Result = ({ viewMode }: { viewMode: ResultViewMode }) => {
       },
     )
     gridRef.current = _grid
-    quickVis($("#quick-vis"), window.bus as unknown as ReturnType<typeof $>)
+    quickVis($("#quick-vis"), window.bus)
 
     _grid.addEventListener("header.click", function (event: CustomEvent) {
       eventBus.publish(

--- a/packages/web-console/types/custom.d.ts
+++ b/packages/web-console/types/custom.d.ts
@@ -1,3 +1,5 @@
+import { editor } from "monaco-editor"
+import $ from "jquery"
 /*******************************************************************************
  *     ___                  _   ____  ____
  *    / _ \ _   _  ___  ___| |_|  _ \| __ )
@@ -77,4 +79,11 @@ declare class ResizeObserver {
   disconnect: () => void
   observe: (target: Element, options?: ResizeObserverObserveOptions) => void
   unobserve: (target: Element) => void
+}
+
+declare global {
+  interface Window {
+    editor_loaded: boolean
+    bus: ReturnType<typeof $>
+  }
 }


### PR DESCRIPTION
This PR is aimed to further reduce the possible flakiness on CI, which, although rare, sometimes manifests itself when the tests start to run before the editor is fully ready UI wise.

**Changes:**
- Introduced the `window.editor_ready` global flag, which is set at the very end of the editor initialization process, when all the completion providers finish setup. This is in contrast to checking for mere `textarea` presence, which can happen much earlier.
- Added `waitForEditorLoad` Cypress command to use in `before` and `beforeEach` hooks.
- Converted "service" queries (DDLs, warning simulation) to `cy.request()` instead of typing them manually in the editor - there is zero user value in the latter, and it significantly slows down the text execution time, as they are usually quite long.
- Configured a slightly longer keystroke delay for typing inside the editor to prevent occasional test hiccups (very rare, but still) when using multi line queries, various cursor keys, etc. 