### PR TITLE
chore(web-console): Small UI fixes related to Tables

### DIFF
--- a/packages/browser-tests/cypress/integration/console/schema.spec.js
+++ b/packages/browser-tests/cypress/integration/console/schema.spec.js
@@ -130,3 +130,24 @@ describe("questdb schema with suspended tables with Linux OS error codes", () =>
     });
   });
 });
+
+describe.only("questdb schema in read-only mode", () => {
+  before(() => {
+    cy.intercept(
+      {
+        method: "GET",
+        url: `${baseUrl}/assets/console-configuration.json`,
+      },
+      {
+        savedQueries: [],
+        readOnly: true,
+      }
+    ).as("getConsoleConfiguration");
+    cy.visit(baseUrl);
+  });
+
+  it("should disable Create Table action in read-only mode", () => {
+    cy.getByDataHook("create-table-panel-button").click();
+    cy.getByDataHook("create-table-panel").should("not.exist");
+  });
+});

--- a/packages/browser-tests/cypress/integration/console/schema.spec.js
+++ b/packages/browser-tests/cypress/integration/console/schema.spec.js
@@ -41,19 +41,6 @@ describe("questdb schema with working tables", () => {
       "have.length.least",
       tables.length
     );
-
-    // Column name search
-    cy.get('input[name="table_filter"]').type("timestamp");
-    cy.getByDataHook("schema-table-title").should("contain", "btc_trades");
-    cy.getByDataHook("schema-table-title").should(
-      "not.contain",
-      "chicago_weather_stations"
-    );
-    cy.getByDataHook("schema-search-clear-button").click();
-    cy.getByDataHook("schema-table-title").should(
-      "contain",
-      "chicago_weather_stations"
-    );
   });
 
   after(() => {

--- a/packages/browser-tests/cypress/integration/console/schema.spec.js
+++ b/packages/browser-tests/cypress/integration/console/schema.spec.js
@@ -131,7 +131,7 @@ describe("questdb schema with suspended tables with Linux OS error codes", () =>
   });
 });
 
-describe.only("questdb schema in read-only mode", () => {
+describe("questdb schema in read-only mode", () => {
   before(() => {
     cy.intercept(
       {
@@ -147,6 +147,12 @@ describe.only("questdb schema in read-only mode", () => {
   });
 
   it("should disable Create Table action in read-only mode", () => {
+    cy.getByDataHook("create-table-panel-button").trigger("mouseover");
+    cy.getByDataHook("tooltip").should(
+      "contain",
+      "To use this feature, turn off read-only mode in the configuration file"
+    );
+
     cy.getByDataHook("create-table-panel-button").click();
     cy.getByDataHook("create-table-panel").should("not.exist");
   });

--- a/packages/web-console/src/components/CreateTableDialog/index.tsx
+++ b/packages/web-console/src/components/CreateTableDialog/index.tsx
@@ -55,7 +55,12 @@ export const CreateTableDialog = () => {
   if (consoleConfig.readOnly) {
     return (
       <IconWithTooltip
-        icon={<DisabledTableIcon size={BUTTON_ICON_SIZE} />}
+        icon={
+          <DisabledTableIcon
+            size={BUTTON_ICON_SIZE}
+            data-hook="create-table-panel-button"
+          />
+        }
         tooltip="To use this feature, turn off read-only mode in the configuration file"
         placement="left"
       />

--- a/packages/web-console/src/components/CreateTableDialog/index.tsx
+++ b/packages/web-console/src/components/CreateTableDialog/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react"
+import styled from "styled-components"
 import { Dialog as TableSchemaDialog } from "../../components/TableSchemaDialog/dialog"
 import { useDispatch, useSelector } from "react-redux"
 import { selectors, actions } from "../../store"
@@ -9,6 +10,10 @@ import { useEditor, useSettings } from "../../providers"
 import { PrimaryToggleButton } from "../../components"
 import { BUTTON_ICON_SIZE } from "../../consts"
 import { IconWithTooltip } from "../../components/IconWithTooltip"
+
+const DisabledTableIcon = styled(TableIcon)`
+  opacity: 0.3;
+`
 
 export const CreateTableDialog = () => {
   const [addTableDialogOpen, setAddTableDialogOpen] = useState<
@@ -47,6 +52,16 @@ export const CreateTableDialog = () => {
     }
   }, [addTableDialogOpen])
 
+  if (consoleConfig.readOnly) {
+    return (
+      <IconWithTooltip
+        icon={<DisabledTableIcon size={BUTTON_ICON_SIZE} />}
+        tooltip="To use this feature, turn off read-only mode in the configuration file"
+        placement="left"
+      />
+    )
+  }
+
   return (
     <TableSchemaDialog
       action="add"
@@ -66,27 +81,20 @@ export const CreateTableDialog = () => {
           icon={
             <PrimaryToggleButton
               data-hook="create-table-panel-button"
-              readOnly={consoleConfig.readOnly}
               selected={addTableDialogOpen !== undefined}
-              {...(!consoleConfig.readOnly && {
-                onClick: () => {
-                  dispatch(
-                    actions.console.setActiveSidebar(
-                      addTableDialogOpen ? undefined : "create",
-                    ),
-                  )
-                },
-              })}
+              onClick={() => {
+                dispatch(
+                  actions.console.setActiveSidebar(
+                    addTableDialogOpen ? undefined : "create",
+                  ),
+                )
+              }}
             >
               <TableIcon size={BUTTON_ICON_SIZE} />
             </PrimaryToggleButton>
           }
           placement="left"
-          tooltip={
-            consoleConfig.readOnly
-              ? "To use this feature, turn off read-only mode in the configuration file"
-              : "Create table"
-          }
+          tooltip="Create table"
         />
       }
       ctaText="Create"

--- a/packages/web-console/src/components/TableSchemaDialog/dialog.tsx
+++ b/packages/web-console/src/components/TableSchemaDialog/dialog.tsx
@@ -199,7 +199,10 @@ export const Dialog = ({
         }
       }}
     >
-      <StyledContentWrapper mode={action === "add" ? "side" : "modal"}>
+      <StyledContentWrapper
+        mode={action === "add" ? "side" : "modal"}
+        data-hook="create-table-panel"
+      >
         <Form<SchemaFormValues>
           name="table-schema"
           defaultValues={defaults}

--- a/packages/web-console/src/components/Tooltip/index.tsx
+++ b/packages/web-console/src/components/Tooltip/index.tsx
@@ -103,7 +103,7 @@ export const Wrapper = styled.div`
 `
 
 export const Tooltip = ({ arrow, children, ...rest }: Props) => (
-  <Wrapper {...rest}>
+  <Wrapper {...rest} data-hook="tooltip">
     <Text color="foreground">{children}</Text>
     {arrow && <TooltipArrow ref={arrow.setArrowElement} style={arrow.styles} />}
   </Wrapper>

--- a/packages/web-console/src/scenes/Schema/Row/index.tsx
+++ b/packages/web-console/src/scenes/Schema/Row/index.tsx
@@ -87,12 +87,8 @@ const Wrapper = styled.div<Pick<Props, "expanded"> & { suspended?: boolean }>`
   }
 `
 
-const HitBox = styled.div`
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  left: 0;
-  top: 0;
+const StyledTitle = styled(Title)`
+  z-index: 1;
 `
 
 const TableActions = styled.span`
@@ -169,8 +165,8 @@ const Row = ({
       className={className}
       expanded={expanded}
       suspended={walTableData?.suspended && kind === "table"}
+      onClick={onClick}
     >
-      <HitBox onClick={onClick} />
       <FlexRow>
         {kind === "table" && (
           <TableIcon
@@ -204,7 +200,7 @@ const Row = ({
           <DotIcon size="12px" />
         )}
 
-        <Title
+        <StyledTitle
           color="foreground"
           ellipsis
           kind={kind}
@@ -215,7 +211,7 @@ const Row = ({
             searchWords={[query ?? ""]}
             textToHighlight={name}
           />
-        </Title>
+        </StyledTitle>
         {suffix}
 
         <Spacer />

--- a/packages/web-console/src/scenes/Schema/Row/index.tsx
+++ b/packages/web-console/src/scenes/Schema/Row/index.tsx
@@ -28,11 +28,12 @@ import { Rocket } from "@styled-icons/boxicons-regular"
 import { SortDown } from "@styled-icons/boxicons-regular"
 import { RightArrow } from "@styled-icons/boxicons-regular"
 import { CheckboxBlankCircle } from "@styled-icons/remix-line"
-import { Information } from "@styled-icons/remix-line"
+import { FileCopy, Information } from "@styled-icons/remix-line"
 import type { TreeNodeKind } from "../../../components/Tree"
 import * as QuestDB from "../../../utils/questdb"
 import Highlighter from "react-highlight-words"
 import { TableIcon } from "../table-icon"
+import { Button, Box } from "@questdb/react-components"
 
 import { Text, TransitionDuration, IconWithTooltip } from "../../../components"
 import type { TextProps } from "../../../components"
@@ -73,6 +74,24 @@ const Title = styled(Text)<TextProps & { kind: TreeNodeKind }>`
   }
 `
 
+const CopyButton = styled(Button)<Pick<Props, "tooltip">>`
+  && {
+    position: absolute;
+    z-index: 1;
+    right: 1rem;
+    opacity: 0;
+    background: ${({ theme }) => theme.color.backgroundLighter};
+    padding-top: 1.2rem;
+    padding-bottom: 1.2rem;
+    font-size: 1.3rem;
+
+    .highlight {
+      background-color: #7c804f;
+      color: ${({ theme }) => theme.color.foreground};
+    }
+  }
+`
+
 const Wrapper = styled.div<Pick<Props, "expanded"> & { suspended?: boolean }>`
   position: relative;
   display: flex;
@@ -84,6 +103,17 @@ const Wrapper = styled.div<Pick<Props, "expanded"> & { suspended?: boolean }>`
   &:hover,
   &:active {
     background: ${color("selection")};
+  }
+
+  &:hover
+    ${/* sc-selector */ CopyButton},
+    &:active
+    ${/* sc-selector */ CopyButton} {
+    opacity: 1;
+  }
+
+  &:hover ${/* sc-selector */ Type} {
+    opacity: 0;
   }
 `
 
@@ -200,6 +230,21 @@ const Row = ({
           <DotIcon size="12px" />
         )}
 
+        {["column", "table"].includes(kind) && !walTableData?.suspended && (
+          <CopyButton
+            skin="secondary"
+            size="sm"
+            tooltip={tooltip}
+            prefixIcon={<FileCopy size="16px" />}
+            onClick={(e) => {
+              navigator.clipboard.writeText(name)
+              e.stopPropagation()
+            }}
+          >
+            Copy
+          </CopyButton>
+        )}
+
         <StyledTitle
           color="foreground"
           ellipsis
@@ -212,6 +257,7 @@ const Row = ({
             textToHighlight={name}
           />
         </StyledTitle>
+
         {suffix}
 
         <Spacer />

--- a/packages/web-console/src/scenes/Schema/SuspensionDialog/index.tsx
+++ b/packages/web-console/src/scenes/Schema/SuspensionDialog/index.tsx
@@ -122,6 +122,7 @@ export const SuspensionDialog = ({
 
   return (
     <Dialog.Root
+      open={active}
       onOpenChange={(open) => {
         if (!open) {
           eventBus.publish(EventType.MSG_QUERY_SCHEMA)
@@ -133,6 +134,10 @@ export const SuspensionDialog = ({
           <ErrorButton
             prefixIcon={<ErrorIcon size="18px" />}
             data-hook="schema-suspension-dialog-trigger"
+            onClick={(e: any) => {
+              setActive(true)
+              e.stopPropagation()
+            }}
           >
             Suspended
           </ErrorButton>
@@ -147,6 +152,11 @@ export const SuspensionDialog = ({
         <StyledDialogContent
           data-hook="schema-suspension-dialog"
           data-table-name={walTableData.name}
+          onClick={(e: React.MouseEvent<HTMLDivElement>) => {
+            e.stopPropagation()
+          }}
+          onEscapeKeyDown={() => setActive(false)}
+          onPointerDownOutside={() => setActive(false)}
         >
           <Dialog.Title>
             <Box>
@@ -302,15 +312,14 @@ export const SuspensionDialog = ({
           </StyledDescription>
 
           <Dialog.ActionButtons>
-            <Dialog.Close asChild>
-              <Button
-                prefixIcon={<Undo size={18} />}
-                skin="secondary"
-                data-hook="schema-suspension-dialog-dismiss"
-              >
-                Dismiss
-              </Button>
-            </Dialog.Close>
+            <Button
+              prefixIcon={<Undo size={18} />}
+              skin="secondary"
+              data-hook="schema-suspension-dialog-dismiss"
+              onClick={() => setActive(false)}
+            >
+              Dismiss
+            </Button>
           </Dialog.ActionButtons>
         </StyledDialogContent>
       </Dialog.Portal>

--- a/packages/web-console/src/scenes/Schema/SuspensionDialog/index.tsx
+++ b/packages/web-console/src/scenes/Schema/SuspensionDialog/index.tsx
@@ -312,14 +312,16 @@ export const SuspensionDialog = ({
           </StyledDescription>
 
           <Dialog.ActionButtons>
-            <Button
-              prefixIcon={<Undo size={18} />}
-              skin="secondary"
-              data-hook="schema-suspension-dialog-dismiss"
-              onClick={() => setActive(false)}
-            >
-              Dismiss
-            </Button>
+            <Dialog.Close asChild>
+              <Button
+                prefixIcon={<Undo size={18} />}
+                skin="secondary"
+                data-hook="schema-suspension-dialog-dismiss"
+                onClick={() => setActive(false)}
+              >
+                Dismiss
+              </Button>
+            </Dialog.Close>
           </Dialog.ActionButtons>
         </StyledDialogContent>
       </Dialog.Portal>

--- a/packages/web-console/src/scenes/Schema/index.tsx
+++ b/packages/web-console/src/scenes/Schema/index.tsx
@@ -286,12 +286,8 @@ const Schema = ({
             .filter((table: QuestDB.Table) => {
               const normalizedTableName = table.table_name.toLowerCase()
               const normalizedQuery = query.toLowerCase()
-              const tableColumns = columns
-                ?.filter((c) => c.table_name === table.table_name)
-                .map((c) => c.column_name)
               return (
-                (normalizedTableName.includes(normalizedQuery) ||
-                  tableColumns?.find((c) => c.startsWith(query))) &&
+                normalizedTableName.includes(normalizedQuery) &&
                 (filterSuspendedOnly
                   ? table.walEnabled &&
                     walTables?.find((t) => t.name === table.table_name)

--- a/packages/web-console/src/scenes/Schema/index.tsx
+++ b/packages/web-console/src/scenes/Schema/index.tsx
@@ -58,7 +58,7 @@ import LoadingError from "./LoadingError"
 import { Box } from "../../components/Box"
 import { Button, DropdownMenu, ForwardRef } from "@questdb/react-components"
 import { Panel } from "../../components/Panel"
-import { QuestContext, useSettings } from "../../providers"
+import { QuestContext } from "../../providers"
 import { eventBus } from "../../modules/EventBus"
 import { EventType } from "../../modules/EventBus/types"
 import { formatTableSchemaQueryResult } from "./Table/ContextualMenu/services"
@@ -147,7 +147,6 @@ const Schema = ({
   const [walTables, setWalTables] = useState<QuestDB.WalTable[]>()
   const [opened, setOpened] = useState<string>()
   const [isScrolling, setIsScrolling] = useState(false)
-  const { consoleConfig } = useSettings()
   const dispatch = useDispatch()
   const [scrollAtTop, setScrollAtTop] = useState(true)
   const scrollerRef = useRef<HTMLDivElement | null>(null)
@@ -328,25 +327,8 @@ const Schema = ({
           title="Tables"
           afterTitle={
             <div style={{ display: "flex" }}>
-              {consoleConfig.readOnly === false && tables && (
+              {tables && (
                 <Box align="center" gap="0.5rem">
-                  <PopperHover
-                    delay={350}
-                    placement="bottom"
-                    trigger={
-                      <Button
-                        onClick={() =>
-                          dispatch(actions.console.setActiveSidebar("create"))
-                        }
-                        skin="transparent"
-                      >
-                        <Add size="22px" />
-                      </Button>
-                    }
-                  >
-                    <Tooltip>Create table</Tooltip>
-                  </PopperHover>
-
                   <DropdownMenu.Root
                     modal={false}
                     onOpenChange={setDropdownOpen}


### PR DESCRIPTION
- Remove the `+` icon in the Tables header - it will come back when the Create Table view is opened in the left side of the screen.
- Fix for clicking the disabled `Create Table` icon in read-only mode - it should not be possible to show it and clicking the icon should be a no-op.
- Fix table filter: it should show only the tables with a match and highlight.