### PR TITLE
fix(web-console): open a new tab when query param exists and metrics tab is open

### DIFF
--- a/packages/browser-tests/cypress/integration/console/editor.spec.js
+++ b/packages/browser-tests/cypress/integration/console/editor.spec.js
@@ -176,6 +176,24 @@ describe("&query URL param", () => {
       .invoke("text")
       .should("match", /hello.world$/); // not matching on appendedQuery, because query should be selected for which Monaco adds special chars between words
   });
+
+  it("should open a new editor tab when the last active buffer is a metrics buffer", () => {
+    // when
+    cy.getByDataHook("schema-add-metrics-button").click();
+    // then
+    cy.getByDataHook("metrics-root").should("be.visible");
+
+    // when
+    cy.visit(`${baseUrl}?query=${encodeURIComponent("select x from long_sequence(1)")}`);
+
+    // then
+    cy.getEditorContent().should("be.visible");
+    cy.getEditorTabs().should("have.length", 3);
+    cy.getEditorTabByTitle("Metrics 1").should("be.visible");
+    cy.getEditorTabByTitle("Query")
+      .should("be.visible")
+      .should("have.attr", "active");
+  });
 });
 
 describe("autocomplete", () => {

--- a/packages/web-console/src/providers/EditorProvider/index.tsx
+++ b/packages/web-console/src/providers/EditorProvider/index.tsx
@@ -205,9 +205,11 @@ export const EditorProvider = ({ children }: PropsWithChildren<{}>) => {
 
   const updateBuffer: EditorContext["updateBuffer"] = async (id, payload) => {
     const editorViewState = editorRef.current?.saveViewState()
+    const bufferType = await bufferStore.getBufferTypeById(id)
+
     await bufferStore.update(id, {
       ...payload,
-      ...(editorViewState && !payload?.metricsViewState
+      ...(editorViewState && bufferType === BufferType.SQL
         ? { editorViewState }
         : {}),
     })

--- a/packages/web-console/src/scenes/Editor/Monaco/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/index.tsx
@@ -317,6 +317,8 @@ const MonacoEditor = () => {
         // otherwise, append the query
       } else {
         appendQuery(editor, query, { appendAt: "end" })
+        const newValue = editor.getValue()
+        updateBuffer(activeBuffer.id as number, { value: newValue })
       }
     }
 

--- a/packages/web-console/src/scenes/Editor/index.tsx
+++ b/packages/web-console/src/scenes/Editor/index.tsx
@@ -22,7 +22,7 @@
  *
  ******************************************************************************/
 
-import React, { CSSProperties, forwardRef, Ref } from "react"
+import React, { CSSProperties, forwardRef, Ref, useEffect } from "react"
 import styled from "styled-components"
 
 import { PaneWrapper } from "../../components"
@@ -46,7 +46,15 @@ const Editor = ({
   innerRef,
   ...rest
 }: Props & { innerRef: Ref<HTMLDivElement> }) => {
-  const { activeBuffer } = useEditor()
+  const { activeBuffer, addBuffer, setActiveBuffer } = useEditor()
+  
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const query = params.get("query")
+    if (query && activeBuffer.metricsViewState) {
+      addBuffer({ label: "Query" }).then(setActiveBuffer)
+    }
+  }, [])
 
   return (
     <EditorPaneWrapper ref={innerRef} {...rest}>

--- a/packages/web-console/src/store/buffers.ts
+++ b/packages/web-console/src/store/buffers.ts
@@ -151,6 +151,9 @@ export const bufferStore = {
       .equals("activeBufferId")
       .modify({ value: id }),
 
+  getBufferTypeById: (id: number) =>
+    db.buffers.get(id).then((buffer) => buffer?.metricsViewState ? BufferType.METRICS : BufferType.SQL),
+
   update: (id: number, buffer: Partial<Buffer>) =>
     db.buffers.update(id, buffer),
 


### PR DESCRIPTION
- Fixes the problem about incorrectly saving `editorViewState` in a metrics buffer when buffers are updated via reorder/close etc.
- Fixes unresponsiveness when web console gets `query` query param, and the active buffer is a metrics tab