### PR TITLE
feat(web-console): Add news image zoom

### DIFF
--- a/packages/web-console/src/scenes/Layout/index.tsx
+++ b/packages/web-console/src/scenes/Layout/index.tsx
@@ -36,6 +36,7 @@ import { CreateTableDialog } from "../../components/CreateTableDialog"
 import { EditorProvider } from "../../providers"
 import { Help } from "./help"
 import { Warnings } from "./warning"
+import { ImageZoom } from "../News/image-zoom"
 
 import "allotment/dist/style.css"
 
@@ -62,6 +63,7 @@ const Root = styled.div`
 `
 
 const Main = styled.div<{ sideOpened: boolean }>`
+  position: relative;
   flex: 1;
   display: flex;
   width: ${({ sideOpened }) =>
@@ -81,6 +83,7 @@ const Layout = () => {
       <Warnings />
       <Root>
         <Main sideOpened={activeSidebar !== undefined}>
+          <ImageZoom />
           <Page>
             <Console />
           </Page>

--- a/packages/web-console/src/scenes/News/image-zoom.tsx
+++ b/packages/web-console/src/scenes/News/image-zoom.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useRef, useState } from "react"
+import styled from "styled-components"
+import { Box } from "@questdb/react-components"
+import { useSelector } from "react-redux"
+import { selectors } from "../../store"
+import { Thumbnail } from "./thumbnail"
+
+const Root = styled(Box).attrs({ align: "center", justifyContent: "center" })`
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  z-index: 1000;
+  background: rgba(33, 34, 44, 0.5);
+`
+
+export const ImageZoom = () => {
+  const imageToZoom = useSelector(selectors.console.getImageToZoom)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const [rootWidth, setRootWidth] = useState(0)
+
+  useEffect(() => {
+    if (rootRef.current) {
+      setRootWidth(rootRef.current.offsetWidth)
+    }
+  }, [imageToZoom])
+
+  if (!imageToZoom) return null
+
+  return (
+    <Root ref={rootRef}>
+      {imageToZoom && (
+        <Thumbnail
+          {...imageToZoom}
+          containerWidth={rootWidth ? rootWidth * 0.75 : 460}
+        />
+      )}
+    </Root>
+  )
+}

--- a/packages/web-console/src/scenes/News/image-zoom.tsx
+++ b/packages/web-console/src/scenes/News/image-zoom.tsx
@@ -36,12 +36,17 @@ export const ImageZoom = () => {
   const imageToZoom = useSelector(selectors.console.getImageToZoom)
   const rootRef = useRef<HTMLDivElement>(null)
   const [rootWidth, setRootWidth] = useState(0)
+  const activeSidebar = useSelector(selectors.console.getActiveSidebar)
 
   useEffect(() => {
     if (rootRef.current) {
       setRootWidth(rootRef.current.offsetWidth)
     }
   }, [imageToZoom])
+
+  if (activeSidebar !== "news") {
+    return null
+  }
 
   return (
     <Root ref={rootRef} visible={imageToZoom !== undefined}>

--- a/packages/web-console/src/scenes/News/image-zoom.tsx
+++ b/packages/web-console/src/scenes/News/image-zoom.tsx
@@ -42,6 +42,7 @@ export const ImageZoom = () => {
   const dispatch = useDispatch()
   const rootRef = useRef<HTMLDivElement>(null)
   const [rootWidth, setRootWidth] = useState(0)
+  const [rootHeight, setRootHeight] = useState(0)
   const activeSidebar = useSelector(selectors.console.getActiveSidebar)
 
   const handleEsc = (event: KeyboardEvent) => {
@@ -53,6 +54,7 @@ export const ImageZoom = () => {
   useEffect(() => {
     if (rootRef.current) {
       setRootWidth(rootRef.current.offsetWidth)
+      setRootHeight(rootRef.current.offsetHeight)
     }
   }, [imageToZoom])
 
@@ -76,6 +78,7 @@ export const ImageZoom = () => {
           <Thumbnail
             {...imageToZoom}
             containerWidth={rootWidth ? rootWidth * 0.9 : 460}
+            containerHeight={rootHeight ? rootHeight * 0.75 : 460}
           />
         </Wrapper>
       )}

--- a/packages/web-console/src/scenes/News/image-zoom.tsx
+++ b/packages/web-console/src/scenes/News/image-zoom.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useRef, useState } from "react"
 import styled from "styled-components"
 import { Box } from "@questdb/react-components"
-import { useSelector } from "react-redux"
-import { selectors } from "../../store"
+import { useSelector, useDispatch } from "react-redux"
+import { selectors, actions } from "../../store"
 import { Thumbnail } from "./thumbnail"
 
 const Root = styled(Box).attrs({ align: "center", justifyContent: "center" })<{
@@ -22,7 +22,7 @@ const Overlay = styled.div<{ visible: boolean }>`
   top: 0;
   width: 100%;
   height: 100%;
-  background: rgba(33, 34, 44, 0.5);
+  background: rgba(33, 34, 44, 0.9);
   opacity: ${({ visible }) => (visible ? 1 : 0)};
   pointer-events: ${({ visible }) => (visible ? "auto" : "none")};
   transition: opacity 0.2s ease-in-out;
@@ -30,13 +30,25 @@ const Overlay = styled.div<{ visible: boolean }>`
 
 const Wrapper = styled.div`
   z-index: 1001;
+
+  img {
+    border: 1px solid ${({ theme }) => theme.color.offWhite};
+    border-radius: ${({ theme }) => theme.borderRadius};
+  }
 `
 
 export const ImageZoom = () => {
   const imageToZoom = useSelector(selectors.console.getImageToZoom)
+  const dispatch = useDispatch()
   const rootRef = useRef<HTMLDivElement>(null)
   const [rootWidth, setRootWidth] = useState(0)
   const activeSidebar = useSelector(selectors.console.getActiveSidebar)
+
+  const handleEsc = (event: KeyboardEvent) => {
+    if (event.key === "Escape") {
+      dispatch(actions.console.setImageToZoom(undefined))
+    }
+  }
 
   useEffect(() => {
     if (rootRef.current) {
@@ -44,12 +56,28 @@ export const ImageZoom = () => {
     }
   }, [imageToZoom])
 
+  useEffect(() => {
+    if (activeSidebar === "news") {
+      document.addEventListener("keydown", handleEsc)
+    } else {
+      document.removeEventListener("keydown", handleEsc)
+    }
+  }, [activeSidebar])
+
   if (activeSidebar !== "news") {
     return null
   }
 
   return (
-    <Root ref={rootRef} visible={imageToZoom !== undefined}>
+    <Root
+      ref={rootRef}
+      visible={imageToZoom !== undefined}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          dispatch(actions.console.setImageToZoom(undefined))
+        }
+      }}
+    >
       <Overlay visible={imageToZoom !== undefined} />
       {imageToZoom && (
         <Wrapper>

--- a/packages/web-console/src/scenes/News/image-zoom.tsx
+++ b/packages/web-console/src/scenes/News/image-zoom.tsx
@@ -69,15 +69,7 @@ export const ImageZoom = () => {
   }
 
   return (
-    <Root
-      ref={rootRef}
-      visible={imageToZoom !== undefined}
-      onKeyDown={(event) => {
-        if (event.key === "Escape") {
-          dispatch(actions.console.setImageToZoom(undefined))
-        }
-      }}
-    >
+    <Root ref={rootRef} visible={imageToZoom !== undefined}>
       <Overlay visible={imageToZoom !== undefined} />
       {imageToZoom && (
         <Wrapper>

--- a/packages/web-console/src/scenes/News/image-zoom.tsx
+++ b/packages/web-console/src/scenes/News/image-zoom.tsx
@@ -5,12 +5,31 @@ import { useSelector } from "react-redux"
 import { selectors } from "../../store"
 import { Thumbnail } from "./thumbnail"
 
-const Root = styled(Box).attrs({ align: "center", justifyContent: "center" })`
+const Root = styled(Box).attrs({ align: "center", justifyContent: "center" })<{
+  visible: boolean
+}>`
   width: 100%;
   height: 100%;
   position: absolute;
   z-index: 1000;
+  opacity: ${({ visible }) => (visible ? 1 : 0)};
+  pointer-events: ${({ visible }) => (visible ? "auto" : "none")};
+`
+
+const Overlay = styled.div<{ visible: boolean }>`
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
   background: rgba(33, 34, 44, 0.5);
+  opacity: ${({ visible }) => (visible ? 1 : 0)};
+  pointer-events: ${({ visible }) => (visible ? "auto" : "none")};
+  transition: opacity 0.2s ease-in-out;
+`
+
+const Wrapper = styled.div`
+  z-index: 1001;
 `
 
 export const ImageZoom = () => {
@@ -24,15 +43,16 @@ export const ImageZoom = () => {
     }
   }, [imageToZoom])
 
-  if (!imageToZoom) return null
-
   return (
-    <Root ref={rootRef}>
+    <Root ref={rootRef} visible={imageToZoom !== undefined}>
+      <Overlay visible={imageToZoom !== undefined} />
       {imageToZoom && (
-        <Thumbnail
-          {...imageToZoom}
-          containerWidth={rootWidth ? rootWidth * 0.75 : 460}
-        />
+        <Wrapper>
+          <Thumbnail
+            {...imageToZoom}
+            containerWidth={rootWidth ? rootWidth * 0.9 : 460}
+          />
+        </Wrapper>
       )}
     </Root>
   )

--- a/packages/web-console/src/scenes/News/index.tsx
+++ b/packages/web-console/src/scenes/News/index.tsx
@@ -168,6 +168,8 @@ const News = () => {
     setNewsOpened(activeSidebar === "news")
   }, [activeSidebar])
 
+  console.log(enterpriseNews)
+
   return (
     <Drawer
       mode="side"
@@ -233,6 +235,32 @@ const News = () => {
                       alt={`${newsItem.title} thumbnail`}
                       width={newsItem.thumbnail[0].thumbnails.large.width}
                       height={newsItem.thumbnail[0].thumbnails.large.height}
+                      fadeIn={true}
+                      {...(newsItem && newsItem.thumbnail
+                        ? {
+                            onMouseOver: () => {
+                              if (newsItem.thumbnail)
+                                dispatch(
+                                  actions.console.setImageToZoom({
+                                    src: newsItem.thumbnail[0].thumbnails.large
+                                      .url,
+                                    width:
+                                      newsItem.thumbnail[0].thumbnails.large
+                                        .width,
+                                    height:
+                                      newsItem.thumbnail[0].thumbnails.large
+                                        .height,
+                                    alt: newsItem.title,
+                                  }),
+                                )
+                            },
+                            onMouseOut: () => {
+                              dispatch(
+                                actions.console.setImageToZoom(undefined),
+                              )
+                            },
+                          }
+                        : {})}
                     />
                   )}
 

--- a/packages/web-console/src/scenes/News/index.tsx
+++ b/packages/web-console/src/scenes/News/index.tsx
@@ -233,6 +233,7 @@ const News = () => {
                   newsItem.thumbnail[0].thumbnails.large && (
                     <Thumbnail
                       containerWidth={460}
+                      containerHeight={460}
                       src={newsItem.thumbnail[0].thumbnails.large.url}
                       alt={`${newsItem.title} thumbnail`}
                       width={newsItem.thumbnail[0].thumbnails.large.width}

--- a/packages/web-console/src/scenes/News/index.tsx
+++ b/packages/web-console/src/scenes/News/index.tsx
@@ -17,6 +17,7 @@ import { UnreadItemsIcon } from "../../components/UnreadItemsIcon"
 import { Thumbnail } from "./thumbnail"
 import { Bell } from "./bell"
 import { BUTTON_ICON_SIZE } from "../../consts"
+import { clear } from "console"
 
 const Loading = styled.div`
   display: grid;
@@ -91,6 +92,8 @@ const News = () => {
   // This boolean is to animate the bell icon and display a bullet indicator
   const [hasUnreadNews, setHasUnreadNews] = useState(false)
   const activeSidebar = useSelector(selectors.console.getActiveSidebar)
+
+  let hoverTimeout: NodeJS.Timeout
 
   const getEnterpriseNews = async () => {
     setIsLoading(true)
@@ -237,22 +240,28 @@ const News = () => {
                       {...(newsItem && newsItem.thumbnail
                         ? {
                             onMouseOver: () => {
-                              if (newsItem.thumbnail)
-                                dispatch(
-                                  actions.console.setImageToZoom({
-                                    src: newsItem.thumbnail[0].thumbnails.large
-                                      .url,
-                                    width:
-                                      newsItem.thumbnail[0].thumbnails.large
-                                        .width,
-                                    height:
-                                      newsItem.thumbnail[0].thumbnails.large
-                                        .height,
-                                    alt: newsItem.title,
-                                  }),
-                                )
+                              if (newsItem.thumbnail) {
+                                hoverTimeout = setTimeout(() => {
+                                  if (newsItem && newsItem.thumbnail) {
+                                    dispatch(
+                                      actions.console.setImageToZoom({
+                                        src: newsItem.thumbnail[0].thumbnails
+                                          .large.url,
+                                        width:
+                                          newsItem.thumbnail[0].thumbnails.large
+                                            .width,
+                                        height:
+                                          newsItem.thumbnail[0].thumbnails.large
+                                            .height,
+                                        alt: newsItem.title,
+                                      }),
+                                    )
+                                  }
+                                }, 500)
+                              }
                             },
                             onMouseOut: () => {
+                              clearTimeout(hoverTimeout)
                               dispatch(
                                 actions.console.setImageToZoom(undefined),
                               )

--- a/packages/web-console/src/scenes/News/index.tsx
+++ b/packages/web-console/src/scenes/News/index.tsx
@@ -17,7 +17,6 @@ import { UnreadItemsIcon } from "../../components/UnreadItemsIcon"
 import { Thumbnail } from "./thumbnail"
 import { Bell } from "./bell"
 import { BUTTON_ICON_SIZE } from "../../consts"
-import { clear } from "console"
 
 const Loading = styled.div`
   display: grid;
@@ -61,13 +60,15 @@ const NewsText = styled(Text).attrs({ color: "foreground" })`
     font-size: 1.6rem;
   }
 
-  p {
+  p,
+  li {
     font-size: ${({ theme }) => theme.fontSize.lg};
     line-height: 1.75;
   }
 
   code {
     background-color: ${({ theme }) => theme.color.selection};
+    color: ${({ theme }) => theme.color.pink};
     padding: 0.2rem 0.4rem;
     border-radius: 0.2rem;
   }

--- a/packages/web-console/src/scenes/News/index.tsx
+++ b/packages/web-console/src/scenes/News/index.tsx
@@ -168,8 +168,6 @@ const News = () => {
     setNewsOpened(activeSidebar === "news")
   }, [activeSidebar])
 
-  console.log(enterpriseNews)
-
   return (
     <Drawer
       mode="side"

--- a/packages/web-console/src/scenes/News/index.tsx
+++ b/packages/web-console/src/scenes/News/index.tsx
@@ -262,9 +262,11 @@ const News = () => {
                             },
                             onMouseOut: () => {
                               clearTimeout(hoverTimeout)
-                              dispatch(
-                                actions.console.setImageToZoom(undefined),
-                              )
+                              setTimeout(() => {
+                                dispatch(
+                                  actions.console.setImageToZoom(undefined),
+                                )
+                              }, 250)
                             },
                           }
                         : {})}

--- a/packages/web-console/src/scenes/News/thumbnail.tsx
+++ b/packages/web-console/src/scenes/News/thumbnail.tsx
@@ -18,13 +18,12 @@ const Root = styled.div`
   }
 `
 
-const ThumbImg = styled.img<{ loaded: boolean }>`
-  width: 46rem;
+const ThumbImg = styled.img<{ loaded: boolean; fadeIn?: boolean }>`
   height: auto;
 
-  ${({ loaded }) => `
+  ${({ loaded, fadeIn }) => `
     opacity: ${loaded ? 1 : 0};
-    transition: opacity 0.2s ease-in-out;
+    ${fadeIn && `transition: opacity 0.2s ease-in-out;`}
   `}
 `
 export const Thumbnail = ({
@@ -33,12 +32,15 @@ export const Thumbnail = ({
   width,
   height,
   containerWidth,
+  fadeIn,
+  ...rest
 }: {
   src: string
   alt: string
   width: number
   height: number
   containerWidth: number
+  fadeIn?: boolean
 }) => {
   const [isLoaded, setIsLoaded] = useState(false)
 
@@ -55,7 +57,7 @@ export const Thumbnail = ({
   }, [src])
 
   return (
-    <Root>
+    <Root {...rest}>
       {!isLoaded && <Loader />}
       <ThumbImg
         src={src}
@@ -63,6 +65,7 @@ export const Thumbnail = ({
         width={scaledImageWidth}
         height={scaledImageHeight}
         loaded={isLoaded}
+        fadeIn={fadeIn}
       />
     </Root>
   )

--- a/packages/web-console/src/scenes/News/thumbnail.tsx
+++ b/packages/web-console/src/scenes/News/thumbnail.tsx
@@ -32,6 +32,7 @@ export const Thumbnail = ({
   width,
   height,
   containerWidth,
+  containerHeight,
   fadeIn,
   ...rest
 }: {
@@ -40,12 +41,18 @@ export const Thumbnail = ({
   width: number
   height: number
   containerWidth: number
+  containerHeight: number
   fadeIn?: boolean
 }) => {
   const [isLoaded, setIsLoaded] = useState(false)
 
-  const scaledImageWidth = containerWidth
-  const scaledImageHeight = (scaledImageWidth / width) * height
+  let scaledImageWidth = containerWidth
+  let scaledImageHeight = (scaledImageWidth / width) * height
+  if (scaledImageHeight > containerHeight) {
+    const ratio = containerHeight / scaledImageHeight
+    scaledImageHeight = containerHeight
+    scaledImageWidth *= ratio
+  }
 
   useEffect(() => {
     const imgElement = new Image()

--- a/packages/web-console/src/store/Console/actions.ts
+++ b/packages/web-console/src/store/Console/actions.ts
@@ -24,6 +24,7 @@
 import {
   ConsoleAction,
   ConsoleAT,
+  ImageToZoom,
   TopPanel,
   Sidebar,
   BottomPanel,
@@ -43,6 +44,11 @@ const setActiveBottomPanel = (panel: BottomPanel): ConsoleAction => ({
   type: ConsoleAT.SET_ACTIVE_BOTTOM_PANEL,
 })
 
+const setImageToZoom = (image?: ImageToZoom): ConsoleAction => ({
+  payload: image,
+  type: ConsoleAT.SET_IMAGE_TO_ZOOM,
+})
+
 const toggleSideMenu = (): ConsoleAction => ({
   type: ConsoleAT.TOGGLE_SIDE_MENU,
 })
@@ -52,4 +58,5 @@ export default {
   setActiveTopPanel,
   setActiveSidebar,
   setActiveBottomPanel,
+  setImageToZoom,
 }

--- a/packages/web-console/src/store/Console/reducers.ts
+++ b/packages/web-console/src/store/Console/reducers.ts
@@ -29,6 +29,7 @@ export const initialState: ConsoleStateShape = {
   activeTopPanel: "tables",
   activeSidebar: undefined,
   activeBottomPanel: "zeroState",
+  imageToZoom: undefined,
 }
 
 const _console = (
@@ -61,6 +62,13 @@ const _console = (
       return {
         ...state,
         activeBottomPanel: action.payload,
+      }
+    }
+
+    case ConsoleAT.SET_IMAGE_TO_ZOOM: {
+      return {
+        ...state,
+        imageToZoom: action.payload,
       }
     }
 

--- a/packages/web-console/src/store/Console/selectors.ts
+++ b/packages/web-console/src/store/Console/selectors.ts
@@ -21,7 +21,7 @@
  *  limitations under the License.
  *
  ******************************************************************************/
-import { StoreShape, Sidebar, BottomPanel, TopPanel } from "types"
+import { StoreShape, Sidebar, BottomPanel, TopPanel, ImageToZoom } from "types"
 
 const getSideMenuOpened: (store: StoreShape) => boolean = (store) =>
   store.console.sideMenuOpened
@@ -35,9 +35,14 @@ const getActiveSidebar: (store: StoreShape) => Sidebar = (store) =>
 const getActiveBottomPanel: (store: StoreShape) => BottomPanel = (store) =>
   store.console.activeBottomPanel
 
+const getImageToZoom: (store: StoreShape) => ImageToZoom | undefined = (
+  store,
+) => store.console.imageToZoom
+
 export default {
   getSideMenuOpened,
   getActiveTopPanel,
   getActiveSidebar,
   getActiveBottomPanel,
+  getImageToZoom,
 }

--- a/packages/web-console/src/store/Console/types.ts
+++ b/packages/web-console/src/store/Console/types.ts
@@ -28,11 +28,19 @@ export type Sidebar = "news" | "create" | undefined
 
 export type BottomPanel = "result" | "zeroState" | "import"
 
+export type ImageToZoom = {
+  src: string
+  alt: string
+  width: number
+  height: number
+}
+
 export type ConsoleStateShape = Readonly<{
   sideMenuOpened: boolean
   activeTopPanel: TopPanel
   activeSidebar: Sidebar
   activeBottomPanel: BottomPanel
+  imageToZoom: ImageToZoom | undefined
 }>
 
 export enum ConsoleAT {
@@ -40,6 +48,7 @@ export enum ConsoleAT {
   SET_ACTIVE_TOP_PANEL = "CONSOLE/SET_ACTIVE_TOP_PANEL",
   SET_ACTIVE_SIDEBAR = "CONSOLE/SET_ACTIVE_SIDEBAR",
   SET_ACTIVE_BOTTOM_PANEL = "CONSOLE/SET_ACTIVE_BOTTOM_PANEL",
+  SET_IMAGE_TO_ZOOM = "CONSOLE/SET_IMAGE_TO_ZOOM",
 }
 
 type ToggleSideMenuAction = Readonly<{
@@ -61,8 +70,14 @@ type setActiveBottomPanelAction = Readonly<{
   type: ConsoleAT.SET_ACTIVE_BOTTOM_PANEL
 }>
 
+type setImageToZoomAction = Readonly<{
+  payload?: ImageToZoom
+  type: ConsoleAT.SET_IMAGE_TO_ZOOM
+}>
+
 export type ConsoleAction =
   | ToggleSideMenuAction
   | setActiveTopPanelAction
   | setActiveSidebarAction
   | setActiveBottomPanelAction
+  | setImageToZoomAction

--- a/packages/web-console/src/utils/questdb.ts
+++ b/packages/web-console/src/utils/questdb.ts
@@ -27,7 +27,7 @@ import { eventBus } from "../modules/EventBus"
 import { EventType } from "../modules/EventBus/types"
 import { AuthPayload } from "../modules/OAuth2/types"
 import { StoreKey } from "./localStorage/types"
-import {API_VERSION} from "../consts";
+import { API_VERSION } from "../consts"
 
 type ColumnDefinition = Readonly<{ name: string; type: string }>
 
@@ -86,12 +86,12 @@ type RawErrorResult = {
 }
 
 type RawNoticeResult = {
-    ddl: undefined
-    dml: undefined
-    error: undefined
-    notice: "<notice message>"
-    position: undefined
-    query: string
+  ddl: undefined
+  dml: undefined
+  error: undefined
+  notice: "<notice message>"
+  position: undefined
+  query: string
 }
 
 type DdlResult = {
@@ -104,7 +104,12 @@ type DmlResult = {
   type: Type.DML
 }
 
-type RawResult = RawDqlResult | RawDmlResult | RawDdlResult | RawErrorResult | RawNoticeResult
+type RawResult =
+  | RawDqlResult
+  | RawDmlResult
+  | RawDdlResult
+  | RawErrorResult
+  | RawNoticeResult
 
 export type ErrorResult = RawErrorResult & {
   type: Type.ERROR
@@ -112,7 +117,7 @@ export type ErrorResult = RawErrorResult & {
 }
 
 export type NoticeResult = RawNoticeResult & {
-    type: Type.NOTICE
+  type: Type.NOTICE
 }
 
 export type QueryRawResult =
@@ -620,7 +625,7 @@ export class Client {
         `chk?${Client.encodeParams({
           f: "json",
           j: name,
-          version: API_VERSION,  
+          version: API_VERSION,
         })}`,
         { headers: this.commonHeaders },
       )


### PR DESCRIPTION
Add an image overlay mode for News thumbnails. The mode is activated on hover with a slight delay and deactivated when user mouse goes out of the thumbnail.

<img width="1805" alt="Screenshot 2024-10-28 at 15 48 30" src="https://github.com/user-attachments/assets/9358a5c4-bcb7-4786-a1be-5af2a587a0f4">
