### PR TITLE
chore(web-console): reduce chart re-rendering

### DIFF
--- a/packages/web-console/src/scenes/Editor/Metrics/createUplotOptions.ts
+++ b/packages/web-console/src/scenes/Editor/Metrics/createUplotOptions.ts
@@ -1,9 +1,9 @@
 import { utcToLocal } from "../../../utils"
-import React, { useContext } from "react"
-import { ThemeContext } from "styled-components"
+import React from "react"
 import uPlot from "uplot"
 import { DATETIME_FORMAT } from "./utils"
 import { Widget } from "./types"
+import { DefaultTheme } from "styled-components"
 
 type Params = {
   data: uPlot.AlignedData
@@ -16,7 +16,10 @@ type Params = {
   timeRef: React.RefObject<HTMLSpanElement>
   valueRef: React.RefObject<HTMLSpanElement>
   widgetConfig: Widget
+  theme: DefaultTheme
 }
+
+export type UplotOptions = Omit<uPlot.Options, "width" | "height">
 
 const valuePlugin = (
   timeRef: React.RefObject<HTMLSpanElement>,
@@ -49,7 +52,7 @@ const valuePlugin = (
   },
 })
 
-export const useGraphOptions = ({
+export const createUplotOptions = ({
   data,
   startTime,
   endTime,
@@ -59,8 +62,8 @@ export const useGraphOptions = ({
   timeRef,
   valueRef,
   widgetConfig,
-}: Params): Omit<uPlot.Options, "width" | "height"> => {
-  const theme = useContext(ThemeContext)
+  theme,
+}: Params): UplotOptions => {
   const baseAxisConfig: uPlot.Axis = {
     stroke: theme.color.gray2,
     labelFont: `600 12px ${theme.font}`,

--- a/packages/web-console/src/scenes/Editor/Metrics/graph.tsx
+++ b/packages/web-console/src/scenes/Editor/Metrics/graph.tsx
@@ -125,19 +125,8 @@ export const Graph = ({
   const endTime = new Date(durationTokenToDate(dateTo)).getTime()
 
   const [delayedLoading, setDelayedLoading] = useState(loading)
-  const [uplotOptions, setUplotOptions] = useState<UplotOptions>(
-    createUplotOptions({
-      data,
-      startTime,
-      endTime,
-      colors,
-      timeRef,
-      valueRef,
-      mapXValue: (rawValue) => getXAxisFormat(rawValue, startTime, endTime),
-      mapYValue,
-      widgetConfig,
-      theme,
-    }),
+  const [uplotOptions, setUplotOptions] = useState<UplotOptions | undefined>(
+    undefined,
   )
 
   const resizeObserver = new ResizeObserver((entries) => {

--- a/packages/web-console/src/scenes/Editor/Metrics/graph.tsx
+++ b/packages/web-console/src/scenes/Editor/Metrics/graph.tsx
@@ -118,18 +118,27 @@ export const Graph = ({
   const timeRef = useRef(null)
   const valueRef = useRef(null)
   const uPlotRef = useRef<uPlot>()
-  const [startTime, setStartTime] = useState<number>(
-    new Date(durationTokenToDate(dateFrom)).getTime(),
-  )
-  const [endTime, setEndTime] = useState<number>(
-    new Date(durationTokenToDate(dateTo)).getTime(),
-  )
-  const [delayedLoading, setDelayedLoading] = useState(loading)
-  const [uplotOptions, setUplotOptions] = useState<UplotOptions | undefined>(
-    undefined,
-  )
 
   const { isTableMetric, mapYValue, chartTitle } = widgetConfig
+
+  const startTime = new Date(durationTokenToDate(dateFrom)).getTime()
+  const endTime = new Date(durationTokenToDate(dateTo)).getTime()
+
+  const [delayedLoading, setDelayedLoading] = useState(loading)
+  const [uplotOptions, setUplotOptions] = useState<UplotOptions>(
+    createUplotOptions({
+      data,
+      startTime,
+      endTime,
+      colors,
+      timeRef,
+      valueRef,
+      mapXValue: (rawValue) => getXAxisFormat(rawValue, startTime, endTime),
+      mapYValue,
+      widgetConfig,
+      theme,
+    }),
+  )
 
   const resizeObserver = new ResizeObserver((entries) => {
     uPlotRef.current?.setSize({
@@ -142,11 +151,6 @@ export const Graph = ({
   const to = durationTokenToDate(dateTo)
 
   useEffect(() => {
-    setStartTime(new Date(from).getTime())
-    setEndTime(new Date(to).getTime())
-  }, [data, dateFrom, dateTo])
-
-  useMemo(() => {
     setUplotOptions(
       createUplotOptions({
         data,


### PR DESCRIPTION
The current version of Metrics re-renders the charts more than it's needed due to how the method to generate the uPlot configuration object is executed. This PR ensures each chart widget is rendered one time per refresh cycle. This can be verified by putting on a logger in the [`onCreate` method of the uPlot component](https://github.com/questdb/ui/blob/main/packages/web-console/src/scenes/Editor/Metrics/graph.tsx#L236).

Changes:
- Convert `useGraphOptions` to a method that is no longer a React hook, since there is no need to get the theme context in there anymore. 
- Refresh the uPlot configuration object only when the data is changed (= per refresh cycle). 