### PR TITLE
fix(web-console): jit compiled icon shrink problem and notifications height

### DIFF
--- a/packages/browser-tests/cypress/integration/console/grid.spec.js
+++ b/packages/browser-tests/cypress/integration/console/grid.spec.js
@@ -66,7 +66,10 @@ describe("questdb grid", () => {
 
     cy.getGridViewport().scrollTo("bottom");
     cy.wait(100);
-    cy.getCollapsedNotifications().should("contain", "HTTP 400 (Bad request)");
+    cy.getCollapsedNotifications().should(
+      "contain",
+      "simulated cairo exception"
+    );
   });
 
   it("copy cell into the clipboard", () => {

--- a/packages/browser-tests/cypress/integration/console/schema.spec.js
+++ b/packages/browser-tests/cypress/integration/console/schema.spec.js
@@ -465,9 +465,15 @@ describe("materialized views", () => {
       (req) => {
         req.continue((res) => {
           if (res.body && res.body.dataset && res.body.dataset.length > 0) {
-            // [view_name, refresh_type, base_table_name, last_refresh_timestamp, view_sql, view_table_dir_name, invalidation_reason, view_status, base_table_txn, applied_base_table_txn]
-            res.body.dataset[0][6] = "this is an invalidation reason";
-            res.body.dataset[0][7] = "invalid";
+            const viewStatusIndex = res.body.columns.findIndex(
+              (c) => c.name === "view_status"
+            );
+            const invalidationReasonIndex = res.body.columns.findIndex(
+              (c) => c.name === "invalidation_reason"
+            );
+            res.body.dataset[0][viewStatusIndex] = "invalid";
+            res.body.dataset[0][invalidationReasonIndex] =
+              "this is an invalidation reason";
           }
           return res;
         });

--- a/packages/web-console/src/scenes/Editor/Monaco/query-in-notification.tsx
+++ b/packages/web-console/src/scenes/Editor/Monaco/query-in-notification.tsx
@@ -15,10 +15,10 @@ export const QueryInNotification = ({ query }: { query: string }) => {
 
   return (
     <Box gap="1rem" align="center">
+      <CopyButton text={query} iconOnly={true} />
       <StyledText color="foreground" title={query}>
         {query}
       </StyledText>
-      <CopyButton text={query} iconOnly={true} />
     </Box>
   )
 }

--- a/packages/web-console/src/scenes/Editor/QueryResult/index.tsx
+++ b/packages/web-console/src/scenes/Editor/QueryResult/index.tsx
@@ -41,7 +41,6 @@ type Props = Timings &
 const Wrapper = styled.div`
   display: flex;
   align-items: center;
-  margin-top: 0.2rem;
   overflow: hidden;
   ${collapseTransition};
 

--- a/packages/web-console/src/scenes/Editor/QueryResult/index.tsx
+++ b/packages/web-console/src/scenes/Editor/QueryResult/index.tsx
@@ -98,7 +98,7 @@ const QueryResult = ({ compiler, authentication, count, execute, fetch, rowCount
     <Wrapper _height={95} duration={TransitionDuration.FAST}>
       <div>
         <Text color="gray2">
-          {rowCount.toLocaleString()} row{rowCount > 1 ? "s" : ""} in&nbsp;
+          {rowCount.toLocaleString()} row{(rowCount > 1 || rowCount === 0) ? "s" : ""} in&nbsp;
           {formatTiming(fetch)}
         </Text>
       </div>

--- a/packages/web-console/src/scenes/Notifications/Notification/SuccessNotification/index.tsx
+++ b/packages/web-console/src/scenes/Notifications/Notification/SuccessNotification/index.tsx
@@ -39,6 +39,7 @@ const CheckmarkOutlineIcon = styled(CheckmarkOutline)`
 
 const ZapIcon = styled(Zap)`
   color: ${color("yellow")};
+  flex-shrink: 0;
 `
 
 export const SuccessNotification = (props: NotificationShape) => {

--- a/packages/web-console/src/scenes/Notifications/Notification/styles.tsx
+++ b/packages/web-console/src/scenes/Notifications/Notification/styles.tsx
@@ -38,6 +38,11 @@ export const Wrapper = styled.div<{
   flex-shrink: 0;
   width: 100%;
   overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none; 
+  &::-webkit-scrollbar {
+    display: none;
+  }
 
   ${bezierTransition};
 `

--- a/packages/web-console/src/scenes/Notifications/Notification/styles.tsx
+++ b/packages/web-console/src/scenes/Notifications/Notification/styles.tsx
@@ -25,7 +25,6 @@
 import styled from "styled-components"
 import { NotificationShape } from "types"
 import { bezierTransition } from "../../../components"
-import { color } from "../../../utils"
 
 export const Wrapper = styled.div<{
   isMinimized: NotificationShape["isMinimized"]
@@ -33,14 +32,12 @@ export const Wrapper = styled.div<{
   display: flex;
   align-items: center;
   border-right: none;
-  width: 100%;
-  overflow: hidden;
   height: ${({ isMinimized }) => (isMinimized ? "auto" : "4.5rem")};
-  ${({ isMinimized }) => !isMinimized && `
-    border-bottom: 1px ${color("backgroundDarker")} solid;
-  `}
-  
+  border-bottom: ${({ isMinimized, theme }) => isMinimized ? "none" : `1px solid ${theme.color.backgroundDarker}`};
   padding: 0 1rem;
+  flex-shrink: 0;
+  width: 100%;
+  overflow-x: auto;
 
   ${bezierTransition};
 `
@@ -52,8 +49,6 @@ export const Content = styled.div`
 `
 
 export const SideContent = styled.div`
-  margin-left: auto;
   padding-left: 1rem;
-  overflow: hidden;
   text-overflow: ellipsis;
 `

--- a/packages/web-console/src/scenes/Notifications/index.tsx
+++ b/packages/web-console/src/scenes/Notifications/index.tsx
@@ -70,8 +70,7 @@ const Menu = styled(PaneMenu)`
 
 const Content = styled(PaneContent)<{ minimized: boolean }>`
   overflow: ${(props) => (props.minimized ? "hidden" : "auto")};
-  padding: ${(props) => (props.minimized ? "0" : "0 0 1rem")};
-  flex: initial;
+  overflow-x: hidden;
   height: ${(props) => (props.minimized ? "4rem" : "100%")};
 `
 
@@ -97,8 +96,12 @@ const TerminalBoxIcon = styled(TerminalBox)`
 const ClearAllNotifications = styled.div`
   display: flex;
   width: 100%;
+  height: 4.5rem;
   justify-content: center;
+  padding: 0.5rem 1rem;
   margin-top: auto;
+  align-items: center;
+  flex-shrink: 0;
 `
 
 const Notifications = () => {
@@ -152,7 +155,7 @@ const Notifications = () => {
             <Notification isMinimized={true} {...lastNotification} />
           )}
         </LatestNotification>
-        <Button skin="transparent" onClick={toggleMinimized}>
+        <Button skin={`${isMinimized ? "secondary" : "transparent"}`} onClick={toggleMinimized}>
           {isMinimized ? <ArrowUpS size="18px" /> : <Subtract size="18px" />}
         </Button>
       </Menu>

--- a/packages/web-console/src/scenes/Schema/Row/index.tsx
+++ b/packages/web-console/src/scenes/Schema/Row/index.tsx
@@ -86,7 +86,9 @@ const Wrapper = styled.div<{ $level?: number, $selectOpen?: boolean, $focused?: 
   user-select: none;
   border: 1px solid transparent;
   border-radius: 0.4rem;
+  min-width: fit-content;
   width: 100%;
+  flex-grow: 1;
 
   cursor: ${({ $selectOpen }) => $selectOpen ? "pointer" : "default"};
 
@@ -129,7 +131,6 @@ const TableActions = styled.span`
 const FlexRow = styled.div<{ $selectOpen?: boolean, $isTableKind?: boolean }>`
   display: flex;
   align-items: center;
-  width: 100%;
   padding-right: 1rem;
   transform: translateX(${({ $selectOpen, $isTableKind }) => $selectOpen && $isTableKind ? "1rem" : "0"});
   transition: transform 275ms ease-in-out;

--- a/packages/web-console/src/scenes/Schema/VirtualTables/index.tsx
+++ b/packages/web-console/src/scenes/Schema/VirtualTables/index.tsx
@@ -319,7 +319,7 @@ const VirtualTables: FC<VirtualTablesProps> = ({
         <Row
           kind="detail"
           index={index}
-          name={`${item.name}:`}
+          name={item.value ? `${item.name}:` : item.name}
           value={item.value}
           id={item.id}
           onExpandCollapse={() => {}}
@@ -490,7 +490,7 @@ const VirtualTables: FC<VirtualTablesProps> = ({
 
       fetchColumnsForExpandedTables()
     }
-  }, [state.view, regularTables, matViewTables]);
+  }, [state.view, regularTables, matViewTables, materializedViews]);
 
   if (state.view === View.loading || (state.view === View.ready && !columnsReady)) {
     return <Loading />


### PR DESCRIPTION
- Fix JIT compiled query icon shrink problem
- Fix notifications being collapsed when there are multiple
- Long queries can be scrolled horizontally in query history
- Move copy query button to the left of query (no need to scroll all the way to the end of a long query for copying)
- Change wording from "row" to "rows" when there is no row in result set
- Fix failing materialized view invalidation test