### PR TITLE
fix(web-console): prevent infinite state updates in metrics

### DIFF
--- a/packages/web-console/src/scenes/Editor/Metrics/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Metrics/index.tsx
@@ -277,9 +277,7 @@ export const Metrics = () => {
     }
   }, [buffer?.id, refreshMetricsData])
 
-  useEffect(() => {
-    setupListeners()
-  }, [refreshRate, setupListeners])
+  }, [refreshRate])
 
   useEffect(() => {
     isNavigatingFromSearchRef.current = false

--- a/packages/web-console/src/scenes/Editor/Metrics/index.tsx
+++ b/packages/web-console/src/scenes/Editor/Metrics/index.tsx
@@ -277,6 +277,8 @@ export const Metrics = () => {
     }
   }, [buffer?.id, refreshMetricsData])
 
+  useEffect(() => {
+    setupListeners()
   }, [refreshRate])
 
   useEffect(() => {

--- a/packages/web-console/src/scenes/Editor/index.tsx
+++ b/packages/web-console/src/scenes/Editor/index.tsx
@@ -81,7 +81,7 @@ const Editor = ({
     <EditorPaneWrapper ref={innerRef} {...rest}>
       <Tabs />
       {activeBuffer.editorViewState && <Monaco executionRefs={executionRefs} />}
-      {activeBuffer.metricsViewState && <Metrics />}
+      {activeBuffer.metricsViewState && <Metrics key={activeBuffer.id} />}
       {activeBuffer.editorViewState && <Notifications onClearNotifications={handleClearNotifications} />}
     </EditorPaneWrapper>
   )


### PR DESCRIPTION
Reworked the state management of this component, ensuring updates all go through the `updateBuffer` call, no redundant local state, no unnecessary rerenders, no mutations on context values.
- Metrics component was getting the buffers object from Dexie, setting a local state, and was not properly syncing local state with the storage.
- In some cases, we were running effect to set the local state because context value changed ->  running effect to set the context value -> .... This was causing infinite loops. -> removed redundant local state and effects
- We had a focus listener but it did not have any effect -> removed
- We had a visibility check but ref was being set only when telemetry is disabled -> reversed, it is set when telemetry is enabled
