### PR TITLE
chore(web-console): dispose inactive models on tab change

### DIFF
--- a/packages/browser-tests/cypress/integration/console/editor.spec.js
+++ b/packages/browser-tests/cypress/integration/console/editor.spec.js
@@ -470,6 +470,7 @@ describe("editor tabs", () => {
     cy.get(getTabDragHandleByTitle("SQL 1")).drag(
       getTabDragHandleByTitle("SQL")
     );
+    // subsequent wait()x3: add an arbitrary waiting period to ensure models are updated
     cy.wait(250);
     cy.getEditorTabs().first().should("contain", "SQL 1");
     cy.getEditorTabs().last().should("contain", "SQL");

--- a/packages/browser-tests/cypress/integration/console/editor.spec.js
+++ b/packages/browser-tests/cypress/integration/console/editor.spec.js
@@ -477,8 +477,10 @@ describe("editor tabs", () => {
     cy.getEditorTabs().last().should("contain", "SQL 1");
 
     // Test model disposal logic. It should dispose of prior models when switching active tabs
-    const editorModels = window.monaco.editor.getModels();
-    expect(editorModels.length).to.equal(1);
+    cy.window().then((window) => {
+      const editorModels = window.monaco.editor.getModels();
+      expect(editorModels.length).to.equal(1);
+    });
   });
 });
 

--- a/packages/browser-tests/cypress/integration/console/editor.spec.js
+++ b/packages/browser-tests/cypress/integration/console/editor.spec.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-const contextPath = process.env.QDB_HTTP_CONTEXT_WEB_CONSOLE || ""
+const contextPath = process.env.QDB_HTTP_CONTEXT_WEB_CONSOLE || "";
 const baseUrl = `http://localhost:9999${contextPath}`;
 
 const getTabDragHandleByTitle = (title) =>
@@ -475,6 +475,10 @@ describe("editor tabs", () => {
     );
     cy.getEditorTabs().first().should("contain", "SQL");
     cy.getEditorTabs().last().should("contain", "SQL 1");
+
+    // Test model disposal logic. It should dispose of prior models when switching active tabs
+    const editorModels = window.monaco.editor.getModels();
+    expect(editorModels.length).to.equal(1);
   });
 });
 

--- a/packages/browser-tests/cypress/integration/console/editor.spec.js
+++ b/packages/browser-tests/cypress/integration/console/editor.spec.js
@@ -464,17 +464,22 @@ describe("editor tabs", () => {
   });
 
   it("should drag tabs", () => {
+    cy.typeQuery("-- query 1");
     cy.get(".new-tab-button").click();
+    cy.typeQuery("-- query 2");
     cy.get(getTabDragHandleByTitle("SQL 1")).drag(
       getTabDragHandleByTitle("SQL")
     );
+    cy.wait(250);
     cy.getEditorTabs().first().should("contain", "SQL 1");
     cy.getEditorTabs().last().should("contain", "SQL");
     cy.get(getTabDragHandleByTitle("SQL 1")).drag(
       getTabDragHandleByTitle("SQL")
     );
+    cy.wait(250);
     cy.getEditorTabs().first().should("contain", "SQL");
     cy.getEditorTabs().last().should("contain", "SQL 1");
+    cy.wait(250);
 
     // Test model disposal logic. It should dispose of prior models when switching active tabs
     cy.window().then((window) => {

--- a/packages/web-console/src/providers/EditorProvider/index.tsx
+++ b/packages/web-console/src/providers/EditorProvider/index.tsx
@@ -99,7 +99,8 @@ export const EditorProvider = ({ children }: PropsWithChildren<{}>) => {
   const setActiveBuffer = async (buffer: Buffer) => {
     try {
       monacoRef.current?.editor.getModels().forEach((model) => {
-        if (model.getValue() !== buffer.value) {
+        const value = model.getValue()
+        if (model.getValue() !== buffer.value || value === "") {
           model.dispose()
         }
       })

--- a/packages/web-console/src/providers/EditorProvider/index.tsx
+++ b/packages/web-console/src/providers/EditorProvider/index.tsx
@@ -98,14 +98,17 @@ export const EditorProvider = ({ children }: PropsWithChildren<{}>) => {
 
   const setActiveBuffer = async (buffer: Buffer) => {
     try {
+      const currentActiveBufferId = (await bufferStore.getActiveId())?.value
+
       monacoRef.current?.editor.getModels().forEach((model) => {
         const value = model.getValue()
-        if (model.getValue() !== buffer.value || value === "") {
+        if (
+          buffer.id !== currentActiveBufferId &&
+          (model.getValue() !== buffer.value || value === "")
+        ) {
           model.dispose()
         }
       })
-
-      const currentActiveBufferId = (await bufferStore.getActiveId())?.value
 
       if (currentActiveBufferId) {
         if (buffer.id === currentActiveBufferId) {

--- a/packages/web-console/src/providers/EditorProvider/index.tsx
+++ b/packages/web-console/src/providers/EditorProvider/index.tsx
@@ -98,7 +98,14 @@ export const EditorProvider = ({ children }: PropsWithChildren<{}>) => {
 
   const setActiveBuffer = async (buffer: Buffer) => {
     try {
+      monacoRef.current?.editor.getModels().forEach((model) => {
+        if (model.getValue() !== buffer.value) {
+          model.dispose()
+        }
+      })
+
       const currentActiveBufferId = (await bufferStore.getActiveId())?.value
+
       if (currentActiveBufferId) {
         if (buffer.id === currentActiveBufferId) {
           return
@@ -123,7 +130,7 @@ export const EditorProvider = ({ children }: PropsWithChildren<{}>) => {
         }
       }
     } catch (e) {
-      console.warn('Error setting active buffer:', e)
+      console.warn("Error setting active buffer:", e)
     }
   }
 

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -46,6 +46,7 @@ loader.config({
 const Content = styled(PaneContent)`
   position: relative;
   overflow: hidden;
+  background: #2c2e3d;
 
   .monaco-editor .squiggly-error {
     background: none;


### PR DESCRIPTION
Current logic does not dispose of inactive editor models while switching tabs, meaning the model array grows exponentially in size with every tab change/drag/creation. This is true even if the editor itself is unmounted (i.e. when switch to metric tabs), because the models reside in an array within a global window object.

This ensures the only model is the active one.