### PR TITLE
fix(web-console): wait for all body to be streamed before calculating network time

### DIFF
--- a/packages/web-console/src/utils/questdb/client.ts
+++ b/packages/web-console/src/utils/questdb/client.ts
@@ -213,10 +213,19 @@ export class Client {
       response.status === 400 ||
       (response.ok && response.status === 403)
     ) {
+      let responseText
+      try {
+        responseText = await response.text()
+      } catch (error) {
+        return Promise.reject({
+          error: `Failed to read response: ${error}`,
+          type: Type.ERROR,
+        })
+      }
       const fetchTime = (new Date().getTime() - start.getTime()) * 1e6
       let data;
       try {
-        data = (await response.json()) as RawResult
+        data = JSON.parse(responseText) as RawResult
       } catch (error) {
         return Promise.reject({
           error: `Invalid JSON response from the server: ${error}`,


### PR DESCRIPTION
`.json()` reads the whole response body, and then parses it as JSON. 
Our network time should include the time elapsed while waiting for the whole body, but should not include the parsing time. Thus, replaced `.json()` with `.text()` and then `JSON.parse()`