### PR TITLE
chore(web-console): UX improvements around editor

### DIFF
--- a/packages/web-console/src/components/CopyButton/index.tsx
+++ b/packages/web-console/src/components/CopyButton/index.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from "react"
+import styled from "styled-components"
+import { Button } from "@questdb/react-components"
+import { FileCopy } from "@styled-icons/remix-line"
+import { Text } from "../../components"
+import { CheckboxCircle } from "@styled-icons/remix-fill"
+
+const StyledButton = styled(Button)`
+  padding: 1.2rem 0.6rem;
+`
+
+const StyledCheckboxCircle = styled(CheckboxCircle)`
+  position: absolute;
+  transform: translate(75%, -75%);
+  color: ${({ theme }) => theme.color.green};
+`
+
+export const CopyButton = ({
+  text,
+  iconOnly,
+}: {
+  text: string
+  iconOnly?: boolean
+}) => {
+  const [copied, setCopied] = useState(false)
+
+  return (
+    <StyledButton
+      skin="secondary"
+      onClick={(e) => {
+        navigator.clipboard.writeText(text)
+        e.stopPropagation()
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+      }}
+      {...(!iconOnly && { prefixIcon: <FileCopy size="16px" /> })}
+    >
+      {copied && <StyledCheckboxCircle size="14px" />}
+      {iconOnly ? <FileCopy size="16px" /> : "Copy"}
+    </StyledButton>
+  )
+}

--- a/packages/web-console/src/providers/EditorProvider/index.tsx
+++ b/packages/web-console/src/providers/EditorProvider/index.tsx
@@ -14,6 +14,7 @@ import {
   insertTextAtCursor,
   appendQuery,
   QuestDBLanguageName,
+  clearModelMarkers,
 } from "../../scenes/Editor/Monaco/utils"
 import { fallbackBuffer, makeBuffer, bufferStore } from "../../store/buffers"
 import { db } from "../../store/db"
@@ -113,6 +114,8 @@ export const EditorProvider = ({ children }: PropsWithChildren<{}>) => {
 
       editorRef.current.setModel(model)
       editorRef.current.focus()
+
+      clearModelMarkers(monacoRef.current, editorRef.current)
     }
     if (buffer.editorViewState) {
       editorRef.current?.restoreViewState(buffer.editorViewState)

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -123,6 +123,7 @@ const MonacoEditor = () => {
   const decorationsRef = useRef<editor.IEditorDecorationsCollection>()
   const errorRef = useRef<ErrorResult | undefined>()
   const errorRangeRef = useRef<IRange | undefined>()
+  const runningValueRef = useRef(running.value)
 
   // Set the initial line number width in chars based on the number of lines in the active buffer
   const [lineNumbersMinChars, setLineNumbersMinChars] = useState(
@@ -209,7 +210,7 @@ const MonacoEditor = () => {
               ),
               options: {
                 isWholeLine: false,
-                glyphMarginClassName: running.value
+                glyphMarginClassName: runningValueRef.current
                   ? "cancelQueryGlyph"
                   : "cursorQueryGlyph",
               },
@@ -301,6 +302,7 @@ const MonacoEditor = () => {
   }, [request, quest, dispatch, running])
 
   useEffect(() => {
+    runningValueRef.current = running.value
     if (running.value && editorRef?.current) {
       if (monacoRef?.current) {
         clearModelMarkers(monacoRef.current, editorRef.current)

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -418,6 +418,8 @@ const MonacoEditor = () => {
 
                 editorRef?.current.setScrollPosition({ scrollLeft })
 
+                editorRef?.current.focus()
+
                 editorRef?.current.setPosition({
                   lineNumber: errorRange.startLineNumber,
                   column: errorRange.startColumn,

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -103,6 +103,10 @@ const Content = styled(PaneContent)`
   }
 `
 
+const CancelButton = styled(Button)`
+  padding: 1.2rem 0.6rem;
+`
+
 const DEFAULT_LINE_CHARS = 5
 
 const MonacoEditor = () => {
@@ -361,13 +365,9 @@ const MonacoEditor = () => {
                 content: (
                   <Box gap="1rem" align="center">
                     <Text color="foreground">Running...</Text>
-                    <Button
-                      skin="error"
-                      onClick={() => toggleRunning()}
-                      prefixIcon={<Stop size="18px" />}
-                    >
-                      Cancel
-                    </Button>
+                    <CancelButton skin="error" onClick={() => toggleRunning()}>
+                      <Stop size="18px" />
+                    </CancelButton>
                   </Box>
                 ),
                 sideContent: <QueryInNotification query={request.query} />,

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -47,7 +47,7 @@ const Content = styled(PaneContent)`
 
   .monaco-editor .squiggly-error {
     background: none;
-    border-bottom: 0.2rem ${color("red")} solid;
+    border-bottom: 0.3rem ${color("red")} solid;
   }
 
   .monaco-scrollable-element > .scrollbar > .slider {
@@ -373,7 +373,9 @@ const MonacoEditor = () => {
                   content: (
                     <Text color="foreground" ellipsis title={result.query}>
                       {result.notice}
-                      {result.query !== undefined && result.query !== '' && `: ${result.query}`}
+                      {result.query !== undefined &&
+                        result.query !== "" &&
+                        `: ${result.query}`}
                     </Text>
                   ),
                   type: NotificationType.NOTICE,
@@ -425,30 +427,16 @@ const MonacoEditor = () => {
                   error.error,
                 )
 
-                const layoutInfo = editorRef?.current.getLayoutInfo()
-                const editorWidth = layoutInfo.contentWidth
-
-                const fontInfo = editorRef?.current
-                  .getOptions()
-                  .get(monacoRef?.current.editor.EditorOption.fontInfo)
-                const charWidth = fontInfo.typicalHalfwidthCharacterWidth
-
-                const columnsInViewport = Math.floor(editorWidth / charWidth)
-
-                editorRef?.current.revealLineInCenter(
-                  errorRange.startLineNumber,
-                )
-
-                if (errorRange.startColumn > columnsInViewport) {
-                  const scrollLeft = (errorRange.startColumn - 1) * charWidth
-                  editorRef?.current.setScrollPosition({ scrollLeft })
-                }
-
                 editorRef?.current.focus()
 
                 editorRef?.current.setPosition({
                   lineNumber: errorRange.startLineNumber,
                   column: errorRange.startColumn,
+                })
+
+                editorRef?.current.revealPosition({
+                  lineNumber: errorRange.startLineNumber,
+                  column: errorRange.endColumn,
                 })
               }
             }

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -135,6 +135,7 @@ const MonacoEditor = () => {
   const decorationsRef = useRef<editor.IEditorDecorationsCollection>()
   const runningValueRef = useRef(running.value)
   const activeBufferRef = useRef(activeBuffer)
+  const requestRef = useRef(request)
 
   const errorRefs = useRef<
     Record<string, { error?: ErrorResult; range?: IRange }>
@@ -232,9 +233,15 @@ const MonacoEditor = () => {
               ),
               options: {
                 isWholeLine: false,
-                glyphMarginClassName: runningValueRef.current
-                  ? "cancelQueryGlyph"
-                  : "cursorQueryGlyph",
+                glyphMarginClassName:
+                  runningValueRef.current &&
+                  requestRef.current?.row &&
+                  requestRef.current?.row + 1 ===
+                    cursorMatch.range.startLineNumber
+                    ? "cancelQueryGlyph"
+                    : runningValueRef.current
+                    ? ""
+                    : "cursorQueryGlyph",
               },
             },
             ...(hasError &&
@@ -481,6 +488,13 @@ const MonacoEditor = () => {
       }
     }
   }, [running])
+
+  useEffect(() => {
+    requestRef.current = request
+    if (monacoRef?.current && editorRef?.current) {
+      renderLineMarkings(monacoRef?.current, editorRef?.current)
+    }
+  }, [request])
 
   const setCompletionProvider = async () => {
     if (editorReady && monacoRef?.current && editorRef?.current) {

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -350,6 +350,19 @@ const MonacoEditor = () => {
         : getQueryRequestFromEditor(editorRef.current)
 
       if (request?.query) {
+        // give the notification a slight delay to prevent flashing for fast queries
+        setTimeout(() => {
+          if (runningValueRef.current) {
+            dispatch(
+              actions.query.addNotification({
+                type: NotificationType.LOADING,
+                content: <Text color="foreground">Running...</Text>,
+                sideContent: <QueryInNotification query={request.query} />,
+              }),
+            )
+          }
+        }, 250)
+
         void quest
           .queryRaw(request.query, { limit: "0,1000", explain: true })
           .then((result) => {

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -33,6 +33,7 @@ import { createSchemaCompletionProvider } from "./questdb-sql"
 import { color } from "../../../utils"
 import { eventBus } from "../../../modules/EventBus"
 import { EventType } from "../../../modules/EventBus/types"
+import { QueryInNotification } from "./query-in-notification"
 
 loader.config({
   paths: {
@@ -312,11 +313,7 @@ const MonacoEditor = () => {
             ) {
               dispatch(
                 actions.query.addNotification({
-                  content: (
-                    <Text color="foreground" ellipsis title={result.query}>
-                      {result.query}
-                    </Text>
-                  ),
+                  content: <QueryInNotification query={result.query} />,
                 }),
               )
               eventBus.publish(EventType.MSG_QUERY_SCHEMA)
@@ -330,11 +327,7 @@ const MonacoEditor = () => {
                   content: (
                     <QueryResult {...result.timings} rowCount={result.count} />
                   ),
-                  sideContent: (
-                    <Text color="foreground" ellipsis title={result.query}>
-                      {result.query}
-                    </Text>
-                  ),
+                  sideContent: <QueryInNotification query={result.query} />,
                 }),
               )
               eventBus.publish(EventType.MSG_QUERY_DATASET, result)
@@ -347,11 +340,7 @@ const MonacoEditor = () => {
             dispatch(
               actions.query.addNotification({
                 content: <Text color="red">{error.error}</Text>,
-                sideContent: (
-                  <Text color="foreground" ellipsis title={request.query}>
-                    {request.query}
-                  </Text>
-                ),
+                sideContent: <QueryInNotification query={request.query} />,
                 type: NotificationType.ERROR,
               }),
             )

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -45,6 +45,11 @@ const Content = styled(PaneContent)`
   position: relative;
   overflow: hidden;
 
+  .monaco-editor .squiggly-error {
+    background: none;
+    border-bottom: 0.2rem ${color("red")} solid;
+  }
+
   .monaco-scrollable-element > .scrollbar > .slider {
     background: ${color("selection")};
   }

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -59,7 +59,8 @@ const Content = styled(PaneContent)`
     }
   }
 
-  .cursorQueryGlyph {
+  .cursorQueryGlyph,
+  .cancelQueryGlyph {
     margin-left: 2rem;
     z-index: 1;
     cursor: pointer;
@@ -67,9 +68,20 @@ const Content = styled(PaneContent)`
     &:after {
       display: block;
       content: "";
-      background-image: url("data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIGhlaWdodD0iMThweCIgd2lkdGg9IjE4cHgiIGFyaWEtaGlkZGVuPSJ0cnVlIiBmb2N1c2FibGU9ImZhbHNlIiBmaWxsPSIjNTBmYTdiIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGNsYXNzPSJTdHlsZWRJY29uQmFzZS1zYy1lYTl1bGotMCBrZkRiTmwiPjxwYXRoIGZpbGw9Im5vbmUiIGQ9Ik0wIDBoMjR2MjRIMHoiPjwvcGF0aD48cGF0aCBkPSJNMTYuMzk0IDEyIDEwIDcuNzM3djguNTI2TDE2LjM5NCAxMnptMi45ODIuNDE2TDguNzc3IDE5LjQ4MkEuNS41IDAgMCAxIDggMTkuMDY2VjQuOTM0YS41LjUgMCAwIDEgLjc3Ny0uNDE2bDEwLjU5OSA3LjA2NmEuNS41IDAgMCAxIDAgLjgzMnoiPjwvcGF0aD48L3N2Zz4K");
       width: 18px;
       height: 18px;
+    }
+  }
+
+  .cursorQueryGlyph {
+    &:after {
+      background-image: url("data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIGhlaWdodD0iMThweCIgd2lkdGg9IjE4cHgiIGFyaWEtaGlkZGVuPSJ0cnVlIiBmb2N1c2FibGU9ImZhbHNlIiBmaWxsPSIjNTBmYTdiIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGNsYXNzPSJTdHlsZWRJY29uQmFzZS1zYy1lYTl1bGotMCBrZkRiTmwiPjxwYXRoIGZpbGw9Im5vbmUiIGQ9Ik0wIDBoMjR2MjRIMHoiPjwvcGF0aD48cGF0aCBkPSJNMTYuMzk0IDEyIDEwIDcuNzM3djguNTI2TDE2LjM5NCAxMnptMi45ODIuNDE2TDguNzc3IDE5LjQ4MkEuNS41IDAgMCAxIDggMTkuMDY2VjQuOTM0YS41LjUgMCAwIDEgLjc3Ny0uNDE2bDEwLjU5OSA3LjA2NmEuNS41IDAgMCAxIDAgLjgzMnoiPjwvcGF0aD48L3N2Zz4K");
+    }
+  }
+
+  .cancelQueryGlyph {
+    &:after {
+      background-image: url("data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIGhlaWdodD0iMThweCIgd2lkdGg9IjE4cHgiIGFyaWEtaGlkZGVuPSJ0cnVlIiBmb2N1c2FibGU9ImZhbHNlIiBmaWxsPSIjZmY1NTU1IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGNsYXNzPSJTdHlsZWRJY29uQmFzZS1zYy1lYTl1bGotMCBqQ2hkR0siPjxwYXRoIGZpbGw9Im5vbmUiIGQ9Ik0wIDBoMjR2MjRIMHoiPjwvcGF0aD48cGF0aCBkPSJNNyA3djEwaDEwVjdIN3pNNiA1aDEyYTEgMSAwIDAgMSAxIDF2MTJhMSAxIDAgMCAxLTEgMUg2YTEgMSAwIDAgMS0xLTFWNmExIDEgMCAwIDEgMS0xeiI+PC9wYXRoPjwvc3ZnPgo=");
     }
   }
 
@@ -141,7 +153,10 @@ const MonacoEditor = () => {
   }
 
   const handleEditorClick = (e: BaseSyntheticEvent) => {
-    if (e.target.classList.contains("cursorQueryGlyph")) {
+    if (
+      e.target.classList.contains("cursorQueryGlyph") ||
+      e.target.classList.contains("cancelQueryGlyph")
+    ) {
       editorRef?.current?.focus()
       toggleRunning()
     }
@@ -194,7 +209,9 @@ const MonacoEditor = () => {
               ),
               options: {
                 isWholeLine: false,
-                glyphMarginClassName: "cursorQueryGlyph",
+                glyphMarginClassName: running.value
+                  ? "cancelQueryGlyph"
+                  : "cursorQueryGlyph",
               },
             },
             ...(errorRangeRef.current &&
@@ -289,6 +306,10 @@ const MonacoEditor = () => {
         clearModelMarkers(monacoRef.current, editorRef.current)
       }
 
+      if (monacoRef?.current && editorRef?.current) {
+        renderLineMarkings(monacoRef.current, editorRef?.current)
+      }
+
       const request = running.isRefresh
         ? getQueryRequestFromLastExecutedQuery(lastExecutedQuery)
         : getQueryRequestFromEditor(editorRef.current)
@@ -302,10 +323,6 @@ const MonacoEditor = () => {
             errorRangeRef.current = undefined
             dispatch(actions.query.stopRunning())
             dispatch(actions.query.setResult(result))
-
-            if (monacoRef?.current && editorRef?.current) {
-              renderLineMarkings(monacoRef.current, editorRef?.current)
-            }
 
             if (
               result.type === QuestDB.Type.DDL ||
@@ -363,13 +380,16 @@ const MonacoEditor = () => {
                   lineNumber: errorRange.startLineNumber,
                   column: errorRange.startColumn,
                 })
-                renderLineMarkings(monacoRef?.current, editorRef?.current)
               }
             }
           })
         setRequest(request)
       } else {
         dispatch(actions.query.stopRunning())
+      }
+    } else {
+      if (monacoRef?.current && editorRef?.current) {
+        renderLineMarkings(monacoRef?.current, editorRef?.current)
       }
     }
   }, [running])

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -34,6 +34,8 @@ import { color } from "../../../utils"
 import { eventBus } from "../../../modules/EventBus"
 import { EventType } from "../../../modules/EventBus/types"
 import { QueryInNotification } from "./query-in-notification"
+import { Box, Button } from "@questdb/react-components"
+import { Stop } from "@styled-icons/remix-line"
 
 loader.config({
   paths: {
@@ -356,7 +358,18 @@ const MonacoEditor = () => {
             dispatch(
               actions.query.addNotification({
                 type: NotificationType.LOADING,
-                content: <Text color="foreground">Running...</Text>,
+                content: (
+                  <Box gap="1rem" align="center">
+                    <Text color="foreground">Running...</Text>
+                    <Button
+                      skin="error"
+                      onClick={() => toggleRunning()}
+                      prefixIcon={<Stop size="18px" />}
+                    >
+                      Cancel
+                    </Button>
+                  </Box>
+                ),
                 sideContent: <QueryInNotification query={request.query} />,
               }),
             )

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -404,7 +404,21 @@ const MonacoEditor = () => {
                   errorRange,
                   error.error,
                 )
-                editorRef?.current.revealPositionInCenter({
+
+                const fontInfo = editorRef?.current
+                  .getOptions()
+                  .get(monacoRef?.current.editor.EditorOption.fontInfo)
+                const charWidth = fontInfo.typicalHalfwidthCharacterWidth
+
+                const scrollLeft = (errorRange.startColumn - 1) * charWidth
+
+                editorRef?.current.revealLineInCenter(
+                  errorRange.startLineNumber,
+                )
+
+                editorRef?.current.setScrollPosition({ scrollLeft })
+
+                editorRef?.current.setPosition({
                   lineNumber: errorRange.startLineNumber,
                   column: errorRange.startColumn,
                 })

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -370,6 +370,10 @@ const MonacoEditor = () => {
                   errorRange,
                   error.error,
                 )
+                editorRef?.current.revealPositionInCenter({
+                  lineNumber: errorRange.startLineNumber,
+                  column: errorRange.startColumn,
+                })
                 renderLineMarkings(monacoRef?.current, editorRef?.current)
               }
             }

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -405,18 +405,24 @@ const MonacoEditor = () => {
                   error.error,
                 )
 
+                const layoutInfo = editorRef?.current.getLayoutInfo()
+                const editorWidth = layoutInfo.contentWidth
+
                 const fontInfo = editorRef?.current
                   .getOptions()
                   .get(monacoRef?.current.editor.EditorOption.fontInfo)
                 const charWidth = fontInfo.typicalHalfwidthCharacterWidth
 
-                const scrollLeft = (errorRange.startColumn - 1) * charWidth
+                const columnsInViewport = Math.floor(editorWidth / charWidth)
 
                 editorRef?.current.revealLineInCenter(
                   errorRange.startLineNumber,
                 )
 
-                editorRef?.current.setScrollPosition({ scrollLeft })
+                if (errorRange.startColumn > columnsInViewport) {
+                  const scrollLeft = (errorRange.startColumn - 1) * charWidth
+                  editorRef?.current.setScrollPosition({ scrollLeft })
+                }
 
                 editorRef?.current.focus()
 

--- a/packages/web-console/src/scenes/Editor/Monaco/query-in-notification.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/query-in-notification.tsx
@@ -6,6 +6,8 @@ import { CopyButton } from "../../../components/CopyButton"
 
 const StyledText = styled(Text)`
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `
 
 export const QueryInNotification = ({ query }: { query: string }) => {
@@ -14,7 +16,7 @@ export const QueryInNotification = ({ query }: { query: string }) => {
   return (
     <Box gap="1rem" align="center">
       <StyledText color="foreground" title={query}>
-        {query.length > 50 ? `${query.slice(0, 50)}...` : query}
+        {query}
       </StyledText>
       <CopyButton text={query} iconOnly={true} />
     </Box>

--- a/packages/web-console/src/scenes/Editor/Monaco/query-in-notification.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/query-in-notification.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import styled from "styled-components"
+import { Text } from "../../../components"
+import { Box } from "@questdb/react-components"
+import { CopyButton } from "../../../components/CopyButton"
+
+const StyledText = styled(Text)`
+  white-space: nowrap;
+`
+
+export const QueryInNotification = ({ query }: { query: string }) => {
+  if (!query) return null
+
+  return (
+    <Box gap="1rem" align="center">
+      <StyledText color="foreground" title={query}>
+        {query.length > 50 ? `${query.slice(0, 50)}...` : query}
+      </StyledText>
+      <CopyButton text={query} iconOnly={true} />
+    </Box>
+  )
+}

--- a/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/conf.ts
+++ b/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/conf.ts
@@ -6,7 +6,8 @@ export const conf: monaco.languages.LanguageConfiguration = {
    * This way we can highlight table names escaped with quotes and the ones created from CSV files.
    * An additional example is a "bad integer" error, i.e. (20000) - needs brackets to be allowed as well.
    */
-  wordPattern: /(-?\d*\.\d\w*)|([^\`\~\!\@\#\$\%\^\&\*\-\=\+\[\{\]\}\\\|\;\:\"\,\<\>\/\?\s]+)/g,
+  wordPattern:
+    /(-?\d*\.\d\w*)|([^\`\~\!\@\#\$\%\^\&\*\-\+\[\{\]\}\\\|\;\:\"\,\<\>\/\?\s]+)/g,
   comments: {
     lineComment: "--",
     blockComment: ["/*", "*/"],

--- a/packages/web-console/src/scenes/Notifications/index.tsx
+++ b/packages/web-console/src/scenes/Notifications/index.tsx
@@ -54,6 +54,7 @@ const Wrapper = styled(PaneWrapper)<{ minimized: boolean }>`
 
 const Menu = styled(PaneMenu)`
   justify-content: space-between;
+  overflow: hidden;
 `
 
 const Content = styled(PaneContent)<{ minimized: boolean }>`
@@ -71,6 +72,7 @@ const Header = styled(Text)`
 const LatestNotification = styled.div`
   margin-left: 1rem;
   flex: 1;
+  width: calc(100% - 10rem);
 `
 
 const TerminalBoxIcon = styled(TerminalBox)`

--- a/packages/web-console/src/scenes/Notifications/index.tsx
+++ b/packages/web-console/src/scenes/Notifications/index.tsx
@@ -30,7 +30,6 @@ import React, {
   useLayoutEffect,
 } from "react"
 import { useDispatch, useSelector } from "react-redux"
-import { TransitionGroup } from "react-transition-group"
 import styled from "styled-components"
 import {
   PaneContent,

--- a/packages/web-console/src/scenes/Notifications/index.tsx
+++ b/packages/web-console/src/scenes/Notifications/index.tsx
@@ -43,6 +43,7 @@ import { actions, selectors } from "../../store"
 import { TerminalBox, Subtract, ArrowUpS } from "@styled-icons/remix-line"
 import { Button } from "@questdb/react-components"
 import Notification from "./Notification"
+import { NotificationType } from "../../store/Query/types"
 
 const Wrapper = styled(PaneWrapper)<{ minimized: boolean }>`
   flex: ${(props) => (props.minimized ? "initial" : "1")};
@@ -142,9 +143,16 @@ const Notifications = () => {
         </Button>
       </Menu>
       {!isMinimized && (
-        <Content minimized={isMinimized} ref={contentRef}>
-          <TransitionGroup data-hook="notifications-expanded">
-            {notifications.map((notification) => (
+        <Content
+          minimized={isMinimized}
+          ref={contentRef}
+          data-hook="notifications-expanded"
+        >
+          {notifications
+            .filter(
+              (notification) => notification.type !== NotificationType.LOADING,
+            )
+            .map((notification) => (
               <Notification
                 isMinimized={false}
                 key={
@@ -153,7 +161,6 @@ const Notifications = () => {
                 {...notification}
               />
             ))}
-          </TransitionGroup>
           {!isMinimized && (
             <ClearAllNotifications>
               <Button

--- a/packages/web-console/src/store/Query/types.ts
+++ b/packages/web-console/src/store/Query/types.ts
@@ -35,6 +35,7 @@ export enum NotificationType {
   INFO = "info",
   SUCCESS = "success",
   NOTICE = "notice",
+  LOADING = "loading",
 }
 
 export type NotificationShape = Readonly<{


### PR DESCRIPTION
- Scrolling to error position in the editor
- Truncate query text in Notifications bar, add Copy CTA
- Switch the green "play" triangle in the editor margin to "stop" when query is running. clicking on the "stop" button will cancel.
- Proper multi-tab error support. Error markers (highlight + squiggly lines) in one tab should not spill over to the next one, they should be separate.
- Remove `=` as word delimiter, so that expressions like `==` can be highlighted as errors (since they can now be tokens)