### PR TITLE
chore: highlight integer numbers that include `_` (underscore) separator

### DIFF
--- a/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/language.ts
+++ b/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/language.ts
@@ -109,9 +109,9 @@ export const language: monaco.languages.IMonarchLanguage = {
       ],
     ],
     numbers: [
-      [/0[xX][0-9a-fA-F]*/, "number"],
-      [/[$][+-]*\d*(\.\d*)?/, "number"],
-      [/((\d+(\.\d*)?)|(\.\d+))([eE][\-+]?\d+)?/, "number"],
+      [/0[xX][0-9a-fA-F]*/, "number"], // hex integers
+      [/[+-]?\d+((_)?\d+)*[Ll]?/, "number"], // integers
+      [/[+-]?\d*(\.\d*)?[Ee]/, "number"], // floating point number
     ],
     strings: [
       [/N'/, { token: "string", next: "@string" }],


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1afee740-82bf-4779-90d6-dae90cee55a3)
