### PR TITLE
feat(web-console): add storage details, persistent expand states, symbol details

### DIFF
--- a/packages/browser-tests/cypress/integration/console/editor.spec.js
+++ b/packages/browser-tests/cypress/integration/console/editor.spec.js
@@ -438,7 +438,7 @@ describe("editor tabs", () => {
       const dragHandle = getTabDragHandleByTitle(title);
       cy.get(dragHandle).click();
       cy.getEditorContent().should("be.visible");
-      cy.typeQuery(`-- ${index + 1}`);
+      cy.typeQueryDirectly(`-- ${index + 1}`);
       cy.getEditorTabByTitle(title).within(() => {
         cy.get(".chrome-tab-close").click();
       });

--- a/packages/browser-tests/cypress/integration/console/editor.spec.js
+++ b/packages/browser-tests/cypress/integration/console/editor.spec.js
@@ -424,45 +424,6 @@ describe("editor tabs", () => {
     cy.getEditorTabByTitle("New updated name").should("be.visible");
   });
 
-  it("should close and archive tabs", () => {
-    cy.getEditorContent().should("be.visible");
-    cy.typeQueryDirectly("--1");
-
-    ["SQL 1", "SQL 2"].forEach((title) => {
-      cy.get(".new-tab-button").click();
-      const dragHandle = getTabDragHandleByTitle(title);
-      cy.get(dragHandle).should("be.visible");
-    });
-
-    ["SQL 1", "SQL 2"].forEach((title, index) => {
-      const dragHandle = getTabDragHandleByTitle(title);
-      cy.get(dragHandle).click();
-      cy.getEditorContent().should("be.visible");
-      cy.typeQueryDirectly(`-- ${index + 1}`);
-      cy.getEditorTabByTitle(title).within(() => {
-        cy.get(".chrome-tab-close").click();
-      });
-      cy.getEditorTabByTitle(title).should("not.exist");
-      cy.wait(2000);
-    });
-
-    cy.get(".chrome-tab").should("have.length", 1);
-
-    cy.getByDataHook("editor-tabs-history-button").click();
-    cy.getByDataHook("editor-tabs-history").should("be.visible");
-    cy.getByDataHook("editor-tabs-history-item").should("contain", "SQL 2");
-    // Restore closed tabs. "SQL 2" should be first, as it was closed last
-    cy.getByDataHook("editor-tabs-history-item").first().click();
-    cy.getEditorTabByTitle("SQL 2").should("be.visible");
-    cy.getByDataHook("editor-tabs-history-button").click();
-    cy.getByDataHook("editor-tabs-history-item").should("have.length", 1);
-    cy.getByDataHook("editor-tabs-history-item").should("not.contain", "SQL 2");
-    // Clear history
-    cy.getByDataHook("editor-tabs-history-clear").click();
-    cy.getByDataHook("editor-tabs-history-button").click();
-    cy.getByDataHook("editor-tabs-history-item").should("not.exist");
-  });
-
   it("should drag tabs", () => {
     cy.get(".new-tab-button").click();
     cy.get(".chrome-tab-was-just-added").should("not.exist");
@@ -490,6 +451,52 @@ describe("editor tabs", () => {
       expect($tabs.first()).to.contain("SQL");
       expect($tabs.last()).to.contain("SQL 1");
     });
+  });
+});
+
+describe("editor tabs history", () => {
+  before(() => {
+    cy.loadConsoleWithAuth();
+    cy.getEditorContent().should("be.visible");
+    cy.getEditorTabs().should("be.visible");
+  });
+
+  it("should close and archive tabs", () => {
+    cy.typeQuery("--1");
+
+    ["SQL 1", "SQL 2"].forEach((title) => {
+      cy.get(".new-tab-button").click();
+      const dragHandle = getTabDragHandleByTitle(title);
+      cy.get(dragHandle).should("be.visible");
+    });
+
+    ["SQL 1", "SQL 2"].forEach((title, index) => {
+      const dragHandle = getTabDragHandleByTitle(title);
+      cy.get(dragHandle).click();
+      cy.getEditorContent().should("be.visible");
+      cy.typeQuery(`-- ${index + 1}`);
+      cy.getEditorTabByTitle(title).within(() => {
+        cy.get(".chrome-tab-close").click();
+      });
+      cy.getEditorTabByTitle(title).should("not.exist");
+      cy.wait(2000);
+    });
+
+    cy.get(".chrome-tab").should("have.length", 1);
+
+    cy.getByDataHook("editor-tabs-history-button").click();
+    cy.getByDataHook("editor-tabs-history").should("be.visible");
+    cy.getByDataHook("editor-tabs-history-item").should("contain", "SQL 2");
+    // Restore closed tabs. "SQL 2" should be first, as it was closed last
+    cy.getByDataHook("editor-tabs-history-item").first().click();
+    cy.getEditorTabByTitle("SQL 2").should("be.visible");
+    cy.getByDataHook("editor-tabs-history-button").click();
+    cy.getByDataHook("editor-tabs-history-item").should("have.length", 1);
+    cy.getByDataHook("editor-tabs-history-item").should("not.contain", "SQL 2");
+    // Clear history
+    cy.getByDataHook("editor-tabs-history-clear").click();
+    cy.getByDataHook("editor-tabs-history-button").click();
+    cy.getByDataHook("editor-tabs-history-item").should("not.exist");
   });
 });
 

--- a/packages/browser-tests/cypress/integration/console/schema.spec.js
+++ b/packages/browser-tests/cypress/integration/console/schema.spec.js
@@ -29,6 +29,48 @@ describe("questdb schema with working tables", () => {
     cy.getByDataHook("schema-row-error-icon").should("not.exist");
   });
 
+  it("should show the symbol column details", () => {
+    cy.getByDataHook("schema-table-title").contains("btc_trades").click();
+    cy.getByDataHook("schema-folder-title").contains("Columns").click();
+    cy.getByDataHook("schema-column-title").contains("symbol").click();
+
+    cy.getByDataHook("schema-row").should(($el) => {
+      expect($el.text()).to.include("Indexed:");
+      expect($el.text()).to.include("No");
+    });
+
+    cy.getByDataHook("schema-row").should(($el) => {
+      expect($el.text()).to.include("Symbol capacity:");
+      expect($el.text()).to.include("256");
+    });
+
+    cy.getByDataHook("schema-row").should(($el) => {
+      expect($el.text()).to.include("Cached:");
+      expect($el.text()).to.include("Yes");
+    });
+
+    // collapse table
+    cy.getByDataHook("schema-table-title").contains("btc_trades").click();
+  });
+
+  it("should show the storage details", () => {
+    cy.getByDataHook("schema-table-title").contains("btc_trades").click();
+    cy.getByDataHook("schema-row").contains("Storage details").click();
+
+    cy.getByDataHook("schema-row").should(($el) => {
+      expect($el.text()).to.include("WAL:");
+      expect($el.text()).to.include("Enabled");
+    });
+
+    cy.getByDataHook("schema-row").should(($el) => {
+      expect($el.text()).to.include("Partitioning:");
+      expect($el.text()).to.include("By day");
+    });
+
+    // collapse table
+    cy.getByDataHook("schema-table-title").contains("btc_trades").click();
+  });
+
   it("should filter the table with input field", () => {
     // Table name search
     cy.get('input[name="table_filter"]').type("btc_trades");
@@ -78,7 +120,6 @@ describe("questdb schema with suspended tables with Linux OS error codes", () =>
   });
   beforeEach(() => {
     cy.loadConsoleWithAuth();
-    cy.expandTables();
   });
 
   it("should work with 2 suspended tables, btc_trades and ecommerce_stats", () => {
@@ -152,7 +193,6 @@ describe("table select UI", () => {
   });
   beforeEach(() => {
     cy.loadConsoleWithAuth();
-    cy.expandTables();
   });
 
   it("should show select ui on click", () => {

--- a/packages/browser-tests/cypress/integration/console/schema.spec.js
+++ b/packages/browser-tests/cypress/integration/console/schema.spec.js
@@ -21,6 +21,13 @@ describe("questdb schema with working tables", () => {
     });
     cy.refreshSchema();
   });
+
+  afterEach(() => {
+    cy.collapseTables();
+    cy.refreshSchema();
+    cy.expandTables();
+  });
+
   it("should show all the tables when there are no suspended", () => {
     tables.forEach((table) => {
       cy.getByDataHook("schema-table-title").should("contain", table);
@@ -48,9 +55,6 @@ describe("questdb schema with working tables", () => {
       expect($el.text()).to.include("Cached:");
       expect($el.text()).to.include("Yes");
     });
-
-    // collapse table
-    cy.getByDataHook("schema-table-title").contains("btc_trades").click();
   });
 
   it("should show the storage details", () => {
@@ -66,9 +70,6 @@ describe("questdb schema with working tables", () => {
       expect($el.text()).to.include("Partitioning:");
       expect($el.text()).to.include("By day");
     });
-
-    // collapse table
-    cy.getByDataHook("schema-table-title").contains("btc_trades").click();
   });
 
   it("should filter the table with input field", () => {
@@ -292,7 +293,7 @@ describe("materialized views", () => {
     cy.getByDataHook("schema-matview-title").should("contain", "btc_trades_mv");
   });
 
-  it("should show the base table and copy DDL for a materialized view", () => {
+  it("should show the base table and copy schema for a materialized view", () => {
     cy.expandMatViews();
     cy.getByDataHook("schema-matview-title").contains("btc_trades_mv").click();
     cy.getByDataHook("schema-row").contains("Base tables").click();

--- a/packages/web-console/src/components/Tree/index.tsx
+++ b/packages/web-console/src/components/Tree/index.tsx
@@ -26,8 +26,34 @@ import React, { useState, useCallback, useEffect, useRef } from "react"
 import Row from "../../scenes/Schema/Row"
 import styled from "styled-components"
 import { WrapWithIf } from "../"
+import { color } from "../../utils/"
 
-export type TreeNodeKind = "column" | "table" | "matview" | "folder"
+const LeafWrapper = styled.div`
+  position: relative;
+  display: flex;
+  margin-left: 2rem;
+  flex-direction: column;
+
+  &:hover {
+    &:before {
+      opacity: 1;
+    }
+  }
+
+  &:before {
+    position: absolute;
+    height: 100%;
+    width: 2px;
+    left: -0.4rem;
+    top: 0;
+    opacity: 0;
+    transition: .2s;
+    content: "";
+    background: ${color("gray1")};
+  }
+`
+
+export type TreeNodeKind = "column" | "table" | "matview" | "folder" | "detail"
 
 export type TreeNodeRenderParams = {
   toggleOpen: ToggleOpen
@@ -77,7 +103,7 @@ const Leaf = (leaf: TreeNode) => {
     onOpen,
     render,
     children: initialChildren = [],
-    wrapper,
+    wrapper = LeafWrapper,
   } = leaf
   const [open, setOpen] = useState(initiallyOpen ?? false)
   const [loading, setLoading] = useState(false)

--- a/packages/web-console/src/scenes/Schema/Row/index.tsx
+++ b/packages/web-console/src/scenes/Schema/Row/index.tsx
@@ -24,7 +24,7 @@
 
 import React, { MouseEvent, useContext, useState, useEffect, useRef } from "react"
 import styled from "styled-components"
-import { Rocket } from "@styled-icons/boxicons-regular"
+import { Rocket, InfoCircle } from "@styled-icons/boxicons-regular"
 import { SortDown } from "@styled-icons/boxicons-regular"
 import { ChevronRight } from "@styled-icons/boxicons-solid"
 import { Error as ErrorIcon } from "@styled-icons/boxicons-regular"
@@ -34,7 +34,7 @@ import { OneHundredTwentyThree, CalendarMinus, Globe, GeoAlt, Type as CharIcon }
 import type { TreeNodeKind } from "../../../components/Tree"
 import * as QuestDB from "../../../utils/questdb"
 import Highlighter from "react-highlight-words"
-import { TableIcon, MaterializedViewIcon } from "../table-icon"
+import { TableIcon } from "../table-icon"
 import { Box } from "@questdb/react-components"
 import { Text, TransitionDuration, IconWithTooltip, spinAnimation } from "../../../components"
 import { color } from "../../../utils"
@@ -111,6 +111,10 @@ const StyledTitle = styled(Title)`
     background-color: #45475a;
     color: ${({ theme }) => theme.color.foreground};
   }
+
+  svg {
+    color: ${color("cyan")};
+  }
 `
 
 const TableActions = styled.span`
@@ -133,11 +137,13 @@ const Spacer = styled.span`
 const RocketIcon = styled(Rocket)`
   color: ${color("orange")};
   margin-right: 1rem;
+  flex-shrink: 0;
 `
 
 const SortDownIcon = styled(SortDown)`
   color: ${color("green")};
   margin-right: 0.8rem;
+  flex-shrink: 0;
 `
 
 const ChevronRightIcon = styled(ChevronRight)`
@@ -155,17 +161,6 @@ const ChevronDownIcon = styled(ChevronRightIcon)`
 const DotIcon = styled(CheckboxBlankCircle)`
   color: ${color("gray2")};
   margin-right: 1rem;
-`
-
-const TruncatedBox = styled(Box)`
-  display: inline;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-  cursor: default;
-  font-style: italic;
-  color: ${color("gray2")};
-  text-align: right;
 `
 
 const Loader = styled(Loader4)`
@@ -366,6 +361,9 @@ const Row = ({
                 isMaterializedView={kind === "matview"}
               />
             )}
+            {kind === "detail" && (
+              <InfoCircle size="14px" />
+            )}
             <Highlighter
               highlightClassName="highlight"
               searchWords={[query ?? ""]}
@@ -380,7 +378,7 @@ const Row = ({
           )}
 
           {kind === "detail" && (
-            <Text color="gray2" transform="lowercase">
+            <Text color="gray2">
               {value}
             </Text>
           )}

--- a/packages/web-console/src/scenes/Schema/Row/index.tsx
+++ b/packages/web-console/src/scenes/Schema/Row/index.tsx
@@ -70,7 +70,6 @@ const Type = styled(Text)`
   display: flex;
   align-items: center;
   flex: 0;
-  transition: opacity ${TransitionDuration.REG}ms;
 `
 
 const Title = styled(Text)`
@@ -87,7 +86,6 @@ const Wrapper = styled.div<{ $isExpandable: boolean, $includesSymbol?: boolean }
   padding: 0.5rem 0;
   padding-left: 1rem;
   padding-right: 1rem;
-  transition: background ${TransitionDuration.REG}ms;
   user-select: none;
   ${({ $isExpandable }) => $isExpandable && `
     cursor: pointer;

--- a/packages/web-console/src/scenes/Schema/VirtualTables/index.tsx
+++ b/packages/web-console/src/scenes/Schema/VirtualTables/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo, useState, useCallback, useRef } from 'react';
+import React, { FC, useEffect, useMemo, useState, useRef } from 'react';
 import { GroupedVirtuoso } from 'react-virtuoso';
 import styled from 'styled-components';
 import { Loader3 } from '@styled-icons/remix-line';
@@ -82,10 +82,6 @@ export const VirtualTables: FC<VirtualTablesProps> = ({
   const forceUpdate = () => setToggle(toggle => !toggle);
   const tablesExpanded = getSectionExpanded(TABLES_GROUP_KEY)
   const matViewsExpanded = getSectionExpanded(MATVIEWS_GROUP_KEY)
-
-  const clearColumnsCache = useCallback((tableName: string) => {
-    delete columnsCache.current[tableName];
-  }, []);
 
   const { groups, groupCounts, allTables } = useMemo(() => {
     const filtered = tables.filter((table: QuestDB.Table) => {
@@ -205,9 +201,7 @@ export const VirtualTables: FC<VirtualTablesProps> = ({
             selectOpen={selectOpen}
             selected={selected}
             onSelectToggle={handleSelectToggle}
-            cachedColumns={columnsCache.current[table.table_name]}
-            onCacheColumns={(columns) => columnsCache.current[table.table_name] = columns}
-            onClearColumnsCache={clearColumnsCache}
+            columnsCache={columnsCache}
             path={`${table.matView ? MATVIEWS_GROUP_KEY : TABLES_GROUP_KEY}:${table.table_name}`}
           />
         )

--- a/packages/web-console/src/scenes/Schema/VirtualTables/index.tsx
+++ b/packages/web-console/src/scenes/Schema/VirtualTables/index.tsx
@@ -125,6 +125,13 @@ export const VirtualTables: FC<VirtualTablesProps> = ({
     }
   }, [tables, query, filterSuspendedOnly, walTables, tablesExpanded, matViewsExpanded])
 
+  useEffect(() => {
+    if (!tablesExpanded) {
+      setSectionExpanded(TABLES_GROUP_KEY, true)
+      forceUpdate()
+    }
+  }, [])
+
   if (state.view === View.loading) {
     return <Loading />
   }

--- a/packages/web-console/src/scenes/Schema/VirtualTables/index.tsx
+++ b/packages/web-console/src/scenes/Schema/VirtualTables/index.tsx
@@ -208,6 +208,7 @@ export const VirtualTables: FC<VirtualTablesProps> = ({
             cachedColumns={columnsCache.current[table.table_name]}
             onCacheColumns={(columns) => columnsCache.current[table.table_name] = columns}
             onClearColumnsCache={clearColumnsCache}
+            path={`${table.matView ? MATVIEWS_GROUP_KEY : TABLES_GROUP_KEY}:${table.table_name}`}
           />
         )
       }}

--- a/packages/web-console/src/scenes/Schema/index.tsx
+++ b/packages/web-console/src/scenes/Schema/index.tsx
@@ -346,13 +346,13 @@ const Schema = ({
         <Panel.Header
           afterTitle={
             <div style={{ display: "flex", marginRight: "1rem", justifyContent: "space-between", flex: 1 }}>
-                <Toolbar
-                  suspendedTablesCount={
-                    walTables?.filter((t) => t.suspended).length ?? 0
-                  }
-                  filterSuspendedOnly={filterSuspendedOnly}
-                  setFilterSuspendedOnly={setFilterSuspendedOnly}
-                />
+              <Toolbar
+                suspendedTablesCount={
+                  walTables?.filter((t) => t.suspended).length ?? 0
+                }
+                filterSuspendedOnly={filterSuspendedOnly}
+                setFilterSuspendedOnly={setFilterSuspendedOnly}
+              />
               {tables && (
                 <Box align="center" gap="0">
                   {selectOpen && (

--- a/packages/web-console/src/scenes/Schema/localStorageUtils.ts
+++ b/packages/web-console/src/scenes/Schema/localStorageUtils.ts
@@ -1,0 +1,40 @@
+const STORAGE_KEY_PREFIX = 'questdb:expanded:';
+export const TABLES_GROUP_KEY = `${STORAGE_KEY_PREFIX}tables`;
+export const MATVIEWS_GROUP_KEY = `${STORAGE_KEY_PREFIX}matviews`;
+
+const getItemFromStorage = (key: string, defaultValue = false): boolean => {
+  try {
+    const value = localStorage.getItem(key);
+    return value === null ? defaultValue : value === 'true';
+  } catch (e) {
+    return defaultValue;
+  }
+};
+
+const setItemToStorage = (key: string, value: boolean): void => {
+  try {
+    localStorage.setItem(key, value ? 'true' : 'false');
+    if (!value) {
+      Object.keys(localStorage).filter(k => k.startsWith(key)).forEach(k => localStorage.removeItem(k));
+    }
+  } catch (e) {
+    console.warn('Failed to save to localStorage:', e);
+  }
+};
+
+export const getTableKey = (tableName: string): string => `${TABLES_GROUP_KEY}:${tableName}`;
+export const getMatViewKey = (tableName: string): string => `${MATVIEWS_GROUP_KEY}:${tableName}`;
+export const getFolderKey = (kind: 'table' | 'matview', tableName: string, folderName: string): string => 
+  `${kind === 'table' ? TABLES_GROUP_KEY : MATVIEWS_GROUP_KEY}:${tableName}:${folderName.toLowerCase().replace(/\s+/g, '')}`;
+
+export const getSectionExpanded = (sectionKey: string): boolean => getItemFromStorage(sectionKey);
+export const setSectionExpanded = (sectionKey: string, expanded: boolean): void => setItemToStorage(sectionKey, expanded)
+
+export const getTableExpanded = (tableName: string): boolean => getItemFromStorage(getTableKey(tableName));
+export const setTableExpanded = (tableName: string, expanded: boolean): void => setItemToStorage(getTableKey(tableName), expanded);
+
+export const getMatViewExpanded = (tableName: string): boolean => getItemFromStorage(getMatViewKey(tableName));
+export const setMatViewExpanded = (tableName: string, expanded: boolean): void => setItemToStorage(getMatViewKey(tableName), expanded);
+
+export const getFolderExpanded = (kind: 'table' | 'matview', tableName: string, folderName: string): boolean => getItemFromStorage(getFolderKey(kind, tableName, folderName));
+export const setFolderExpanded = (kind: 'table' | 'matview', tableName: string, folderName: string, expanded: boolean): void => setItemToStorage(getFolderKey(kind, tableName, folderName), expanded);

--- a/packages/web-console/src/scenes/Schema/localStorageUtils.ts
+++ b/packages/web-console/src/scenes/Schema/localStorageUtils.ts
@@ -2,7 +2,7 @@ const STORAGE_KEY_PREFIX = 'questdb:expanded:';
 export const TABLES_GROUP_KEY = `${STORAGE_KEY_PREFIX}tables`;
 export const MATVIEWS_GROUP_KEY = `${STORAGE_KEY_PREFIX}matviews`;
 
-const getItemFromStorage = (key: string, defaultValue = false): boolean => {
+export const getItemFromStorage = (key: string, defaultValue = false): boolean => {
   try {
     const value = localStorage.getItem(key);
     return value === null ? defaultValue : value === 'true';
@@ -11,7 +11,7 @@ const getItemFromStorage = (key: string, defaultValue = false): boolean => {
   }
 };
 
-const setItemToStorage = (key: string, value: boolean): void => {
+export const setItemToStorage = (key: string, value: boolean): void => {
   try {
     localStorage.setItem(key, value ? 'true' : 'false');
     if (!value) {
@@ -22,19 +22,5 @@ const setItemToStorage = (key: string, value: boolean): void => {
   }
 };
 
-export const getTableKey = (tableName: string): string => `${TABLES_GROUP_KEY}:${tableName}`;
-export const getMatViewKey = (tableName: string): string => `${MATVIEWS_GROUP_KEY}:${tableName}`;
-export const getFolderKey = (kind: 'table' | 'matview', tableName: string, folderName: string): string => 
-  `${kind === 'table' ? TABLES_GROUP_KEY : MATVIEWS_GROUP_KEY}:${tableName}:${folderName.toLowerCase().replace(/\s+/g, '')}`;
-
 export const getSectionExpanded = (sectionKey: string): boolean => getItemFromStorage(sectionKey);
 export const setSectionExpanded = (sectionKey: string, expanded: boolean): void => setItemToStorage(sectionKey, expanded)
-
-export const getTableExpanded = (tableName: string): boolean => getItemFromStorage(getTableKey(tableName));
-export const setTableExpanded = (tableName: string, expanded: boolean): void => setItemToStorage(getTableKey(tableName), expanded);
-
-export const getMatViewExpanded = (tableName: string): boolean => getItemFromStorage(getMatViewKey(tableName));
-export const setMatViewExpanded = (tableName: string, expanded: boolean): void => setItemToStorage(getMatViewKey(tableName), expanded);
-
-export const getFolderExpanded = (kind: 'table' | 'matview', tableName: string, folderName: string): boolean => getItemFromStorage(getFolderKey(kind, tableName, folderName));
-export const setFolderExpanded = (kind: 'table' | 'matview', tableName: string, folderName: string, expanded: boolean): void => setItemToStorage(getFolderKey(kind, tableName, folderName), expanded);

--- a/packages/web-console/src/scenes/Schema/table-icon.tsx
+++ b/packages/web-console/src/scenes/Schema/table-icon.tsx
@@ -1,19 +1,16 @@
-import { IconWithTooltip } from "../../components"
-import React from "react"
+import React, { FC } from "react"
 import styled from "styled-components"
-import * as QuestDB from "../../utils/questdb"
 import { Table } from "@styled-icons/remix-line"
-import { Box } from "@questdb/react-components"
+import { color } from '../../utils'
 
-type Props = {
-  partitionBy?: QuestDB.PartitionBy
+type TableIconProps = {
   walEnabled?: boolean
+  isPartitioned?: boolean
+  isMaterializedView?: boolean
 }
 
-const WHITE = "#f8f8f2"
-
-const WIDTH = "1.5rem"
-const HEIGHT = "1.5rem"
+const WIDTH = "1.4rem"
+const HEIGHT = "1.4rem"
 
 const Root = styled.div`
   display: flex;
@@ -21,122 +18,56 @@ const Root = styled.div`
   width: ${WIDTH};
   height: ${HEIGHT};
   position: relative;
-  color: ${WHITE};
   flex-shrink: 0;
-`
-
-const PartitionLetter = styled.span`
-  width: 100%;
-  height: 100%;
-  text-align: center;
-  font-size: 1rem;
-  line-height: ${HEIGHT};
-`
-
-const Icon = styled.div`
-  position: absolute;
-  width: ${WIDTH};
-  height: ${HEIGHT};
-  border: 1px ${WHITE} solid;
-  border-radius: 2px;
+  svg {
+    color: ${color("cyan")};
+  }
 `
 
 const Asterisk = styled.span`
   position: absolute;
   top: -0.6rem;
-  right: -0.5rem;
+  right: -0.3rem;
   font-size: 1rem;
   line-height: 1.8rem;
-  color: #f1fa8c;
+  color: ${color("orange")};
 `
 
-const HLine = styled.div`
-  position: absolute;
-  width: 100%;
-  height: 0.1rem;
-  background: WHITE;
-  top: 0.4rem;
-`
+const NonPartitionedTableIcon = ({ height = "14px", width = "14px" }) => (
+  <svg viewBox="0 0 24 24" height={height} width={width} fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+    <path d="M3 3h18a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1zM4 8h16V5H4v3zM4 10h16v9H4v-9z" fill-rule="evenodd" clip-rule="evenodd"/>
+  </svg>
+)
 
-const VLine = styled.div`
-  position: absolute;
-  width: 0.1rem;
-  height: calc(${HEIGHT} - 0.5rem);
-  background: WHITE;
-  top: 0.4rem;
-`
+export const MaterializedViewIcon = ({ height = "14px", width = "14px" }) => (
+  <svg
+    viewBox="0 0 28 28"
+    height={height}
+    width={width}
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g stroke="currentColor" strokeWidth="2" fill="none" transform="translate(-2, -2)">
+      <line x1="3" y1="4" x2="22" y2="4" />
+      <line x1="4" y1="4" x2="4" y2="22" />
+      <line x1="21" y1="4" x2="21" y2="11" />
+      <line x1="4" y1="21" x2="11" y2="21" />
+    </g>
+    <g transform="translate(6,6)" fill="currentColor">
+      <path fill="none" d="M0 0h24v24H0z" />
+      <path d="M4 8h16V5H4v3zm10 11v-9h-4v9h4zm2 0h4v-9h-4v9zm-8 0v-9H4v9h4zM3 3h18a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1z" />
+    </g>
+  </svg>
+)
 
-const VLine1 = styled(VLine)`
-  left: 0.6rem;
-`
-
-const VLine2 = styled(VLine)`
-  left: 1.3rem;
-`
-
-const IconComponent = ({
-  isPartitioned,
-  partitionBy,
-  walEnabled,
-}: Props & { isPartitioned: boolean }) => (
+export const TableIcon: FC<TableIconProps> = ({ walEnabled, isPartitioned, isMaterializedView }) => (
   <Root>
-    {!walEnabled && <Asterisk>*</Asterisk>}
-    <Icon>
-      {!isPartitioned && (
-        <>
-          <HLine />
-          <VLine1 />
-          <VLine2 />
-        </>
-      )}
-    </Icon>
-    {isPartitioned && partitionBy && (
-      <PartitionLetter>{partitionBy.substr(0, 1)}</PartitionLetter>
+    {isMaterializedView ? (
+      <MaterializedViewIcon height="14px" width="14px" />
+    ) : (
+      <>
+        {!walEnabled && <Asterisk>*</Asterisk>}
+        {isPartitioned ? <Table size="14px" /> : <NonPartitionedTableIcon height="14px" />}
+      </>
     )}
   </Root>
 )
-
-export const TableIcon = ({ partitionBy, walEnabled }: Props) => {
-  const isPartitioned = (partitionBy && partitionBy !== "NONE") || false
-  let tooltipLines = []
-  if (isPartitioned && partitionBy) {
-    tooltipLines.push(
-      `${partitionBy.substr(0, 1)}: Partitioned by ${partitionBy}`,
-    )
-  } else {
-    tooltipLines.push(
-      <Box align="center" gap="0">
-        <Table size="14px" />
-        <span>: Not partitioned</span>
-      </Box>,
-    )
-  }
-
-  if (!walEnabled) {
-    tooltipLines.push("*: non-WAL (Legacy)")
-  }
-
-  return isPartitioned || !walEnabled ? (
-    <IconWithTooltip
-      icon={
-        <span>
-          <IconComponent
-            isPartitioned={isPartitioned}
-            partitionBy={partitionBy}
-            walEnabled={walEnabled}
-          />
-        </span>
-      }
-      tooltip={tooltipLines.map((line, i) => (
-        <div key={i}>{line}</div>
-      ))}
-      placement="bottom"
-    />
-  ) : (
-    <IconComponent
-      isPartitioned={isPartitioned}
-      partitionBy={partitionBy}
-      walEnabled={walEnabled}
-    />
-  )
-}

--- a/packages/web-console/src/scenes/Schema/table-icon.tsx
+++ b/packages/web-console/src/scenes/Schema/table-icon.tsx
@@ -35,7 +35,7 @@ const Asterisk = styled.span`
 
 const NonPartitionedTableIcon = ({ height = "14px", width = "14px" }) => (
   <svg viewBox="0 0 24 24" height={height} width={width} fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-    <path d="M3 3h18a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1zM4 8h16V5H4v3zM4 10h16v9H4v-9z" fill-rule="evenodd" clip-rule="evenodd"/>
+    <path d="M3 3h18a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1zM4 8h16V5H4v3zM4 10h16v9H4v-9z" fillRule="evenodd" clipRule="evenodd"/>
   </svg>
 )
 

--- a/packages/web-console/src/styles/_grid.scss
+++ b/packages/web-console/src/styles/_grid.scss
@@ -67,7 +67,6 @@ $col-resize-ghost-z-index: ($panel-left-z-index + 1);
   position: absolute;
   left: 0;
   right: 0;
-  transition: .2s;
 }
 
 $active-row-background: #44475a;

--- a/packages/web-console/src/styles/_grid.scss
+++ b/packages/web-console/src/styles/_grid.scss
@@ -67,9 +67,10 @@ $col-resize-ghost-z-index: ($panel-left-z-index + 1);
   position: absolute;
   left: 0;
   right: 0;
+  transition: .2s;
 }
 
-$active-row-background: #323342;
+$active-row-background: #44475a;
 
 .qg-r-hover {
   background-color: $active-row-background;


### PR DESCRIPTION
- Adds new icon for non-partitioned tables
- Adds new icon for materialized views
- Adds new icon for symbol type columns
- Adds "Indexed", "Symbol capacity", and "Cached" information under symbol type columns
- Adds "storage details" folder under tables
- Adds "base tables" folder under materialized views
- Fixes geohash column type icon
- Fixes the issue about tables/materialized views being collapsed after a scroll