### PR TITLE
release(web-console): 0.7.0

### DIFF
--- a/packages/web-console/CHANGELOG.md
+++ b/packages/web-console/CHANGELOG.md
@@ -16,6 +16,27 @@ and this project adheres to
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## 0.7.0 - 2025.01.21
+
+### Added
+
+- WAL Metrics for tables [#352](https://github.com/questdb/ui/pull/352)
+- Add TTL feature to tables [#365](https://github.com/questdb/ui/pull/365)
+- webpack dev server proxy to take context path from env variable
+  [#371](https://github.com/questdb/ui/pull/371)
+
+### Changed
+
+- use `SHOW CREATE TABLE` in `Copy schema to clipboard`
+  [#369](https://github.com/questdb/ui/pull/369)
+- Make autocomplete case insensitive
+  [#366](https://github.com/questdb/ui/pull/366)
+
+### Fixed
+
+- kick user out if access token expired and there is no refresh token
+  [#373](https://github.com/questdb/ui/pull/373)
+
 ## 0.6.5 - 2024.12.02
 
 ### Changed

--- a/packages/web-console/package.json
+++ b/packages/web-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@questdb/web-console",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "description": "QuestDB Console",
   "files": [


### PR DESCRIPTION
## 0.7.0 - 2025.01.21

### Added

- WAL Metrics for tables [#352](https://github.com/questdb/ui/pull/352)
- Add TTL feature to tables [#365](https://github.com/questdb/ui/pull/365)
- webpack dev server proxy to take context path from env variable
  [#371](https://github.com/questdb/ui/pull/371)

### Changed

- use `SHOW CREATE TABLE` in `Copy schema to clipboard`
  [#369](https://github.com/questdb/ui/pull/369)
- Make autocomplete case insensitive
  [#366](https://github.com/questdb/ui/pull/366)

### Fixed

- kick user out if access token expired and there is no refresh token
  [#373](https://github.com/questdb/ui/pull/373)