### PR TITLE
fix(ui): fix for users with a `.` in their name are unable to edit instance name (enterprise)

### DIFF
--- a/packages/browser-tests/cypress/commands.js
+++ b/packages/browser-tests/cypress/commands.js
@@ -308,9 +308,9 @@ Cypress.Commands.add("loadConsoleAsAdminAndCreateSSOGroup", (group, externalGrou
   cy.loadConsoleWithAuth(true);
 
   cy.executeSQL(`CREATE GROUP '${group}' WITH EXTERNAL ALIAS '${externalGroup || group}';`);
-  cy.getByDataHook("notification-success").should("be.visible");
+  cy.getByDataHook("success-notification").should("be.visible");
   cy.executeSQL(`GRANT HTTP TO '${group}';`);
-  cy.getByDataHook("notification-success").should("be.visible");
+  cy.getByDataHook("success-notification").should("be.visible");
 
   cy.logout();
 });
@@ -319,9 +319,9 @@ Cypress.Commands.add("loadConsoleAsAdminAndCreateDBUser", (username, password = 
   cy.loadConsoleWithAuth(true);
 
   cy.executeSQL(`create user '${username}' with password '${password}'`);
-  cy.getByDataHook("notification-success").should("be.visible");
+  cy.getByDataHook("success-notification").should("be.visible");
   cy.executeSQL(`grant HTTP to '${username}'`);
-  cy.getByDataHook("notification-success").should("be.visible");
+  cy.getByDataHook("success-notification").should("be.visible");
 
   cy.logout();
 });

--- a/packages/browser-tests/cypress/integration/console/topbar.spec.js
+++ b/packages/browser-tests/cypress/integration/console/topbar.spec.js
@@ -67,7 +67,7 @@ describe("TopBar", () => {
 });
 
 describe("Instance information access control", () => {
-  it("should not allow editing instance information in OSS if the instance is readonly", () => {
+  it("should not allow editing instance information if the instance is readonly", () => {
     cy.intercept(
       {
         method: "GET",
@@ -86,108 +86,6 @@ describe("Instance information access control", () => {
     cy.loadConsoleWithAuth();
 
     cy.wait("@settings");
-    cy.getByDataHook("topbar-instance-badge").should("be.visible");
-    cy.getByDataHook("topbar-instance-edit-icon").should("not.exist");
-  });
-
-  it("should show edit icon if the user has SETTINGS permission", () => {
-    cy.loadConsoleWithAuth();
-    cy.intercept(
-      {
-        method: "GET",
-        url: `${baseUrl}/settings`,
-      },
-      (req) => {
-        req.reply((res) => {
-          const originalConfig = res.body.config || {};
-          res.body.config = Object.assign({}, originalConfig, {
-            "release.type": "EE",
-          });
-          return res;
-        });
-      }
-    ).as("settings");
-    cy.interceptQuery("SHOW PERMISSIONS admin", "showPermissions", {
-      type: "dql",
-      columns: [
-        {
-          name: "permission",
-          type: "STRING",
-        },
-        {
-          name: "table_name",
-          type: "STRING",
-        },
-        {
-          name: "column_name",
-          type: "STRING",
-        },
-        {
-          name: "grant_option",
-          type: "BOOLEAN",
-        },
-        {
-          name: "origin",
-          type: "STRING",
-        },
-      ],
-      dataset: [["SETTINGS", null, null, false, null]],
-      count: 1,
-    });
-    cy.reload();
-    cy.wait("@settings");
-    cy.wait("@showPermissions");
-    cy.getByDataHook("topbar-instance-badge").should("be.visible");
-    cy.getByDataHook("topbar-instance-edit-icon").should("be.visible");
-  });
-
-  it("should not show edit icon if the user has no SETTINGS permission", () => {
-    cy.loadConsoleWithAuth();
-    cy.intercept(
-      {
-        method: "GET",
-        url: `${baseUrl}/settings`,
-      },
-      (req) => {
-        req.reply((res) => {
-          const originalConfig = res.body.config || {};
-          res.body.config = Object.assign({}, originalConfig, {
-            "release.type": "EE",
-          });
-          return res;
-        });
-      }
-    ).as("settings");
-    cy.interceptQuery("SHOW PERMISSIONS admin", "showPermissions", {
-      type: "dql",
-      columns: [
-        {
-          name: "permission",
-          type: "STRING",
-        },
-        {
-          name: "table_name",
-          type: "STRING",
-        },
-        {
-          name: "column_name",
-          type: "STRING",
-        },
-        {
-          name: "grant_option",
-          type: "BOOLEAN",
-        },
-        {
-          name: "origin",
-          type: "STRING",
-        },
-      ],
-      dataset: [["HTTP", null, null, false, null]],
-      count: 1,
-    });
-    cy.reload();
-    cy.wait("@settings");
-    cy.wait("@showPermissions");
     cy.getByDataHook("topbar-instance-badge").should("be.visible");
     cy.getByDataHook("topbar-instance-edit-icon").should("not.exist");
   });

--- a/packages/browser-tests/cypress/integration/enterprise/oidc.spec.js
+++ b/packages/browser-tests/cypress/integration/enterprise/oidc.spec.js
@@ -29,291 +29,288 @@ const interceptTokenRequest = (payload) => {
   );
 };
 
-describe("OIDC authentication", () => {
+describe("OIDC", () => {
   before(() => {
     // setup SSO group mappings
     cy.loadConsoleAsAdminAndCreateSSOGroup("group1");
   });
+  
+  describe("OIDC authentication", () => {
+    beforeEach(() => {
+      cy.clearLocalStorage();
+  
+      // load login page
+      interceptSettings({
+        "config": {
+          "release.type": "EE",
+          "release.version": "1.2.3",
+          "acl.enabled": true,
+          "acl.basic.auth.realm.enabled": false,
+          "acl.oidc.enabled": true,
+          "acl.oidc.client.id": "client1",
+          "acl.oidc.authorization.endpoint": oidcAuthorizationCodeUrl,
+          "acl.oidc.token.endpoint": oidcTokenUrl,
+          "acl.oidc.pkce.required": true,
+          "acl.oidc.state.required": false,
+          "acl.oidc.groups.encoded.in.token": false,
+        }
+      });
+      cy.visit(baseUrl);
 
-  beforeEach(() => {
-    cy.clearLocalStorage();
-
-    // load login page
-    interceptSettings({
-      "config": {
-        "release.type": "EE",
-        "release.version": "1.2.3",
-        "acl.enabled": true,
-        "acl.basic.auth.realm.enabled": false,
-        "acl.oidc.enabled": true,
-        "acl.oidc.client.id": "client1",
-        "acl.oidc.authorization.endpoint": oidcAuthorizationCodeUrl,
-        "acl.oidc.token.endpoint": oidcTokenUrl,
-        "acl.oidc.pkce.required": true,
-        "acl.oidc.state.required": false,
-        "acl.oidc.groups.encoded.in.token": false,
-      }
+      cy.wait("@settings");
+      cy.getByDataHook("auth-login").should("be.visible");
+      cy.getByDataHook("button-sso-continue").should("not.exist");
+      cy.getByDataHook("button-sso-login").should("be.visible");
+      cy.getByDataHook("button-sso-login").contains("Continue with SSO");
+      cy.getEditor().should("not.exist");
     });
-    cy.visit(baseUrl);
 
-    cy.wait("@settings");
-    cy.getByDataHook("auth-login").should("be.visible");
-    cy.getByDataHook("button-sso-login").should("be.visible");
-    cy.getEditor().should("not.exist");
+    it("should login via OIDC", () => {
+      interceptAuthorizationCodeRequest(`${baseUrl}?code=abcdefgh`);
+      cy.getByDataHook("button-sso-login").click();
+      cy.wait("@authorizationCode");
+
+      interceptTokenRequest({
+        "access_token": "gslpJtzmmi6RwaPSx0dYGD4tEkom",
+        "refresh_token": "FUuAAqMp6LSTKmkUd5uZuodhiE4Kr6M7Eyv",
+        "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6I",
+        "token_type": "Bearer",
+        "expires_in": 300
+      });
+      cy.wait("@tokens");
+      cy.getEditor().should("be.visible");
+
+      cy.executeSQL("select current_user();");
+      cy.getGridRow(0).should("contain", "user1");
+
+      cy.logout();
+    });
+
+    it("should request a new token on page reload, even if there is no refresh token", () => {
+      interceptAuthorizationCodeRequest(`${baseUrl}?code=abcdefgh`);
+      cy.getByDataHook("button-sso-login").click();
+      cy.wait("@authorizationCode");
+
+      interceptTokenRequest({
+        "access_token": "gslpJtzmmi6RwaPSx0dYGD4tEkom",
+        "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6I",
+        "token_type": "Bearer",
+        "expires_in": 0
+      });
+      cy.wait("@tokens");
+      cy.getEditor().should("be.visible");
+
+      cy.reload();
+      cy.getEditor().should("be.visible");
+    });
+
+    it("should not force SSO re-authentication with 'Continue as <username>' button", () => {
+      interceptAuthorizationCodeRequest(`${baseUrl}?code=abcdefgh`);
+      cy.getByDataHook("button-sso-login").click();
+      cy.wait("@authorizationCode");
+
+      interceptTokenRequest({
+        "access_token": "gslpJtzmmi6RwaPSx0dYGD4tEkom",
+        "refresh_token": "FUuAAqMp6LSTKmkUd5uZuodhiE4Kr6M7Eyv",
+        "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6I",
+        "token_type": "Bearer",
+        "expires_in": 300
+      });
+      cy.wait("@tokens");
+      cy.getEditor().should("be.visible");
+
+      cy.executeSQL("select current_user();");
+      cy.getGridRow(0).should("contain", "user1");
+
+      cy.logout();
+      cy.getByDataHook("button-sso-continue").should("be.visible");
+      cy.getByDataHook("button-sso-login").should("be.visible");
+      cy.getByDataHook("button-sso-login").contains("Choose a different account");
+
+      cy.getByDataHook("button-sso-continue").click();
+      cy.wait("@authorizationCode").then((interception) => {
+        expect(interception.request.url).to.include("/authorization");
+        const url = new URL(interception.request.url);
+        expect(url.searchParams.get("prompt")).to.equal(null);
+      });
+    });
+
+    it("should force SSO re-authentication with 'Choose a different account' button", () => {
+      interceptAuthorizationCodeRequest(`${baseUrl}?code=abcdefgh`);
+      cy.getByDataHook("button-sso-login").click();
+      cy.wait("@authorizationCode");
+
+      interceptTokenRequest({
+        "access_token": "gslpJtzmmi6RwaPSx0dYGD4tEkom",
+        "refresh_token": "FUuAAqMp6LSTKmkUd5uZuodhiE4Kr6M7Eyv",
+        "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6I",
+        "token_type": "Bearer",
+        "expires_in": 300
+      });
+      cy.wait("@tokens");
+      cy.getEditor().should("be.visible");
+
+      cy.executeSQL("select current_user();");
+      cy.getGridRow(0).should("contain", "user1");
+
+      cy.logout();
+      cy.getByDataHook("button-sso-continue").should("be.visible");
+      cy.getByDataHook("button-sso-login").should("be.visible");
+      cy.getByDataHook("button-sso-login").contains("Choose a different account");
+
+      cy.getByDataHook("button-sso-login").click();
+      cy.wait("@authorizationCode").then((interception) => {
+        expect(interception.request.url).to.include("/authorization");
+        const url = new URL(interception.request.url);
+        expect(url.searchParams.get("prompt")).to.equal("login");
+      });
+    });
+
+    it("display import panel", () => {
+      interceptAuthorizationCodeRequest(`${baseUrl}?code=abcdefgh`);
+      cy.getByDataHook("button-sso-login").click();
+      cy.wait("@authorizationCode");
+
+      interceptTokenRequest({
+        "access_token": "gslpJtzmmi6RwaPSx0dYGD4tEkom",
+        "refresh_token": "FUuAAqMp6LSTKmkUd5uZuodhiE4Kr6M7Eyv",
+        "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6I",
+        "token_type": "Bearer",
+        "expires_in": 300
+      });
+      cy.wait("@tokens");
+      cy.getEditor().should("be.visible");
+
+      cy.getByDataHook("import-panel-button").click();
+      cy.getByDataHook("import-dropbox").should("be.visible");
+      cy.getByDataHook("import-browse-from-disk").should("be.visible");
+
+      cy.get('input[type="file"]').selectFile("cypress/fixtures/test.csv", { force: true });
+      cy.getByDataHook("import-table-column-schema").should("be.visible");
+      cy.getByDataHook("import-table-column-owner").should("be.visible");
+      cy.contains("option", "user1").should("not.exist");
+      cy.contains("option", "group1").should("exist");
+    });
   });
 
-  it("should login via OIDC", () => {
-    interceptAuthorizationCodeRequest(`${baseUrl}?code=abcdefgh`);
-    cy.getByDataHook("button-sso-login").click();
-    cy.wait("@authorizationCode");
+  describe("OIDC authentication - with state", () => {
+    beforeEach(() => {
+      cy.clearLocalStorage();
 
-    interceptTokenRequest({
-      "access_token": "gslpJtzmmi6RwaPSx0dYGD4tEkom",
-      "refresh_token": "FUuAAqMp6LSTKmkUd5uZuodhiE4Kr6M7Eyv",
-      "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6I",
-      "token_type": "Bearer",
-      "expires_in": 300
+      // load login page
+      interceptSettings({
+        "config": {
+          "release.type": "EE",
+          "release.version": "1.2.3",
+          "acl.enabled": true,
+          "acl.basic.auth.realm.enabled": false,
+          "acl.oidc.enabled": true,
+          "acl.oidc.client.id": "client1",
+          "acl.oidc.authorization.endpoint": oidcAuthorizationCodeUrl,
+          "acl.oidc.token.endpoint": oidcTokenUrl,
+          "acl.oidc.pkce.required": true,
+          "acl.oidc.state.required": true,
+          "acl.oidc.groups.encoded.in.token": false,
+        }
+      });
+      cy.visit(baseUrl);
+
+      cy.wait("@settings");
+      cy.getByDataHook("auth-login").should("be.visible");
+      cy.getByDataHook("button-sso-continue").should("not.exist");
+      cy.getByDataHook("button-sso-login").should("be.visible");
+      cy.getByDataHook("button-sso-login").contains("Continue with SSO");
+      cy.getEditor().should("not.exist");
     });
-    cy.wait("@tokens");
-    cy.getEditor().should("be.visible");
 
-    cy.executeSQL("select current_user();");
-    cy.getGridRow(0).should("contain", "user1");
+    it("should login via OIDC with state required", () => {
+      interceptAuthorizationCodeRequest(`${baseUrl}?code=abcdefgh`);
+      cy.getByDataHook("button-sso-login").click();
+      cy.wait("@authorizationCode");
 
-    cy.logout();
-  });
+      interceptTokenRequest({
+        "access_token": "gslpJtzmmi6RwaPSx0dYGD4tEkom",
+        "refresh_token": "FUuAAqMp6LSTKmkUd5uZuodhiE4Kr6M7Eyv",
+        "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6I",
+        "token_type": "Bearer",
+        "expires_in": 300
+      });
+      cy.wait("@tokens");
+      cy.getEditor().should("be.visible");
 
-  it("should request a new token on page reload, even if there is no refresh token", () => {
-    interceptAuthorizationCodeRequest(`${baseUrl}?code=abcdefgh`);
-    cy.getByDataHook("button-sso-login").click();
-    cy.wait("@authorizationCode");
+      cy.executeSQL("select current_user();");
+      cy.getGridRow(0).should("contain", "user1");
 
-    interceptTokenRequest({
-      "access_token": "gslpJtzmmi6RwaPSx0dYGD4tEkom",
-      "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6I",
-      "token_type": "Bearer",
-      "expires_in": 0
+      cy.logout();
+      cy.getByDataHook("auth-login").should("be.visible");
+      cy.getByDataHook("button-sso-continue").should("be.visible");
+      cy.getByDataHook("button-sso-login").should("be.visible");
+      cy.getByDataHook("button-sso-login").contains("Choose a different account");
+      cy.getEditor().should("not.exist");
     });
-    cy.wait("@tokens");
-    cy.getEditor().should("be.visible");
 
-    cy.reload();
-    cy.getEditor().should("be.visible");
-  });
+    it("should login via OIDC, then admin, then OIDC again without re-authenticating if the OAuth2 provider session is still alive", () => {
+      interceptAuthorizationCodeRequest(`${baseUrl}?code=abcdefgh`);
+      cy.getByDataHook("button-sso-login").click();
+      cy.wait("@authorizationCode");
 
-  it("should not force SSO re-authentication with 'Continue as <username>' button", () => {
-    interceptAuthorizationCodeRequest(`${baseUrl}?code=abcdefgh`);
-    cy.getByDataHook("button-sso-login").click();
-    cy.wait("@authorizationCode");
+      interceptTokenRequest({
+        "access_token": "gslpJtzmmi6RwaPSx0dYGD4tEkom",
+        "refresh_token": "FUuAAqMp6LSTKmkUd5uZuodhiE4Kr6M7Eyv",
+        "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6I",
+        "token_type": "Bearer",
+        "expires_in": 300
+      });
+      cy.wait("@tokens");
+      cy.getEditor().should("be.visible");
 
-    interceptTokenRequest({
-      "access_token": "gslpJtzmmi6RwaPSx0dYGD4tEkom",
-      "refresh_token": "FUuAAqMp6LSTKmkUd5uZuodhiE4Kr6M7Eyv",
-      "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6I",
-      "token_type": "Bearer",
-      "expires_in": 300
+      cy.executeSQL("select current_user();");
+      cy.getGridRow(0).should("contain", "user1");
+
+      cy.logout();
+      cy.getByDataHook("auth-login").should("be.visible");
+      cy.getByDataHook("button-sso-continue").should("be.visible");
+      cy.getByDataHook("button-sso-login").should("be.visible");
+      cy.getByDataHook("button-sso-login").contains("Choose a different account");
+      cy.getEditor().should("not.exist");
+
+      cy.loginWithUserAndPassword();
+
+      cy.executeSQL("select current_user();");
+      cy.getGridRow(0).should("contain", "admin");
+
+      cy.logout();
+      cy.getByDataHook("auth-login").should("be.visible");
+      cy.getByDataHook("button-sso-continue").should("be.visible");
+      cy.getByDataHook("button-sso-continue").contains("Continue as user1");
+      cy.getByDataHook("button-sso-login").should("be.visible");
+      cy.getByDataHook("button-sso-login").contains("Choose a different account");
+      cy.getEditor().should("not.exist");
+
+      cy.getByDataHook("button-sso-continue").click();
+      cy.getEditor().should("be.visible");
+
+      cy.executeSQL("select current_user();");
+      cy.getGridRow(0).should("contain", "user1");
     });
-    cy.wait("@tokens");
-    cy.getEditor().should("be.visible");
 
-    cy.executeSQL("select current_user();");
-    cy.getGridRow(0).should("contain", "user1");
+    it("should force SSO re-authentication with state error", () => {
+      interceptAuthorizationCodeRequest(`${baseUrl}?code=abcdefgh`, true);
+      cy.getByDataHook("button-sso-login").click();
+      cy.wait("@authorizationCode");
 
-    cy.logout();
-    cy.getByDataHook("button-sso-continue").should("be.visible");
-    cy.getByDataHook("button-sso-login").should("be.visible");
-    cy.getByDataHook("button-sso-login").contains("Choose a different account");
+      cy.getByDataHook("auth-login").should("be.visible");
+      cy.getByDataHook("button-sso-continue").should("not.exist");
+      cy.getByDataHook("button-sso-login").should("be.visible");
+      cy.getByDataHook("button-sso-login").contains("Continue with SSO");
+      cy.getEditor().should("not.exist");
 
-    cy.getByDataHook("button-sso-continue").click();
-    cy.wait("@authorizationCode").then((interception) => {
-      expect(interception.request.url).to.include("/authorization");
-      const url = new URL(interception.request.url);
-      expect(url.searchParams.get("prompt")).to.equal(null);
-    });
-  });
-
-  it("should force SSO re-authentication with 'Choose a different account' button", () => {
-    interceptAuthorizationCodeRequest(`${baseUrl}?code=abcdefgh`);
-    cy.getByDataHook("button-sso-login").click();
-    cy.wait("@authorizationCode");
-
-    interceptTokenRequest({
-      "access_token": "gslpJtzmmi6RwaPSx0dYGD4tEkom",
-      "refresh_token": "FUuAAqMp6LSTKmkUd5uZuodhiE4Kr6M7Eyv",
-      "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6I",
-      "token_type": "Bearer",
-      "expires_in": 300
-    });
-    cy.wait("@tokens");
-    cy.getEditor().should("be.visible");
-
-    cy.executeSQL("select current_user();");
-    cy.getGridRow(0).should("contain", "user1");
-
-    cy.logout();
-    cy.getByDataHook("button-sso-continue").should("be.visible");
-    cy.getByDataHook("button-sso-login").should("be.visible");
-    cy.getByDataHook("button-sso-login").contains("Choose a different account");
-
-    cy.getByDataHook("button-sso-login").click();
-    cy.wait("@authorizationCode").then((interception) => {
-      expect(interception.request.url).to.include("/authorization");
-      const url = new URL(interception.request.url);
-      expect(url.searchParams.get("prompt")).to.equal("login");
-    });
-  });
-
-  it("display import panel", () => {
-    interceptAuthorizationCodeRequest(`${baseUrl}?code=abcdefgh`);
-    cy.getByDataHook("button-sso-login").click();
-    cy.wait("@authorizationCode");
-
-    interceptTokenRequest({
-      "access_token": "gslpJtzmmi6RwaPSx0dYGD4tEkom",
-      "refresh_token": "FUuAAqMp6LSTKmkUd5uZuodhiE4Kr6M7Eyv",
-      "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6I",
-      "token_type": "Bearer",
-      "expires_in": 300
-    });
-    cy.wait("@tokens");
-    cy.getEditor().should("be.visible");
-
-    cy.getByDataHook("import-panel-button").click();
-    cy.getByDataHook("import-dropbox").should("be.visible");
-    cy.getByDataHook("import-browse-from-disk").should("be.visible");
-
-    cy.get('input[type="file"]').selectFile("cypress/fixtures/test.csv", { force: true });
-    cy.getByDataHook("import-table-column-schema").should("be.visible");
-    cy.getByDataHook("import-table-column-owner").should("be.visible");
-    cy.contains("option", "user1").should("not.exist");
-    cy.contains("option", "group1").should("exist");
-
-    cy.logout();
-  });
-});
-
-describe("OIDC authentication - with state", () => {
-  before(() => {
-    // setup SSO group mappings
-    cy.loadConsoleAsAdminAndCreateSSOGroup("group1");
-  });
-
-  beforeEach(() => {
-    cy.clearLocalStorage();
-
-    // load login page
-    interceptSettings({
-      "config": {
-        "release.type": "EE",
-        "release.version": "1.2.3",
-        "acl.enabled": true,
-        "acl.basic.auth.realm.enabled": false,
-        "acl.oidc.enabled": true,
-        "acl.oidc.client.id": "client1",
-        "acl.oidc.authorization.endpoint": oidcAuthorizationCodeUrl,
-        "acl.oidc.token.endpoint": oidcTokenUrl,
-        "acl.oidc.pkce.required": true,
-        "acl.oidc.state.required": true,
-        "acl.oidc.groups.encoded.in.token": false,
-      }
-    });
-    cy.visit(baseUrl);
-
-    cy.wait("@settings");
-    cy.getByDataHook("auth-login").should("be.visible");
-    cy.getByDataHook("button-sso-continue").should("not.exist");
-    cy.getByDataHook("button-sso-login").should("be.visible");
-    cy.getByDataHook("button-sso-login").contains("Continue with SSO");
-    cy.getEditor().should("not.exist");
-  });
-
-  it("should login via OIDC with state required", () => {
-    interceptAuthorizationCodeRequest(`${baseUrl}?code=abcdefgh`);
-    cy.getByDataHook("button-sso-login").click();
-    cy.wait("@authorizationCode");
-
-    interceptTokenRequest({
-      "access_token": "gslpJtzmmi6RwaPSx0dYGD4tEkom",
-      "refresh_token": "FUuAAqMp6LSTKmkUd5uZuodhiE4Kr6M7Eyv",
-      "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6I",
-      "token_type": "Bearer",
-      "expires_in": 300
-    });
-    cy.wait("@tokens");
-    cy.getEditor().should("be.visible");
-
-    cy.executeSQL("select current_user();");
-    cy.getGridRow(0).should("contain", "user1");
-
-    cy.logout();
-    cy.getByDataHook("auth-login").should("be.visible");
-    cy.getByDataHook("button-sso-continue").should("be.visible");
-    cy.getByDataHook("button-sso-login").should("be.visible");
-    cy.getByDataHook("button-sso-login").contains("Choose a different account");
-    cy.getEditor().should("not.exist");
-  });
-
-  it("should login via OIDC, then admin, then OIDC again without re-authenticating if the OAuth2 provider session is still alive", () => {
-    interceptAuthorizationCodeRequest(`${baseUrl}?code=abcdefgh`);
-    cy.getByDataHook("button-sso-login").click();
-    cy.wait("@authorizationCode");
-
-    interceptTokenRequest({
-      "access_token": "gslpJtzmmi6RwaPSx0dYGD4tEkom",
-      "refresh_token": "FUuAAqMp6LSTKmkUd5uZuodhiE4Kr6M7Eyv",
-      "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6I",
-      "token_type": "Bearer",
-      "expires_in": 300
-    });
-    cy.wait("@tokens");
-    cy.getEditor().should("be.visible");
-
-    cy.executeSQL("select current_user();");
-    cy.getGridRow(0).should("contain", "user1");
-
-    cy.logout();
-    cy.getByDataHook("auth-login").should("be.visible");
-    cy.getByDataHook("button-sso-continue").should("be.visible");
-    cy.getByDataHook("button-sso-login").should("be.visible");
-    cy.getByDataHook("button-sso-login").contains("Choose a different account");
-    cy.getEditor().should("not.exist");
-
-    cy.loginWithUserAndPassword();
-    cy.getEditorContent().should("be.visible");
-
-    cy.executeSQL("select current_user();");
-    cy.getGridRow(0).should("contain", "admin");
-
-    cy.logout();
-    cy.getByDataHook("auth-login").should("be.visible");
-    cy.getByDataHook("button-sso-continue").should("be.visible");
-    cy.getByDataHook("button-sso-login").should("be.visible");
-    cy.getByDataHook("button-sso-login").contains("Choose a different account");
-    cy.getEditorContent().should("not.exist");
-
-    cy.getByDataHook("button-sso-continue").click();
-    cy.getEditorContent().should("be.visible");
-
-    cy.executeSQL("select current_user();");
-    cy.getGridRow(0).should("contain", "user1");
-  });
-
-  it("should force SSO re-authentication with state error", () => {
-    interceptAuthorizationCodeRequest(`${baseUrl}?code=abcdefgh`, true);
-    cy.getByDataHook("button-sso-login").click();
-    cy.wait("@authorizationCode");
-
-    cy.getByDataHook("auth-login").should("be.visible");
-    cy.getByDataHook("button-sso-continue").should("not.exist");
-    cy.getByDataHook("button-sso-login").should("be.visible");
-    cy.getByDataHook("button-sso-login").contains("Continue with SSO");
-    cy.getEditor().should("not.exist");
-
-    cy.getByDataHook("button-sso-login").click();
-    cy.wait("@authorizationCode").then((interception) => {
-      expect(interception.request.url).to.include("/authorization");
-      const url = new URL(interception.request.url);
-      expect(url.searchParams.get("prompt")).to.equal("login");
+      cy.getByDataHook("button-sso-login").click();
+      cy.wait("@authorizationCode").then((interception) => {
+        expect(interception.request.url).to.include("/authorization");
+        const url = new URL(interception.request.url);
+        expect(url.searchParams.get("prompt")).to.equal("login");
+      });
     });
   });
 });

--- a/packages/browser-tests/cypress/integration/enterprise/topbar.spec.js
+++ b/packages/browser-tests/cypress/integration/enterprise/topbar.spec.js
@@ -1,0 +1,62 @@
+/// <reference types="cypress" />
+
+const contextPath = process.env.QDB_HTTP_CONTEXT_WEB_CONSOLE || "";
+const baseUrl = `http://localhost:9999${contextPath}`;
+
+describe("instance information in enterprise", () => {
+  before(() => {
+    // setup DB user with '.' in their name
+    cy.loadConsoleAsAdminAndCreateDBUser("john.doe");
+  });
+
+  it("should be able to edit instance info as admin", () => {
+    cy.visit(baseUrl);
+    cy.loginWithUserAndPassword();
+
+    cy.getByDataHook("topbar-instance-name").should(
+      "have.text",
+      "Instance name is not set"
+    );
+    cy.getByDataHook("topbar-instance-badge").should(
+      "have.css",
+      "background-color",
+      "rgb(40, 42, 54)"
+    );
+    cy.getEditor().should("be.visible");
+
+    cy.executeSQL("select current_user()");
+    cy.getGridRow(0).should("contain", "admin");
+    cy.getByDataHook("topbar-instance-edit-icon").should("be.visible");
+
+    cy.logout()
+  });
+
+  it("should not be able to edit instance info without SETTINGS permission", () => {
+    cy.visit(baseUrl);
+    cy.loginWithUserAndPassword("john.doe", "pwd");
+
+    cy.executeSQL("select current_user()");
+    cy.getGridRow(0).should("contain", "john.doe");
+    cy.getByDataHook("topbar-instance-edit-icon").should("not.exist");
+
+    cy.logout()
+  });
+
+  it("should be able to edit instance info with SETTINGS permission", () => {
+    cy.visit(baseUrl);
+    cy.loginWithUserAndPassword();
+
+    cy.executeSQL(`grant SETTINGS to 'john.doe'`);
+    cy.getByDataHook("notification-success").should("be.visible");
+
+    cy.logout();
+
+    cy.loginWithUserAndPassword("john.doe", "pwd");
+
+    cy.executeSQL("select current_user()");
+    cy.getGridRow(0).should("contain", "john.doe");
+    cy.getByDataHook("topbar-instance-edit-icon").should("be.visible");
+
+    cy.logout()
+  });
+});

--- a/packages/browser-tests/cypress/integration/enterprise/topbar.spec.js
+++ b/packages/browser-tests/cypress/integration/enterprise/topbar.spec.js
@@ -47,7 +47,7 @@ describe("instance information in enterprise", () => {
     cy.loginWithUserAndPassword();
 
     cy.executeSQL(`grant SETTINGS to 'john.doe'`);
-    cy.getByDataHook("notification-success").should("be.visible");
+    cy.getByDataHook("success-notification").should("be.visible");
 
     cy.logout();
 

--- a/packages/web-console/src/scenes/Notifications/Notification/ErrorNotification/index.tsx
+++ b/packages/web-console/src/scenes/Notifications/Notification/ErrorNotification/index.tsx
@@ -40,7 +40,7 @@ export const ErrorNotification = (props: NotificationShape) => {
   return (
     <Wrapper isMinimized={isMinimized}>
       <Timestamp createdAt={createdAt} />
-      <CloseOutlineIcon size="18px" />
+      <CloseOutlineIcon size="18px" data-hook="notification-error" />
       <Content>{content}</Content>
       <SideContent>{sideContent}</SideContent>
     </Wrapper>

--- a/packages/web-console/src/scenes/Notifications/Notification/ErrorNotification/index.tsx
+++ b/packages/web-console/src/scenes/Notifications/Notification/ErrorNotification/index.tsx
@@ -38,9 +38,9 @@ const CloseOutlineIcon = styled(CloseOutline)`
 export const ErrorNotification = (props: NotificationShape) => {
   const { createdAt, content, sideContent, isMinimized } = props
   return (
-    <Wrapper isMinimized={isMinimized}>
+    <Wrapper isMinimized={isMinimized} data-hook="error-notification">
       <Timestamp createdAt={createdAt} />
-      <CloseOutlineIcon size="18px" data-hook="notification-error" />
+      <CloseOutlineIcon size="18px" />
       <Content>{content}</Content>
       <SideContent>{sideContent}</SideContent>
     </Wrapper>

--- a/packages/web-console/src/scenes/Notifications/Notification/InfoNotification/index.tsx
+++ b/packages/web-console/src/scenes/Notifications/Notification/InfoNotification/index.tsx
@@ -30,7 +30,7 @@ import { Timestamp } from "../Timestamp"
 export const InfoNotification = (props: NotificationShape) => {
   const { createdAt, content, sideContent, isMinimized } = props
   return (
-    <Wrapper isMinimized={isMinimized}>
+    <Wrapper isMinimized={isMinimized} data-hook="info-notification">
       <Timestamp createdAt={createdAt} />
       <Content>{content}</Content>
       <SideContent>{sideContent}</SideContent>

--- a/packages/web-console/src/scenes/Notifications/Notification/NoticeNotification/index.tsx
+++ b/packages/web-console/src/scenes/Notifications/Notification/NoticeNotification/index.tsx
@@ -40,7 +40,7 @@ export const NoticeNotification = (props: NotificationShape) => {
   return (
     <Wrapper isMinimized={isMinimized}>
       <Timestamp createdAt={createdAt} />
-      <InfoOutlineIcon size="18px" />
+      <InfoOutlineIcon size="18px" data-hook="notification-info" />
       <Content>{content}</Content>
       <SideContent>{sideContent}</SideContent>
     </Wrapper>

--- a/packages/web-console/src/scenes/Notifications/Notification/NoticeNotification/index.tsx
+++ b/packages/web-console/src/scenes/Notifications/Notification/NoticeNotification/index.tsx
@@ -38,9 +38,9 @@ const InfoOutlineIcon = styled(InfoOutline)`
 export const NoticeNotification = (props: NotificationShape) => {
   const { createdAt, content, sideContent, isMinimized } = props
   return (
-    <Wrapper isMinimized={isMinimized}>
+    <Wrapper isMinimized={isMinimized} data-hook="notice-notification">
       <Timestamp createdAt={createdAt} />
-      <InfoOutlineIcon size="18px" data-hook="notification-info" />
+      <InfoOutlineIcon size="18px" />
       <Content>{content}</Content>
       <SideContent>{sideContent}</SideContent>
     </Wrapper>

--- a/packages/web-console/src/scenes/Notifications/Notification/SuccessNotification/index.tsx
+++ b/packages/web-console/src/scenes/Notifications/Notification/SuccessNotification/index.tsx
@@ -54,7 +54,7 @@ export const SuccessNotification = (props: NotificationShape) => {
           tooltip="JIT Compiled"
         />
       ) : (
-        <CheckmarkOutlineIcon size="18px" />
+        <CheckmarkOutlineIcon size="18px" data-hook="notification-success" />
       )}
       <Content>{content}</Content>
       <SideContent>{sideContent}</SideContent>

--- a/packages/web-console/src/scenes/Notifications/Notification/SuccessNotification/index.tsx
+++ b/packages/web-console/src/scenes/Notifications/Notification/SuccessNotification/index.tsx
@@ -45,7 +45,7 @@ const ZapIcon = styled(Zap)`
 export const SuccessNotification = (props: NotificationShape) => {
   const { createdAt, content, sideContent, jitCompiled, isMinimized } = props
   return (
-    <Wrapper isMinimized={isMinimized}>
+    <Wrapper isMinimized={isMinimized} data-hook="success-notification">
       <Timestamp createdAt={createdAt} />
       {jitCompiled ? (
         <IconWithTooltip
@@ -54,7 +54,7 @@ export const SuccessNotification = (props: NotificationShape) => {
           tooltip="JIT Compiled"
         />
       ) : (
-        <CheckmarkOutlineIcon size="18px" data-hook="notification-success" />
+        <CheckmarkOutlineIcon size="18px" />
       )}
       <Content>{content}</Content>
       <SideContent>{sideContent}</SideContent>

--- a/packages/web-console/src/utils/questdb/client.ts
+++ b/packages/web-console/src/utils/questdb/client.ts
@@ -332,7 +332,7 @@ export class Client {
   }
 
   async showPermissions(user: string): Promise<QueryResult<Permission>> {
-    return await this.query<Permission>(`SHOW PERMISSIONS ${user};`)
+    return await this.query<Permission>(`SHOW PERMISSIONS '${user}';`)
   }
 
   async showColumns(table: string): Promise<QueryResult<Column>> {

--- a/run_browser_tests.sh
+++ b/run_browser_tests.sh
@@ -39,6 +39,7 @@ export QDB_DEV_MODE_ENABLED=true
 export QDB_CAIRO_MAT_VIEW_ENABLED=true
 
 # Running tests which assume authentication is off
+rm -rf tmp/dbroot/*
 ./tmp/questdb-*/bin/questdb.sh start -d tmp/dbroot
 yarn workspace browser-tests test:auth
 ./tmp/questdb-*/bin/questdb.sh stop
@@ -50,6 +51,7 @@ export QDB_HTTP_USER=admin
 export QDB_HTTP_PASSWORD=quest
 
 # Running tests which assume that OSS authentication is on
+rm -rf tmp/dbroot/*
 ./tmp/questdb-*/bin/questdb.sh start -d tmp/dbroot
 yarn workspace browser-tests test
 ./tmp/questdb-*/bin/questdb.sh stop
@@ -67,6 +69,7 @@ PID2="$!"
 echo "Proxy started, PID=$PID2"
 
 # Running tests with context path
+rm -rf tmp/dbroot/*
 ./tmp/questdb-*/bin/questdb.sh start -d tmp/dbroot
 yarn workspace browser-tests test
 ./tmp/questdb-*/bin/questdb.sh stop

--- a/run_ent_browser_tests.sh
+++ b/run_ent_browser_tests.sh
@@ -44,6 +44,7 @@ export QDB_ACL_OIDC_PORT=9999
 export QDB_ACL_OIDC_USERINFO_ENDPOINT=/userinfo
 
 # Running enterprise tests
+rm -rf tmp/dbroot/*
 ./tmp/questdb-*/bin/questdb.sh start -d tmp/dbroot
 yarn workspace browser-tests test:enterprise
 ./tmp/questdb-*/bin/questdb.sh stop


### PR DESCRIPTION
The web console queries the user's permissions to determine if they should be able to edit instance name/type/desc or not.
This is done by executing `show permissions username`.
However, we should be executing `show permissions 'username'` instead, as the former query fails if the username contains a dot (`.`), such as `john.doe`.

The PR also fixes issues with tests.