### PR TITLE
fix(ui): prevent login loop when token expires without a valid refresh token

### DIFF
--- a/packages/web-console/src/providers/AuthProvider.tsx
+++ b/packages/web-console/src/providers/AuthProvider.tsx
@@ -180,7 +180,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
             await refreshAuthToken(settings)
           } else {
             // if there is no refresh token, user has to re-authenticate to get fresh tokens
-            dispatch({ view: View.loggedOut })
+            logout()
           }
         } else {
           setSessionData(tokenResponse)
@@ -193,7 +193,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
             removeValue(StoreKey.OAUTH_STATE)
             const stateParam = urlParams.get("state")
             if (!stateParam || state !== stateParam) {
-              dispatch({ view: View.loggedOut })
+              logout()
               return
             }
           }


### PR DESCRIPTION
When the access token expires, and there is no refresh token, it is not enough to send the user to the logout screen.
We also have to clear the expired token from local storage.