### PR TITLE
fix(web-console): handle line comments in SQLs

### DIFF
--- a/packages/browser-tests/cypress/commands.js
+++ b/packages/browser-tests/cypress/commands.js
@@ -164,6 +164,8 @@ Cypress.Commands.add("getCursorQueryDecoration", () =>
   cy.get(".cursorQueryDecoration")
 );
 
+Cypress.Commands.add("getCursorQueryGlyph", () => cy.get(".cursorQueryGlyph"));
+
 const numberRangeRegexp = (n, width = 3) => {
   const [min, max] = [n - width, n + width];
   const numbers = Array.from(

--- a/packages/browser-tests/cypress/integration/console/editor.spec.js
+++ b/packages/browser-tests/cypress/integration/console/editor.spec.js
@@ -426,3 +426,38 @@ describe("editor tabs", () => {
     cy.getEditorTabs().last().should("contain", "SQL 1");
   });
 });
+
+describe("handling comments", () => {
+  beforeEach(() => {
+    cy.loadConsoleWithAuth();
+  });
+
+  beforeEach(() => {
+    cy.getEditorContent().should("be.visible");
+    cy.getEditorTabs().should("be.visible");
+  });
+
+  it("should highlight and execute sql with line comments in front", () => {
+    cy.typeQuery("-- comment\n-- comment\nselect x from long_sequence(1);");
+    cy.getCursorQueryDecoration().should("have.length", 3);
+    cy.getCursorQueryGlyph().should("have.length", 1);
+    cy.runLine();
+    cy.getGridRow(0).should("contain", "1");
+  });
+
+  it("should highlight and execute sql with line comments inside", () => {
+    cy.typeQuery("select\n\nx\n-- y\n-- z\n from long_sequence(1);");
+    cy.getCursorQueryDecoration().should("have.length", 5);
+    cy.getCursorQueryGlyph().should("have.length", 1);
+    cy.runLine();
+    cy.getGridRow(0).should("contain", "1");
+  });
+
+  it("should highlight and execute sql with line comment at the end", () => {
+    cy.typeQuery("select x from long_sequence(1); -- comment");
+    cy.getCursorQueryDecoration().should("have.length", 1);
+    cy.getCursorQueryGlyph().should("have.length", 1);
+    cy.runLine();
+    cy.getGridRow(0).should("contain", "1");
+  });
+});

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -16,6 +16,7 @@ import {
   getQueryRequestFromLastExecutedQuery,
   QuestDBLanguageName,
   setErrorMarker,
+  stripLineComments,
 } from "./utils"
 import { registerEditorActions, registerLanguageAddons } from "./editor-addons"
 import { registerLegacyEventBusEvents } from "./legacy-event-bus"
@@ -152,7 +153,14 @@ const MonacoEditor = () => {
     const queryAtCursor = getQueryFromCursor(editor)
     const model = editor.getModel()
     if (queryAtCursor && model !== null) {
-      const matches = findMatches(model, queryAtCursor.query)
+      const cleanedModel = monaco.editor.createModel(
+        stripLineComments(model.getValue()),
+        QuestDBLanguageName,
+      )
+
+      const matches = findMatches(cleanedModel, queryAtCursor.query)
+
+      cleanedModel.dispose()
 
       if (matches.length > 0) {
         const hasError = errorRef.current?.query === queryAtCursor.query

--- a/packages/web-console/src/scenes/Editor/Monaco/utils.ts
+++ b/packages/web-console/src/scenes/Editor/Monaco/utils.ts
@@ -34,6 +34,11 @@ export type Request = Readonly<{
   column: number
 }>
 
+export const stripLineComments = (text: string) =>
+  text.replace(/"[^"]*"|'[^']*'|`[^`]*`|(--\s?.*$)/gm, (match, group) => {
+    return group ? "" : match
+  })
+
 export const getSelectedText = (
   editor: IStandaloneCodeEditor,
 ): string | undefined => {
@@ -45,11 +50,9 @@ export const getSelectedText = (
 export const getQueryFromCursor = (
   editor: IStandaloneCodeEditor,
 ): Request | undefined => {
-  const text = editor
-    .getValue({ preserveBOM: false, lineEnding: "\n" })
-    .replace(/"[^"]*"|'[^']*'|`[^`]*`|(--\s?.*$)/gm, (match, group) => {
-      return group ? "" : match
-    })
+  const text = stripLineComments(
+    editor.getValue({ preserveBOM: false, lineEnding: "\n" }),
+  )
   const position = editor.getPosition()
 
   let row = 0


### PR DESCRIPTION
SQL Editor should properly highlight queries containing line comments with the green vertical line and execute correctly in various configurations:
- at the beginning of the query (one or more lines)
- within the query itself (i.e. in the middle, one or more lines)

Example queries that should be executed and highlighted correctly:

```sql
-- line comment 1
-- line comment 2
SELECT x FROM long_sequence(1000);

SELECT
x
-- y
FROM
long_sequence(1000);

SELECT
x
-- y
-- Z
FROM
long_sequence(1000);
```

Screen recording of the correct behavior:

https://github.com/user-attachments/assets/0611c1d7-6809-4e98-9f0d-278701db7b21

