### PR TITLE
fix(web-console): fix suspension lag count

### DIFF
--- a/packages/web-console/src/scenes/Schema/SuspensionDialog/index.tsx
+++ b/packages/web-console/src/scenes/Schema/SuspensionDialog/index.tsx
@@ -89,6 +89,9 @@ export const SuspensionDialog = ({
   const [isSubmitted, setIsSubmitted] = useState(false)
   const [error, setError] = useState<string | undefined>()
 
+  const txnLag =
+    parseFloat(walTableData.sequencerTxn) - parseFloat(walTableData.writerTxn)
+
   const handleSubmit = async (values: FormValues) => {
     setIsSubmitting(true)
     setError(undefined)
@@ -223,8 +226,8 @@ export const SuspensionDialog = ({
               </Box>
 
               <Text color="foreground" size="lg">
-                {walTableData.writerLagTxnCount} transaction
-                {walTableData.writerLagTxnCount === "1" ? "" : "s"} behind
+                {txnLag} transaction
+                {txnLag === 1 ? "" : "s"} behind
               </Text>
 
               {walTableData.errorMessage && (


### PR DESCRIPTION
When the WAL table is suspended, user can click on the `Suspended` button next to the table name to diagnose the problem. The current number of transactions behind is derived from `writerLagTxnCount` property, which gives incorrect results. This PR fixes it by switching to the difference between sequencer and writer txn counts.