### PR TITLE
chore(browser-tests): adjust cypress config to allow for a single retry

### DIFF
--- a/packages/browser-tests/cypress.config.js
+++ b/packages/browser-tests/cypress.config.js
@@ -36,4 +36,7 @@ module.exports = defineConfig({
       });
     },
   },
+  retries: {
+    runMode: 1,
+  },
 });


### PR DESCRIPTION
The small adjustment in the Cypress config allows for one test retry in case the Monaco Editor is initialized in a different order and although the elements we check for are already mounted, user can't type anything yet. This happens on the CI alone and cannot be reliably reproduced on any other platform.
An arbitrary wait timeout has the same positive effect, but it's sub-optimal and would slow down text execution significantly, since there is no need to wait always, just in case there is a rare spurious failure.