### PR TITLE
feat(ui): support for OAuth2 state parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,20 +84,20 @@ jobs:
         if: success() || failure()
         run: ./tmp/questdb-*-rt-linux-x86-64/bin/questdb.sh stop
 
-      - name: Publish @questdb/web-console to npm
-        if: github.ref == 'refs/heads/main'
-        uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          access: public
-          check-version: true
-          package: ./packages/web-console/package.json
-
       - name: Publish @questdb/react-components to npm
-        if: github.ref == 'refs/heads/main'
+        if: success() && github.ref == 'refs/heads/main'
         uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
           access: public
           check-version: true
           package: ./packages/react-components/package.json
+
+      - name: Publish @questdb/web-console to npm
+        if: success() && github.ref == 'refs/heads/main'
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          access: public
+          check-version: true
+          package: ./packages/web-console/package.json

--- a/packages/web-console/src/modules/OAuth2/pkce.ts
+++ b/packages/web-console/src/modules/OAuth2/pkce.ts
@@ -4,7 +4,15 @@ import { sha256 } from "js-sha256"
 import { Base64 } from "js-base64"
 import { Settings } from "../../providers/SettingsProvider/types"
 
+const STATE_LENGTH = 60
 const CODE_VERIFIER_LENGTH = 60
+
+export const generateState = (settings: Settings) => {
+    if (settings["acl.oidc.state.required"]) {
+        return doGenerateState()
+    }
+    return null
+}
 
 export const generateCodeVerifier = (settings: Settings) => {
   if (settings["acl.oidc.pkce.required"]) {
@@ -18,6 +26,14 @@ export const generateCodeChallenge = (code_verifier: string | null) => {
     return doGenerateCodeChallenge(code_verifier)
   }
   return null
+}
+
+const doGenerateState = () => {
+    const state_array = new Uint8Array(STATE_LENGTH)
+    crypto.getRandomValues(state_array)
+    const state = Base64.fromUint8Array(state_array, true)
+    setValue(StoreKey.OAUTH_STATE, state)
+    return state
 }
 
 const doGenerateCodeVerifier = () => {

--- a/packages/web-console/src/modules/OAuth2/pkce.ts
+++ b/packages/web-console/src/modules/OAuth2/pkce.ts
@@ -8,10 +8,10 @@ const STATE_LENGTH = 60
 const CODE_VERIFIER_LENGTH = 60
 
 export const generateState = (settings: Settings) => {
-    if (settings["acl.oidc.state.required"]) {
-        return doGenerateState()
-    }
-    return null
+  if (settings["acl.oidc.state.required"]) {
+    return doGenerateState()
+  }
+  return null
 }
 
 export const generateCodeVerifier = (settings: Settings) => {
@@ -29,11 +29,11 @@ export const generateCodeChallenge = (code_verifier: string | null) => {
 }
 
 const doGenerateState = () => {
-    const state_array = new Uint8Array(STATE_LENGTH)
-    crypto.getRandomValues(state_array)
-    const state = Base64.fromUint8Array(state_array, true)
-    setValue(StoreKey.OAUTH_STATE, state)
-    return state
+  const state_array = new Uint8Array(STATE_LENGTH)
+  crypto.getRandomValues(state_array)
+  const state = Base64.fromUint8Array(state_array, true)
+  setValue(StoreKey.OAUTH_STATE, state)
+  return state
 }
 
 const doGenerateCodeVerifier = () => {

--- a/packages/web-console/src/modules/OAuth2/utils.ts
+++ b/packages/web-console/src/modules/OAuth2/utils.ts
@@ -10,15 +10,15 @@ type TokenPayload = Partial<{
 }>
 
 const getBaseURL = (settings: Settings) => {
-    // if there is no host in settings, no need to construct base URL at all
-    if (!settings["acl.oidc.host"]) {
-        return "";
-    }
+  // if there is no host in settings, no need to construct base URL at all
+  if (!settings["acl.oidc.host"]) {
+    return ""
+  }
 
-    // if there is host in settings, we are in legacy mode, and we should construct the base URL
-    return `${settings["acl.oidc.tls.enabled"] ? "https" : "http"}://${
-        settings["acl.oidc.host"]
-    }:${settings["acl.oidc.port"]}`
+  // if there is host in settings, we are in legacy mode, and we should construct the base URL
+  return `${settings["acl.oidc.tls.enabled"] ? "https" : "http"}://${
+    settings["acl.oidc.host"]
+  }:${settings["acl.oidc.port"]}`
 }
 
 export const getAuthorisationURL = ({
@@ -82,4 +82,4 @@ export const getAuthToken = async (
 }
 
 export const hasUIAuth = (settings: Settings) =>
-    settings["acl.enabled"] && !settings["acl.basic.auth.realm.enabled"]
+  settings["acl.enabled"] && !settings["acl.basic.auth.realm.enabled"]

--- a/packages/web-console/src/modules/OAuth2/utils.ts
+++ b/packages/web-console/src/modules/OAuth2/utils.ts
@@ -24,11 +24,13 @@ const getBaseURL = (settings: Settings) => {
 export const getAuthorisationURL = ({
   settings,
   code_challenge = null,
+  state = null,
   login,
   redirect_uri,
 }: {
   settings: Settings
   code_challenge: string | null
+  state: string | null
   login?: boolean
   redirect_uri: string
 }) => {
@@ -43,6 +45,9 @@ export const getAuthorisationURL = ({
   if (code_challenge) {
     urlParams.append("code_challenge", code_challenge)
     urlParams.append("code_challenge_method", "S256")
+  }
+  if (state) {
+    urlParams.append("state", state)
   }
   if (login) {
     urlParams.append("prompt", "login")

--- a/packages/web-console/src/providers/AuthProvider.tsx
+++ b/packages/web-console/src/providers/AuthProvider.tsx
@@ -48,7 +48,7 @@ const initialState: { view: View; errorMessage?: string } = {
   view: View.loading,
 }
 
-const defaultValues = {
+const defaultValues: ContextProps = {
   sessionData: undefined,
   logout: () => {},
   refreshAuthToken: async () => ({} as AuthPayload),
@@ -80,12 +80,12 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
   const setAuthToken = (tokenResponse: AuthPayload, settings: Settings) => {
     if (tokenResponse.access_token) {
-      tokenResponse.groups_encoded_in_token = settings["acl.oidc.groups.encoded.in.token"]
-      tokenResponse.expires_at = getTokenExpirationDate(tokenResponse.expires_in).toString() // convert from the sec offset
-      setValue(
-        StoreKey.AUTH_PAYLOAD,
-        JSON.stringify(tokenResponse),
-      )
+      tokenResponse.groups_encoded_in_token =
+        settings["acl.oidc.groups.encoded.in.token"]
+      tokenResponse.expires_at = getTokenExpirationDate(
+        tokenResponse.expires_in,
+      ).toString() // convert from the sec offset
+      setValue(StoreKey.AUTH_PAYLOAD, JSON.stringify(tokenResponse))
       // if the token payload does not contain refresh token, token refresh has been disabled in
       // the OAuth2 provider, and we need to clear the refresh token in local storage
       setValue(StoreKey.AUTH_REFRESH_TOKEN, tokenResponse.refresh_token ?? "")
@@ -96,7 +96,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
           null,
           "",
           location.pathname +
-            location.search.replace(/[\?&]code=[^&]+/, "").replace(/^&/, "?"),
+            location.search.replace(/[?&]code=[^&]+/, "").replace(/^&/, "?"),
         )
     } else {
       const error = tokenResponse as unknown as OAuth2Error
@@ -194,7 +194,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
             const stateParam = urlParams.get("state")
             if (!stateParam || state !== stateParam) {
               dispatch({ view: View.loggedOut })
-              return;
+              return
             }
           }
 
@@ -205,7 +205,9 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
               code,
               code_verifier,
               client_id: settings["acl.oidc.client.id"],
-              redirect_uri: settings["acl.oidc.redirect.uri"] || window.location.origin + window.location.pathname,
+              redirect_uri:
+                settings["acl.oidc.redirect.uri"] ||
+                window.location.origin + window.location.pathname,
             })
             const tokenResponse = await response.json()
             setAuthToken(tokenResponse, settings)
@@ -237,9 +239,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
   const basicAuthLogin = async () => {
     // run a simple query to force basic auth by browser
-    const response = await fetch(
-      `exec?query=select 42`,
-    )
+    const response = await fetch(`exec?query=select 42`)
     if (response.status === 200) {
       dispatch({ view: View.ready })
     } else {

--- a/packages/web-console/src/providers/SettingsProvider/types.ts
+++ b/packages/web-console/src/providers/SettingsProvider/types.ts
@@ -15,6 +15,7 @@ export type Settings = Partial<{
   "acl.oidc.authorization.endpoint": string
   "acl.oidc.token.endpoint": string
   "acl.oidc.pkce.required": boolean
+  "acl.oidc.state.required": boolean
   "posthog.enabled": boolean
   "posthog.api.key": string
 }>

--- a/packages/web-console/src/utils/localStorage/types.ts
+++ b/packages/web-console/src/utils/localStorage/types.ts
@@ -26,6 +26,7 @@ export enum StoreKey {
   AUTH_PAYLOAD = "AUTH_PAYLOAD",
   AUTH_REFRESH_TOKEN = "AUTH_REFRESH_TOKEN",
   OAUTH_REDIRECT_COUNT = "oauth.redirect.count",
+  OAUTH_STATE = "oauth.state",
   PKCE_CODE_VERIFIER = "pkce.code.verifier",
   QUERY_TEXT = "query.text",
   EDITOR_LINE = "editor.line",


### PR DESCRIPTION
If the `state` parameter is enabled in settings (`acl.oidc.state.required=true`), the Web Console generates a state value, and sends it to the Authorization Server while requesting authorization code.
The `state` is expected to be sent back to the Web Console together with the authorization code, the Web Console checks if the value of the `state` parameter is the same.
If not, it sends the user to the logout screen.