### PR TITLE
fix(web console): handling comments in SQL editor highlights

### DIFF
--- a/packages/browser-tests/cypress/integration/console/editor.spec.js
+++ b/packages/browser-tests/cypress/integration/console/editor.spec.js
@@ -445,6 +445,29 @@ describe("handling comments", () => {
     cy.getGridRow(0).should("contain", "1");
   });
 
+  it("should highlight and execute sql with empty line comment in front", () => {
+    cy.typeQuery("--\nselect x from long_sequence(1);");
+    cy.getCursorQueryDecoration().should("have.length", 2);
+    cy.getCursorQueryGlyph().should("have.length", 1);
+    cy.runLine();
+    cy.getGridRow(0).should("contain", "1");
+  });
+
+  it("should highlight and execute sql with block comments", () => {
+    cy.typeQuery("/* comment */\nselect x from long_sequence(1);");
+    cy.getCursorQueryDecoration().should("have.length", 2);
+    cy.getCursorQueryGlyph().should("have.length", 1);
+    cy.runLine();
+    cy.getGridRow(0).should("contain", "1");
+
+    cy.clearEditor();
+    cy.typeQuery("/*\ncomment\n*/\nselect x from long_sequence(1);");
+    cy.getCursorQueryDecoration().should("have.length", 4);
+    cy.getCursorQueryGlyph().should("have.length", 1);
+    cy.runLine();
+    cy.getGridRow(0).should("contain", "1");
+  });
+
   it("should highlight and execute sql with line comments inside", () => {
     cy.typeQuery("select\n\nx\n-- y\n-- z\n from long_sequence(1);");
     cy.getCursorQueryDecoration().should("have.length", 5);

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -16,7 +16,7 @@ import {
   getQueryRequestFromLastExecutedQuery,
   QuestDBLanguageName,
   setErrorMarker,
-  stripLineComments,
+  stripSQLComments,
 } from "./utils"
 import { registerEditorActions, registerLanguageAddons } from "./editor-addons"
 import { registerLegacyEventBusEvents } from "./legacy-event-bus"
@@ -154,7 +154,7 @@ const MonacoEditor = () => {
     const model = editor.getModel()
     if (queryAtCursor && model !== null) {
       const cleanedModel = monaco.editor.createModel(
-        stripLineComments(model.getValue()),
+        stripSQLComments(model.getValue()),
         QuestDBLanguageName,
       )
 

--- a/packages/web-console/src/scenes/Editor/Monaco/utils.ts
+++ b/packages/web-console/src/scenes/Editor/Monaco/utils.ts
@@ -39,7 +39,7 @@ export const stripSQLComments = (text: string): string =>
     if (group) {
       const groupLines = group.split("\n")
       if (group.startsWith("--") && groupLines.length > 1) {
-        return "\n" + groupLines[1].replace(/--\s?.*$/g, "")
+        return "\n" + stripSQLComments(groupLines[1])
       }
       return ""
     }

--- a/packages/web-console/src/scenes/Editor/Monaco/utils.ts
+++ b/packages/web-console/src/scenes/Editor/Monaco/utils.ts
@@ -34,9 +34,16 @@ export type Request = Readonly<{
   column: number
 }>
 
-export const stripLineComments = (text: string) =>
-  text.replace(/"[^"]*"|'[^']*'|`[^`]*`|(--\s?.*$)/gm, (match, group) => {
-    return group ? "" : match
+export const stripSQLComments = (text: string): string =>
+  text.replace(/(?<!["'`])(--\s?.*$)/gm, (match, group) => {
+    if (group) {
+      const groupLines = group.split("\n")
+      if (group.startsWith("--") && groupLines.length > 1) {
+        return "\n" + groupLines[1].replace(/--\s?.*$/g, "")
+      }
+      return ""
+    }
+    return match
   })
 
 export const getSelectedText = (
@@ -50,7 +57,7 @@ export const getSelectedText = (
 export const getQueryFromCursor = (
   editor: IStandaloneCodeEditor,
 ): Request | undefined => {
-  const text = stripLineComments(
+  const text = stripSQLComments(
     editor.getValue({ preserveBOM: false, lineEnding: "\n" }),
   )
   const position = editor.getPosition()


### PR DESCRIPTION
This PR fixes the issues with query highlighting where line comments are in place - most importantly before the statement, like so:
<img width="316" alt="Screenshot 2024-10-03 at 17 27 26" src="https://github.com/user-attachments/assets/d83a350e-d293-480f-8022-55fceb350502">

This should work when the comment contains the actual text after the `--` mark, as well as it's empty (`--` only).

