### PR TITLE
release(web-console): 0.7.6

### DIFF
--- a/packages/web-console/CHANGELOG.md
+++ b/packages/web-console/CHANGELOG.md
@@ -16,6 +16,16 @@ and this project adheres to
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## 0.7.6 - 2025.02.27
+
+### Added
+
+- Add button to copy query plans and result sets to clipboard in markdown format [#393](https://github.com/questdb/ui/pull/393)
+
+### Fixed
+
+- Escape table name for SHOW CREATE TABLE [#398](https://github.com/questdb/ui/pull/398)
+
 ## 0.7.5 - 2025.02.13
 
 ### Fixed

--- a/packages/web-console/package.json
+++ b/packages/web-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@questdb/web-console",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "license": "Apache-2.0",
   "description": "QuestDB Console",
   "files": [


### PR DESCRIPTION
### Added

- Add button to copy query plans and result sets to clipboard in markdown format [#393](https://github.com/questdb/ui/pull/393)

### Fixed

- Escape table name for SHOW CREATE TABLE [#398](https://github.com/questdb/ui/pull/398)
