### PR TITLE
chore(web-console): make autocomplete case-insensitive

### DIFF
--- a/packages/browser-tests/cypress/commands.js
+++ b/packages/browser-tests/cypress/commands.js
@@ -158,6 +158,8 @@ Cypress.Commands.add("getAutocomplete", () =>
   cy.get('[widgetid="editor.widget.suggestWidget"]')
 );
 
+Cypress.Commands.add("getMonacoListRow", () => cy.get(".monaco-list-row"));
+
 Cypress.Commands.add("getErrorMarker", () => cy.get(".squiggly-error"));
 
 Cypress.Commands.add("getCursorQueryDecoration", () =>

--- a/packages/browser-tests/cypress/integration/console/editor.spec.js
+++ b/packages/browser-tests/cypress/integration/console/editor.spec.js
@@ -205,6 +205,21 @@ describe("autocomplete", () => {
     cy.matchImageSnapshot();
   });
 
+  it("should be case insensitive", () => {
+    const assertFrom = () =>
+      cy.getAutocomplete().within(() => {
+        cy.getMonacoListRow()
+          .should("have.length", 3)
+          .eq(0)
+          .should("contain", "FROM");
+      });
+    cy.typeQuery("select * from");
+    assertFrom();
+    cy.clearEditor();
+    cy.typeQuery("SELECT * FROM");
+    assertFrom();
+  });
+
   it("should suggest the existing tables on 'from' clause", () => {
     cy.typeQuery("select * from ");
     cy.getAutocomplete()
@@ -225,6 +240,15 @@ describe("autocomplete", () => {
       // list the tables containing `secret` column
       .should("contain", "my_secrets, my_secrets2")
       .clearEditor();
+  });
+
+  it("should suggest columns on SELECT only when applicable", () => {
+    cy.typeQuery("select secret");
+    cy.getAutocomplete().should("contain", "secret").eq(0).click();
+    cy.typeQuery(", public");
+    cy.getAutocomplete().should("contain", "public").eq(0).click();
+    cy.typeQuery(" ");
+    cy.getAutocomplete().should("not.be.visible");
   });
 
   it("should suggest correct columns on 'where' filter", () => {

--- a/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/getLanguageCompletions.ts
+++ b/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/getLanguageCompletions.ts
@@ -25,6 +25,7 @@ export const getLanguageCompletions = (range: IRange) => [
     return {
       label: keyword,
       kind: CompletionItemKind.Keyword,
+      filterText: item, // match case-insensitive
       insertText: keyword,
       range,
     }
@@ -34,7 +35,8 @@ export const getLanguageCompletions = (range: IRange) => [
     return {
       label: operator,
       kind: CompletionItemKind.Operator,
-      insertText: operator.toUpperCase(),
+      filterText: item, // match case-insensitive
+      insertText: operator,
       range,
     }
   }),


### PR DESCRIPTION
Fixes an issue in which lower and upper case tokens trigger different suggestion set.  In the example below, `FROM` should display exactly the same list as `from`:

<img width="654" alt="Screenshot 2025-01-02 at 12 07 11" src="https://github.com/user-attachments/assets/295f38b3-c504-42c6-9cff-1e05cc8b20da" />
<img width="700" alt="Screenshot 2025-01-02 at 12 07 06" src="https://github.com/user-attachments/assets/b65a9669-bdfa-4d80-829b-5dc4dbc70b19" />

Additionally, column suggestions should not be displayed when not applicable, i.e.

display suggestion set:
```sql
SELECT column1, <cursor>
```

do not display suggestion set:
```sql
SELECT column1 <cursor>
```