### PR TITLE
chore(web-console): Metrics: Map commit rate and write throughput per second

### DIFF
--- a/packages/web-console/src/scenes/Editor/Metrics/metric.tsx
+++ b/packages/web-console/src/scenes/Editor/Metrics/metric.tsx
@@ -109,6 +109,7 @@ export const Metric = ({
       if (responses[0] && responses[0].type === QuestDB.Type.DQL) {
         const alignedData = widgetConfig.alignData(
           responses[0].data as unknown as ResultType[MetricType],
+          sampleBySeconds,
         )
         if (isRollingAppendEnabled) {
           dataRef.current = mergeRollingData(dataRef.current, alignedData, from)

--- a/packages/web-console/src/scenes/Editor/Metrics/types.ts
+++ b/packages/web-console/src/scenes/Editor/Metrics/types.ts
@@ -32,7 +32,7 @@ export type Widget = {
   getQuery: ({ tableId, sampleBy, limit, from, to }: MethodArgs) => string
   getQueryLastNotNull: (id?: number) => string
   querySupportsRollingAppend: boolean
-  alignData: (data: any) => uPlot.AlignedData
+  alignData: (data: any, sampleBySeconds: number) => uPlot.AlignedData
   mapYValue: (rawValue: number) => number | string
 }
 

--- a/packages/web-console/src/scenes/Editor/Metrics/utils.ts
+++ b/packages/web-console/src/scenes/Editor/Metrics/utils.ts
@@ -145,8 +145,11 @@ export const getXAxisFormat = (
   return utcToLocal(rawValue, format)
 }
 
-export const sqlValueToFixed = (value: string, decimals: number = 2) => {
-  const parsed = parseFloat(value)
+export const sqlValueToFixed = (
+  value: number | string,
+  decimals: number = 2,
+) => {
+  const parsed = typeof value === "string" ? parseFloat(value) : value
   return Number(parsed.toFixed(decimals)) as unknown as number
 }
 

--- a/packages/web-console/src/scenes/Editor/Metrics/widgets/commitRate.tsx
+++ b/packages/web-console/src/scenes/Editor/Metrics/widgets/commitRate.tsx
@@ -14,7 +14,7 @@ export const commitRate: Widget = {
       {lastValue ? `Currently: ${lastValue}/s` : ``}
     </>
   ),
-  iconUrl: "/assets/metric-commit-rate.svg",
+  iconUrl: "assets/metric-commit-rate.svg",
   isTableMetric: true,
   querySupportsRollingAppend: true,
   getQuery: ({ tableId, sampleBy, limit, from, to }) => {

--- a/packages/web-console/src/scenes/Editor/Metrics/widgets/commitRate.tsx
+++ b/packages/web-console/src/scenes/Editor/Metrics/widgets/commitRate.tsx
@@ -6,12 +6,12 @@ import { TelemetryTable } from "../../../../consts"
 
 export const commitRate: Widget = {
   distribution: 1,
-  label: "Commit rate",
-  getDescription: ({ lastValue, sampleBy }) => (
+  label: "Commit rate per second",
+  getDescription: ({ lastValue }) => (
     <>
       Number of commits written to the table.
       <br />
-      {lastValue ? `Currently: ${lastValue}/${sampleBy}` : ``}
+      {lastValue ? `Currently: ${lastValue}/s` : ``}
     </>
   ),
   iconUrl: "/assets/metric-commit-rate.svg",
@@ -55,9 +55,12 @@ event = 103
 and physicalRowCount != null
 limit -1
 `,
-  alignData: (data: CommitRate[]): uPlot.AlignedData => [
+  alignData: (data: CommitRate[], sampleBySeconds): uPlot.AlignedData => [
     data.map((l) => new Date(l.created).getTime()),
-    data.map((l) => sqlValueToFixed(l.commit_rate)),
+    data.map((l) => {
+      const valueNum = Number(l.commit_rate)
+      return sqlValueToFixed(valueNum / sampleBySeconds)
+    }),
   ],
   mapYValue: (rawValue: number) => formatNumbers(rawValue),
 }

--- a/packages/web-console/src/scenes/Editor/Metrics/widgets/latency.tsx
+++ b/packages/web-console/src/scenes/Editor/Metrics/widgets/latency.tsx
@@ -15,7 +15,7 @@ export const latency: Widget = {
       {lastValue ? `Currently: ${lastValue} for the last ${sampleBy}` : ""}
     </>
   ),
-  iconUrl: "/assets/metric-read-latency.svg",
+  iconUrl: "assets/metric-read-latency.svg",
   isTableMetric: true,
   querySupportsRollingAppend: true,
   getQuery: ({ tableId, sampleBy, limit, from, to }) => {

--- a/packages/web-console/src/scenes/Editor/Metrics/widgets/writeAmplification.tsx
+++ b/packages/web-console/src/scenes/Editor/Metrics/widgets/writeAmplification.tsx
@@ -16,7 +16,7 @@ export const writeAmplification: Widget = {
       {lastValue ? `Currently: ${lastValue} for the last ${sampleBy}` : ""}
     </>
   ),
-  iconUrl: "/assets/metric-write-amplification.svg",
+  iconUrl: "assets/metric-write-amplification.svg",
   isTableMetric: true,
   querySupportsRollingAppend: true,
   getQuery: ({ tableId, sampleBy, limit, from, to }) => {

--- a/packages/web-console/src/scenes/Editor/Metrics/widgets/writeThroughput.tsx
+++ b/packages/web-console/src/scenes/Editor/Metrics/widgets/writeThroughput.tsx
@@ -6,12 +6,12 @@ import { TelemetryTable } from "../../../../consts"
 
 export const writeThroughput: Widget = {
   distribution: 1,
-  label: "Write throughput",
-  getDescription: ({ lastValue, sampleBy }) => (
+  label: "Write throughput per second",
+  getDescription: ({ lastValue }) => (
     <>
       Logical (queryable) rows applied to table.
       <br />
-      {lastValue ? `Currently: ${lastValue}/${sampleBy}` : ""}
+      {lastValue ? `Currently: ${lastValue}/s` : ""}
     </>
   ),
   iconUrl: "/assets/metric-rows-applied.svg",
@@ -41,11 +41,12 @@ and rowCount != null
 and physicalRowCount != null
 limit -1
 `,
-  alignData: (data: RowsApplied[]): uPlot.AlignedData => [
+  alignData: (data: RowsApplied[], sampleBySeconds): uPlot.AlignedData => [
     data.map((l) => new Date(l.time).getTime()),
-    data.map((l) =>
-      l.numOfRowsApplied ? sqlValueToFixed(l.numOfRowsApplied) : 0,
-    ),
+    data.map((l) => {
+      const value = l.numOfRowsApplied ? sqlValueToFixed(l.numOfRowsApplied) : 0
+      return sqlValueToFixed(value / sampleBySeconds)
+    }),
   ],
   mapYValue: (rawValue: number) => formatNumbers(rawValue),
 }

--- a/packages/web-console/src/scenes/Editor/Metrics/widgets/writeThroughput.tsx
+++ b/packages/web-console/src/scenes/Editor/Metrics/widgets/writeThroughput.tsx
@@ -14,7 +14,7 @@ export const writeThroughput: Widget = {
       {lastValue ? `Currently: ${lastValue}/s` : ""}
     </>
   ),
-  iconUrl: "/assets/metric-rows-applied.svg",
+  iconUrl: "assets/metric-rows-applied.svg",
   isTableMetric: true,
   querySupportsRollingAppend: true,
   getQuery: ({ tableId, sampleBy, limit, from, to }) => {


### PR DESCRIPTION
The current logic displays commit rate and write throughput per sampled unit, i.e. `n` number of commits per 10s.

This PR aligns the data so it always displays the value **per second**.

<img width="710" alt="Screenshot 2025-01-23 at 09 35 25" src="https://github.com/user-attachments/assets/bf10ec82-02f6-4103-8575-48bc633c531f" />

<img width="708" alt="Screenshot 2025-01-23 at 09 54 33" src="https://github.com/user-attachments/assets/17b31d1f-3b0d-4856-b7f9-2de243fd7513" />

Side change:
- Make widget icon paths relative 
