### PR TITLE
ci: fix check oss submodule

### DIFF
--- a/.github/workflows/check_oss_submodule.yml
+++ b/.github/workflows/check_oss_submodule.yml
@@ -13,8 +13,9 @@ jobs:
         with:
           submodules: "recursive"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
       - name: Check OSS branch
         run: |
-          python3 -m pip install -U pip
-          python3 -m pip install --upgrade pygit2==1.14.1
-          python3 submodule_is_mergeable.py
+          uv run --with "pygit2==1.14.1" submodule_is_mergeable.py


### PR DESCRIPTION
Swapped out `pip` for `uv` and fixed the pip install clash with Ubuntu's "thou shall not install global packages" settings.