### PR TITLE
fix(web-console): fix dodgy floating-point regex capturing words beginning with 'E'

### DIFF
--- a/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/language.ts
+++ b/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/language.ts
@@ -109,9 +109,9 @@ export const language: monaco.languages.IMonarchLanguage = {
       ],
     ],
     numbers: [
+      [/([+-]?\d+\.\d+[eE]?[+-]?\d+)/, "number"], // floating point number
       [/0[xX][0-9a-fA-F]*/, "number"], // hex integers
       [/[+-]?\d+((_)?\d+)*[Ll]?/, "number"], // integers
-      [/[+-]?\d*(\.\d*)?[Ee]/, "number"], // floating point number
     ],
     strings: [
       [/N'/, { token: "string", next: "@string" }],


### PR DESCRIPTION
With changes:

![image](https://github.com/user-attachments/assets/9fc48361-afcf-46f3-b40f-a09cdc1ce1cc)
