### PR TITLE
fix(web-console): Display `Copy` for suspended tables

### DIFF
--- a/packages/web-console/src/scenes/Schema/Row/index.tsx
+++ b/packages/web-console/src/scenes/Schema/Row/index.tsx
@@ -74,11 +74,13 @@ const Title = styled(Text)<TextProps & { kind: TreeNodeKind }>`
   }
 `
 
-const CopyButton = styled(Button)<Pick<Props, "tooltip">>`
+const CopyButton = styled(Button)<
+  Pick<Props, "tooltip"> & { suspended?: boolean }
+>`
   && {
     position: absolute;
-    z-index: 1;
-    right: 1rem;
+    z-index: 2;
+    right: ${({ suspended }) => (suspended ? "13rem" : "1rem")};
     opacity: 0;
     background: ${({ theme }) => theme.color.backgroundLighter};
     padding-top: 1.2rem;
@@ -230,7 +232,7 @@ const Row = ({
           <DotIcon size="12px" />
         )}
 
-        {["column", "table"].includes(kind) && !walTableData?.suspended && (
+        {["column", "table"].includes(kind) && (
           <CopyButton
             skin="secondary"
             size="sm"
@@ -240,6 +242,7 @@ const Row = ({
               navigator.clipboard.writeText(name)
               e.stopPropagation()
             }}
+            suspended={walTableData?.suspended}
           >
             Copy
           </CopyButton>


### PR DESCRIPTION
Display the `Copy` button for suspended tables too - it's currently not visible.