### PR TITLE
fix(web-console): array truncation in grid & bug fixes

### DIFF
--- a/packages/web-console/src/scenes/Import/ImportCSVFiles/utils.ts
+++ b/packages/web-console/src/scenes/Import/ImportCSVFiles/utils.ts
@@ -2,6 +2,10 @@ import { SchemaColumn } from "components/TableSchemaDialog/types"
 
 export const isGeoHash = (type: string) => type.startsWith("GEOHASH")
 
+const arrayRegex = /^[a-z][a-z0-9]*(\[\])+$/i
+
+export const isArray = (type: string) => arrayRegex.test(type)
+
 export const extractPrecionFromGeohash = (geohash: string) => {
   const regex = /\(([^)]+)\)/g
   const matches = regex.exec(geohash)
@@ -14,7 +18,11 @@ export const extractPrecionFromGeohash = (geohash: string) => {
 export const mapColumnTypeToUI = (type: string) => {
   if (isGeoHash(type)) {
     return "GEOHASH"
-  } else return type.toUpperCase()
+  }
+  if (isArray(type)) {
+    return "ARRAY"
+  }
+  return type.toUpperCase()
 }
 
 export const mapColumnTypeToQuestDB = (column: SchemaColumn) => {

--- a/packages/web-console/src/scenes/Schema/Row/index.tsx
+++ b/packages/web-console/src/scenes/Schema/Row/index.tsx
@@ -24,8 +24,7 @@
 
 import React, { useState, useEffect, useRef, useLayoutEffect } from "react"
 import styled from "styled-components"
-import { InfoCircle } from "@styled-icons/boxicons-regular"
-import { SortDown } from "@styled-icons/boxicons-regular"
+import { SortDown, Bracket, InfoCircle } from "@styled-icons/boxicons-regular"
 import { ChevronRight } from "@styled-icons/boxicons-solid"
 import { Error as ErrorIcon } from "@styled-icons/boxicons-regular"
 import { CheckboxBlankCircle, Loader4 } from "@styled-icons/remix-line"
@@ -223,6 +222,10 @@ const TYPE_ICONS = {
   geo: {
     types: ["GEOHASH"],
     icon: GeoAlt
+  },
+  array: {
+    types: ["ARRAY"],
+    icon: Bracket,
   }
 } as const
 


### PR DESCRIPTION
- Fix copying column name to editor when the first column resize hysteresis is used
- Fix losing the header when resetting grid after scrolling down to new pages
- Fix shuffle to front problem when grid is not focused
- Truncate the array text with opening & closing brackets, reduce default maximum array column width to 40%