### PR TITLE
FIXES ISSUE #346 enforce case-insensitive uniqueness for column names

### DIFF
--- a/packages/web-console/src/components/TableSchemaDialog/dialog.tsx
+++ b/packages/web-console/src/components/TableSchemaDialog/dialog.tsx
@@ -157,7 +157,7 @@ export const Dialog = ({
         }
         return value
       })
-      .unique((a, b) => a.name.toLowerCase() === b.name.toLowerCase())
+      .unique((a, b) => a.name.trim().toLowerCase() === b.name.trim().toLowerCase())
       .messages({
         "array.required": "Please add at least one column",
         "array.unique": "Column names must be unique",


### PR DESCRIPTION
column names in the table schema dialog are now validated case-insensitively to prevent duplicate columns like 'Age and 'age' this fixes issue #346 where duplicate column names differing only by case were incorrectly allowed

Demo : 

https://github.com/user-attachments/assets/9d213e8a-f19b-4114-80a0-9f3eb5070789

