### PR TITLE
feat(web-console): add column name search to Schema filter

### DIFF
--- a/packages/browser-tests/cypress/commands.js
+++ b/packages/browser-tests/cypress/commands.js
@@ -19,6 +19,10 @@ const tableSchemas = {
   my_publics: "CREATE TABLE IF NOT EXISTS 'my_publics' (public STRING);",
   my_secrets: "CREATE TABLE IF NOT EXISTS 'my_secrets' (secret STRING);",
   my_secrets2: "CREATE TABLE IF NOT EXISTS 'my_secrets2' (secret STRING);",
+  contains_magicword:
+    "CREATE TABLE IF NOT EXISTS 'contains_magicword' (ts TIMESTAMP, magicword VARCHAR) timestamp (ts) PARTITION BY DAY;",
+  contains_simpleword:
+    "CREATE TABLE IF NOT EXISTS 'contains_simpleword' (timestamp TIMESTAMP, simpleword VARCHAR) timestamp (timestamp) PARTITION BY DAY;",
 };
 
 const materializedViewSchemas = {

--- a/packages/browser-tests/cypress/integration/console/schema.spec.js
+++ b/packages/browser-tests/cypress/integration/console/schema.spec.js
@@ -132,6 +132,7 @@ describe("questdb schema with search column tables", () => {
   it("should show tables with column matches", () => {
     cy.get('input[name="table_filter"]').type("magicword");
     cy.expandTables();
+    cy.getByDataHook('input[name="table_filter"]').realHover();
 
     cy.get('[data-search-match="true"]').should("have.length", 2);
     cy.get('[data-search-match="true"]')
@@ -147,6 +148,7 @@ describe("questdb schema with search column tables", () => {
     cy.get('[data-expanded="true"][data-kind="table"]').should("not.exist");
 
     cy.get('input[name="table_filter"]').type("simpleword");
+    cy.getByDataHook('input[name="table_filter"]').realHover();
 
     cy.get('[data-search-match="true"]').should("have.length", 2);
     cy.get('[data-search-match="true"]')
@@ -157,6 +159,8 @@ describe("questdb schema with search column tables", () => {
     cy.getByDataHook("schema-search-clear-button").click();
 
     cy.get('input[name="table_filter"]').type("word");
+    cy.getByDataHook('input[name="table_filter"]').realHover();
+
     cy.getByDataHook("schema-table-title").should("have.length", 2);
     cy.get('[data-search-match="true"]').should("have.length", 4);
     cy.get('[data-search-match="true"]').should(
@@ -172,8 +176,14 @@ describe("questdb schema with search column tables", () => {
 
     cy.getByDataHook("schema-search-clear-button").click();
     cy.get('input[name="table_filter"]').type("ts");
+    cy.getByDataHook('input[name="table_filter"]').realHover();
+
     cy.getByDataHook("schema-table-title").should("have.length", 1);
     cy.get('[data-search-match="true"]').should("contain", "ts");
+  });
+
+  afterEach(() => {
+    cy.getByDataHook("schema-search-clear-button").click();
   });
 
   after(() => {

--- a/packages/browser-tests/cypress/integration/console/schema.spec.js
+++ b/packages/browser-tests/cypress/integration/console/schema.spec.js
@@ -157,24 +157,6 @@ describe("questdb schema with search column tables", () => {
     cy.get('[data-search-match="true"]').should("contain", "simpleword");
 
     cy.getByDataHook("schema-search-clear-button").click();
-
-    cy.get('input[name="table_filter"]').type("word");
-    cy.get('input[name="table_filter"]').realHover();
-
-    cy.getByDataHook("schema-table-title").should("have.length", 2);
-    cy.get('[data-search-match="true"]').should("have.length", 4);
-    cy.get('[data-search-match="true"]').should(
-      "contain",
-      "contains_magicword"
-    );
-    cy.get('[data-search-match="true"]').should(
-      "contain",
-      "contains_simpleword"
-    );
-    cy.get('[data-search-match="true"]').should("contain", "magicword");
-    cy.get('[data-search-match="true"]').should("contain", "simpleword");
-
-    cy.getByDataHook("schema-search-clear-button").click();
     cy.get('input[name="table_filter"]').type("ts");
     cy.get('input[name="table_filter"]').realHover();
 

--- a/packages/browser-tests/cypress/integration/console/schema.spec.js
+++ b/packages/browser-tests/cypress/integration/console/schema.spec.js
@@ -132,7 +132,7 @@ describe("questdb schema with search column tables", () => {
   it("should show tables with column matches", () => {
     cy.get('input[name="table_filter"]').type("magicword");
     cy.expandTables();
-    cy.getByDataHook('input[name="table_filter"]').realHover();
+    cy.get('input[name="table_filter"]').realHover();
 
     cy.get('[data-search-match="true"]').should("have.length", 2);
     cy.get('[data-search-match="true"]')
@@ -148,7 +148,7 @@ describe("questdb schema with search column tables", () => {
     cy.get('[data-expanded="true"][data-kind="table"]').should("not.exist");
 
     cy.get('input[name="table_filter"]').type("simpleword");
-    cy.getByDataHook('input[name="table_filter"]').realHover();
+    cy.get('input[name="table_filter"]').realHover();
 
     cy.get('[data-search-match="true"]').should("have.length", 2);
     cy.get('[data-search-match="true"]')
@@ -159,7 +159,7 @@ describe("questdb schema with search column tables", () => {
     cy.getByDataHook("schema-search-clear-button").click();
 
     cy.get('input[name="table_filter"]').type("word");
-    cy.getByDataHook('input[name="table_filter"]').realHover();
+    cy.get('input[name="table_filter"]').realHover();
 
     cy.getByDataHook("schema-table-title").should("have.length", 2);
     cy.get('[data-search-match="true"]').should("have.length", 4);
@@ -176,7 +176,7 @@ describe("questdb schema with search column tables", () => {
 
     cy.getByDataHook("schema-search-clear-button").click();
     cy.get('input[name="table_filter"]').type("ts");
-    cy.getByDataHook('input[name="table_filter"]').realHover();
+    cy.get('input[name="table_filter"]').realHover();
 
     cy.getByDataHook("schema-table-title").should("have.length", 1);
     cy.get('[data-search-match="true"]').should("contain", "ts");

--- a/packages/browser-tests/cypress/integration/console/schema.spec.js
+++ b/packages/browser-tests/cypress/integration/console/schema.spec.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-const contextPath = process.env.QDB_HTTP_CONTEXT_WEB_CONSOLE || ""
+const contextPath = process.env.QDB_HTTP_CONTEXT_WEB_CONSOLE || "";
 const baseUrl = `http://localhost:9999${contextPath}`;
 
 const tables = [
@@ -108,6 +108,39 @@ describe("questdb schema with working tables", () => {
       "have.length.least",
       tables.length
     );
+  });
+
+  it("should show tables with column matches", () => {
+    cy.get('input[name="table_filter"]').type("timestamp");
+    cy.expandTables();
+
+    cy.get('.sash-horizontal[data-testid="sash"]')
+      .realMouseDown({ button: "left", position: "center" })
+      .realMouseMove(0, 300, { position: "center" })
+      .realMouseUp();
+
+    cy.get('[data-search-match="true"]').should("have.length", 2);
+    cy.get('[data-search-match="true"]').should("contain", "timestamp");
+    cy.get('[data-search-match="true"]').should(
+      "contain",
+      "MeasurementTimestamp"
+    );
+    cy.get('[data-expanded="true"][data-kind="table"]').should(
+      "have.length",
+      2
+    );
+    cy.get('[data-expanded="true"][data-kind="table"]').should(
+      "contain",
+      "btc_trades"
+    );
+    cy.get('[data-expanded="true"][data-kind="table"]').should(
+      "contain",
+      "chicago_weather_stations"
+    );
+
+    cy.getByDataHook("schema-search-clear-button").click();
+    cy.getByDataHook("schema-table-title").should("have.length", 4);
+    cy.get('[data-expanded="true"][data-kind="table"]').should("not.exist");
   });
 
   after(() => {
@@ -530,7 +563,8 @@ describe("materialized views", () => {
   });
 
   it("should show a warning icon and tooltip when the view is invalidated", () => {
-    cy.intercept({
+    cy.intercept(
+      {
         method: "GET",
         pathname: "/exec",
         query: {

--- a/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/createSchemaCompletionProvider.ts
+++ b/packages/web-console/src/scenes/Editor/Monaco/questdb-sql/createSchemaCompletionProvider.ts
@@ -18,7 +18,7 @@ const isInColumnListing = (text: string) =>
 export const createSchemaCompletionProvider = (
   editor: editor.IStandaloneCodeEditor,
   tables: Table[] = [],
-  informationSchemaColumns: InformationSchemaColumn[] = [],
+  informationSchemaColumns: Record<string, InformationSchemaColumn[]> = {},
 ) => {
   const completionProvider: languages.CompletionItemProvider = {
     triggerCharacters:
@@ -131,8 +131,9 @@ export const createSchemaCompletionProvider = (
                 suggestions: [
                   ...(isInColumnListing(textUntilPosition)
                     ? getColumnCompletions({
-                        columns: informationSchemaColumns.filter((item) =>
-                          tableContext.includes(item.table_name),
+                        columns: tableContext.reduce(
+                          (acc, tableName) => [...acc, ...(informationSchemaColumns[tableName] ?? [])],
+                          [] as InformationSchemaColumn[]
                         ),
                         range,
                         withTableName,
@@ -146,7 +147,10 @@ export const createSchemaCompletionProvider = (
               return {
                 suggestions: [
                   ...getColumnCompletions({
-                    columns: informationSchemaColumns,
+                    columns: Object.values(informationSchemaColumns).reduce(
+                      (acc, columns) => [...acc, ...columns],
+                      [] as InformationSchemaColumn[]
+                    ),
                     range,
                     withTableName: false,
                     priority: CompletionItemPriority.High,

--- a/packages/web-console/src/scenes/Schema/Row/index.tsx
+++ b/packages/web-console/src/scenes/Schema/Row/index.tsx
@@ -62,7 +62,7 @@ type Props = Readonly<{
   isLoading?: boolean
   type?: string
   errors?: string[]
-  value?: string
+  value?: string | React.ReactNode
 }>
 
 const Type = styled(Text)`
@@ -290,6 +290,7 @@ const Row = ({
   const isExpandable = ["folder", "table", "matview"].includes(kind) || (kind === "column" && type === "SYMBOL")
   const isTableKind = ["table", "matview"].includes(kind)
   const isRootFolder = [MATVIEWS_GROUP_KEY, TABLES_GROUP_KEY].includes(id ?? "")
+  const matchesSearch = ["column", "table", "matview"].includes(kind) && query && name.toLowerCase().includes(query.toLowerCase())
 
   const selected = !!(selectedTables.find((t: {name: string, type: TreeNodeKind}) =>
     t.name === name
@@ -349,6 +350,8 @@ const Row = ({
       ref={wrapperRef}
       data-hook={dataHook ?? "schema-row"}
       data-kind={kind}
+      data-search-match={matchesSearch}
+      data-expanded={expanded}
       data-index={index}
       data-id={id}
       className={className}
@@ -444,11 +447,14 @@ const Row = ({
             {kind === "detail" && (
               <InfoCircle size="14px" />
             )}
-            <Highlighter
-              highlightClassName="highlight"
-              searchWords={[query ?? ""]}
-              textToHighlight={name}
-            />
+            {["column", "table", "matview"].includes(kind)
+              ? <Highlighter
+                  highlightClassName="highlight"
+                  searchWords={[query ?? ""]}
+                  textToHighlight={name}
+                />
+              : name
+            }
           </StyledTitle>
 
           {type && (
@@ -457,7 +463,7 @@ const Row = ({
             </Type>
           )}
 
-          {kind === "detail" && (
+          {kind === "detail" && !isLoading && (
             <Text color="gray2">
               {value}
             </Text>

--- a/packages/web-console/src/scenes/Schema/VirtualTables/index.tsx
+++ b/packages/web-console/src/scenes/Schema/VirtualTables/index.tsx
@@ -21,7 +21,7 @@ import { useRetainLastFocus } from "./useRetainLastFocus"
 import { getSectionExpanded, setSectionExpanded, TABLES_GROUP_KEY, MATVIEWS_GROUP_KEY } from "../localStorageUtils";
 import { useSchema } from "../SchemaContext";
 import { QuestContext } from "../../../providers";
-import { PartitionBy } from "../../../utils/questdb/types";
+import { PartitionBy, SymbolColumnDetails } from "../../../utils/questdb/types";
 import { useSelector } from 'react-redux';
 import { selectors } from "../../../store";
 import { ContextMenu, ContextMenuTrigger, ContextMenuContent, MenuItem } from "../../../components/ContextMenu"
@@ -73,12 +73,6 @@ export type FlattenedTreeItem = {
   walEnabled?: boolean
   type?: string
 };
-
-export type SymbolColumnDetails = {
-  symbolCached: boolean
-  symbolCapacity: number
-  indexed: boolean
-}
 
 export type TreeNode = FlattenedTreeItem & {
   children: TreeNode[]
@@ -546,14 +540,7 @@ const VirtualTables: FC<VirtualTablesProps> = ({
     }
   }, [state.view, regularTables, matViewTables, materializedViews, walTables, allColumns]);
 
-  const allColumnsRef = useRef(allColumns)
   useEffect(() => {
-    if (allColumnsRef.current === allColumns) {
-      allColumnsRef.current = allColumns
-      return
-    }
-    allColumnsRef.current = allColumns
-
     symbolColumnDetailsRef.current.clear()
     fetchedSymbolsRef.current.clear()
   }, [allColumns])

--- a/packages/web-console/src/scenes/Schema/VirtualTables/index.tsx
+++ b/packages/web-console/src/scenes/Schema/VirtualTables/index.tsx
@@ -8,13 +8,22 @@ import * as QuestDB from "../../../utils/questdb";
 import { State, View } from "../../Schema";
 import LoadingError from "../LoadingError";
 import Row, { TreeNodeKind } from "../Row";
-import { createTableNode, createColumnNodes, getNodeFromSchemaTree, updateAndGetSchemaTree, findRowIndexById, flattenTree } from "./utils";
+import {
+  createTableNode,
+  updateAndGetSchemaTree,
+  getNodeFromSchemaTree,
+  findRowIndexById,
+  flattenTree,
+  createSymbolDetailsNodes,
+  createSymbolDetailsPlaceholderNodes
+} from "./utils";
 import { useRetainLastFocus } from "./useRetainLastFocus"
 import { getSectionExpanded, setSectionExpanded, TABLES_GROUP_KEY, MATVIEWS_GROUP_KEY } from "../localStorageUtils";
 import { useSchema } from "../SchemaContext";
 import { QuestContext } from "../../../providers";
 import { PartitionBy } from "../../../utils/questdb/types";
-import { useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
+import { selectors } from "../../../store";
 import { ContextMenu, ContextMenuTrigger, ContextMenuContent, MenuItem } from "../../../components/ContextMenu"
 import { copyToClipboard } from "../../../utils/copyToClipboard"
 import { SuspensionDialog } from '../SuspensionDialog'
@@ -28,13 +37,32 @@ type VirtualTablesProps = {
   loadingError: ErrorResult | null
 }
 
+type BaseTreeColumn = {
+  column: string
+  type: Exclude<string, 'TIMESTAMP' | 'SYMBOL'>
+}
+
+type TimestampColumn = BaseTreeColumn & {
+  designated: boolean
+  type: 'TIMESTAMP'
+}
+
+type SymbolColumn = BaseTreeColumn & {
+  symbolCached: boolean
+  symbolCapacity: number
+  indexed: boolean
+  type: 'SYMBOL'
+}
+
+export type TreeColumn = TimestampColumn | SymbolColumn | BaseTreeColumn
+
 export type FlattenedTreeItem = {
   id: string
   kind: TreeNodeKind
   name: string
   value?: string
   table?: QuestDB.Table
-  column?: QuestDB.Column
+  column?: TreeColumn
   matViewData?: QuestDB.MaterializedView
   walTableData?: QuestDB.WalTable
   parent?: string
@@ -45,6 +73,12 @@ export type FlattenedTreeItem = {
   walEnabled?: boolean
   type?: string
 };
+
+export type SymbolColumnDetails = {
+  symbolCached: boolean
+  symbolCapacity: number
+  indexed: boolean
+}
 
 export type TreeNode = FlattenedTreeItem & {
   children: TreeNode[]
@@ -109,51 +143,53 @@ const VirtualTables: FC<VirtualTablesProps> = ({
   state,
   loadingError,
 }) => {
-  const dispatch = useDispatch()
   const { query, focusedIndex, setFocusedIndex } = useSchema()
   const { quest } = useContext(QuestContext)
+  const allColumns = useSelector(selectors.query.getColumns)
 
-  const [columnsReady, setColumnsReady] = useState(false)
   const [schemaTree, setSchemaTree] = useState<SchemaTree>({})
   const [openedContextMenu, setOpenedContextMenu] = useState<string | null>(null)
   const [openedSuspensionDialog, setOpenedSuspensionDialog] = useState<string | null>(null)
 
+  const symbolColumnDetailsRef = useRef<Map<string, SymbolColumnDetails>>(new Map())
+  const fetchedSymbolsRef = useRef<Set<string>>(new Set())
+  const schemaTreeRef = useRef<SchemaTree>(schemaTree)
   const virtuosoRef = useRef<VirtuosoHandle>(null)
   const rangeRef = useRef<ListRange | null>(null)
   const wrapperRef = useRef<HTMLDivElement>(null)
   useRetainLastFocus({ virtuosoRef, focusedIndex, setFocusedIndex, wrapperRef })
 
   const [regularTables, matViewTables] = useMemo(() => {
-    const filtered = tables.filter((table: QuestDB.Table) => {
+    return tables.reduce((acc, table: QuestDB.Table) => {
       const normalizedTableName = table.table_name.toLowerCase()
       const normalizedQuery = query.toLowerCase()
-      return (
-        normalizedTableName.includes(normalizedQuery) &&
-        (filterSuspendedOnly
-          ? table.walEnabled &&
-            walTables?.find((t) => t.name === table.table_name)
-              ?.suspended
-          : true)
-      )
-    })
+      const tableNameMatches = normalizedTableName.includes(normalizedQuery)
+      const columnMatches = !!query && !!(allColumns[table.table_name]?.some(col => 
+        col.column_name.toLowerCase().includes(normalizedQuery)
+      ))
+      const shownIfFilteredSuspendedOnly = filterSuspendedOnly
+        ? table.walEnabled &&
+          walTables?.find((t) => t.name === table.table_name)
+            ?.suspended
+        : true
+      const shownIfFilteredWithQuery = tableNameMatches || columnMatches
 
-    return filtered.reduce((acc, table) => {
-      const index = table.matView ? 1 : 0
-      acc[index].push(table)
+      if (shownIfFilteredSuspendedOnly && shownIfFilteredWithQuery) {
+        acc[table.matView ? 1 : 0].push({ ...table, hasColumnMatches: columnMatches })
+        return acc
+      }
       return acc
-    }, [[], []] as QuestDB.Table[][]).map(tables => 
+    }, [[], []] as (QuestDB.Table & { hasColumnMatches: boolean })[][]).map(tables => 
       tables.sort((a, b) => a.table_name.toLowerCase().localeCompare(b.table_name.toLowerCase()))
     )
-  }, [tables, query, filterSuspendedOnly, walTables])
+  }, [tables, query, filterSuspendedOnly, walTables, allColumns])
 
   const flattenedItems = useMemo(() => {
-    if (!columnsReady) return [];
-    
     return Object.values(schemaTree).reduce((acc, node) => {
       acc.push(...flattenTree(node));
       return acc;
     }, [] as FlattenedTreeItem[]);
-  }, [schemaTree, columnsReady]);
+  }, [schemaTree])
 
   const handleCopyQuery = async (tableName: string, isMatView: boolean) => {
     try {
@@ -173,42 +209,63 @@ const VirtualTables: FC<VirtualTablesProps> = ({
     }
   }
 
-  const fetchColumns = async (name: string) => {
+  const fetchSymbolColumnDetails = useCallback(async (tableName: string, columnName: string): Promise<SymbolColumnDetails | null> => {
     try {
-      const response = await quest.showColumns(name)
-      if (response && response.type === QuestDB.Type.DQL) {
-        return response.data
+      const response = await quest.showSymbolColumnDetails(tableName, columnName)
+      if (response && response.type === QuestDB.Type.DQL && response.data.length > 0) {
+        return response.data[0]
       }
     } catch (error: any) {
-      toast.error(`Cannot show columns from table '${name}'`)
+      toast.error(`Cannot fetch column details from table '${tableName}' for column ${columnName}`)
     }
+    return null
+  }, [quest])
+
+  const getOrFetchSymbolDetails = useCallback(async (
+    id: string,
+    tableName: string,
+    columnName: string
+  ): Promise<TreeNode[]> => {
+    fetchedSymbolsRef.current.add(id)
+    const cached = symbolColumnDetailsRef.current.get(id)
+    if (cached) {
+      return createSymbolDetailsNodes(cached, id)
+    }
+
+    const details = await fetchSymbolColumnDetails(tableName, columnName)
+    if (details) {
+      symbolColumnDetailsRef.current.set(id, details)
+      return createSymbolDetailsNodes(details, id)
+    }
+
     return []
-  }
+  }, [fetchSymbolColumnDetails])
 
   const toggleNodeExpansion = useCallback(async (id: string) => {
     const isExpanded = getSectionExpanded(id)
     const willBeExpanded = !isExpanded
-    
+
     let newTree = { ...schemaTree }
     const modifiedKeys = setSectionExpanded(id, willBeExpanded)
     modifiedKeys.forEach(key => {
       newTree = updateAndGetSchemaTree(newTree, key, node => ({ ...node, isExpanded: willBeExpanded }))
     })
-    
-    if (id.endsWith(':columns')) {
-      const parts = id.split(':');
-      const tableName = parts[parts.length - 2]
+
+    const splittedId = id.split(':')
+    const isColumnDetail = splittedId.length > 2 && splittedId.slice(-2)[0] === 'columns'
+
+    if (isColumnDetail) {
+      let children: TreeNode[]
       if (!willBeExpanded) {
-        newTree = updateAndGetSchemaTree(newTree, id, node => ({ ...node, children: [] }))
+        fetchedSymbolsRef.current.delete(id)
+        children = []
       } else {
-        const columns = await fetchColumns(tableName);
-        if (columns) {
-          newTree = updateAndGetSchemaTree(newTree, id, node => ({ ...node, children: createColumnNodes(node.table!, id, columns) }))
-        }
+        children = createSymbolDetailsPlaceholderNodes(id)
       }
+      newTree = updateAndGetSchemaTree(newTree, id, node => ({ ...node, children })) 
     }
     setSchemaTree(newTree)
-  }, [schemaTree]);
+  }, [schemaTree])
 
   const navigateInTree = useCallback((options: TreeNavigationOptions) => {
     if (!virtuosoRef.current) {
@@ -291,7 +348,25 @@ const VirtualTables: FC<VirtualTablesProps> = ({
 
   const renderRow = useCallback((index: number) => {
     const item = flattenedItems[index];
-    
+
+    if (item.kind === 'column' && item.isExpanded && item.type === 'SYMBOL' && !fetchedSymbolsRef.current.has(item.id)) {
+      const result = getNodeFromSchemaTree(schemaTreeRef.current, item.id)
+      if (result) {
+        const isLoading = result.node.children.some(child => child.isLoading)
+        if (isLoading) {
+          const splittedId = item.id.split(':')
+          const columnName = splittedId.slice(-1)[0]
+          const tableName = splittedId.slice(-3)[0]
+
+          getOrFetchSymbolDetails(item.id, tableName, columnName).then(children => {
+            setSchemaTree(currentTree =>
+              updateAndGetSchemaTree(currentTree, item.id, node => ({ ...node, children }))
+            )
+          })
+        }
+      }
+    }
+
     if (item.kind === 'detail') {
       return (
         <Row
@@ -299,13 +374,14 @@ const VirtualTables: FC<VirtualTablesProps> = ({
           index={index}
           name={item.value ? `${item.name}:` : item.name}
           value={item.value}
+          isLoading={item.isLoading}
           id={item.id}
           onExpandCollapse={() => {}}
           navigateInTree={navigateInTree}
         />
       );
     }
-    
+
     if (item.id === TABLES_GROUP_KEY || item.id === MATVIEWS_GROUP_KEY) {
       const isTable = item.id === TABLES_GROUP_KEY
       return (
@@ -322,7 +398,7 @@ const VirtualTables: FC<VirtualTablesProps> = ({
         />
       );
     }
-    
+
     if (item.kind === 'folder') {
       return (
         <Row
@@ -406,13 +482,14 @@ const VirtualTables: FC<VirtualTablesProps> = ({
           onExpandCollapse={() => toggleNodeExpansion(item.id)}
           designatedTimestamp={item.designatedTimestamp}
           type={item.type}
+          isLoading={item.isLoading}
           id={item.id}
           navigateInTree={navigateInTree}
         />
       );
     }
     
-    return null;
+    return null
   }, [
     flattenedItems,
     regularTables,
@@ -421,57 +498,71 @@ const VirtualTables: FC<VirtualTablesProps> = ({
     openedContextMenu,
     openedSuspensionDialog,
     navigateInTree,
+    getOrFetchSymbolDetails,
   ]);
 
   useEffect(() => {
     if (state.view === View.ready) {
-      const fetchColumnsForExpandedTables = async () => {
-        const newTree: SchemaTree = {
-          [TABLES_GROUP_KEY]: {
-            id: TABLES_GROUP_KEY,
-            kind: 'folder',
-            name: `Tables (${regularTables.length})`,
-            isExpanded: regularTables.length === 0 ? false : getSectionExpanded(TABLES_GROUP_KEY),
-            children: regularTables.map(table => createTableNode(table, TABLES_GROUP_KEY, false, materializedViews, walTables))
-          },
-          [MATVIEWS_GROUP_KEY]: {
-            id: MATVIEWS_GROUP_KEY,
-            kind: 'folder',
-            name: `Materialized views (${matViewTables.length})`,
-            isExpanded: matViewTables.length === 0 ? false : getSectionExpanded(MATVIEWS_GROUP_KEY),
-            children: matViewTables.map(table => createTableNode(table, MATVIEWS_GROUP_KEY, true, materializedViews, walTables))
-          }
-        };
-
-        const allTables = [...regularTables, ...matViewTables]
-        const fetchPromises: Promise<void>[] = []
-
-        for (const table of allTables) {
-          const columnsId = `${table.matView ? MATVIEWS_GROUP_KEY : TABLES_GROUP_KEY}:${table.table_name}:columns`
-          if (getSectionExpanded(columnsId)) {
-            const fetchPromise = fetchColumns(table.table_name).then(columns => {
-              if (columns) {
-                const result = getNodeFromSchemaTree(newTree, columnsId)
-                if (result) {
-                  result.node.children = createColumnNodes(table, columnsId, columns)
-                  result.node.isExpanded = true
-                }
+      const newTree: SchemaTree = {
+        [TABLES_GROUP_KEY]: {
+          id: TABLES_GROUP_KEY,
+          kind: 'folder',
+          name: `Tables (${regularTables.length})`,
+          isExpanded: regularTables.length === 0 ? false : getSectionExpanded(TABLES_GROUP_KEY),
+          children: regularTables.map(table => {
+            const node = createTableNode(table, TABLES_GROUP_KEY, false, materializedViews, walTables, allColumns[table.table_name] ?? [])
+            if (table.hasColumnMatches) {
+              node.isExpanded = true
+              // Also mark the columns folder as expanded (but not persisted)
+              const columnsFolder = node.children.find(child => child.id.endsWith(':columns'))
+              if (columnsFolder) {
+                columnsFolder.isExpanded = true
               }
-            })
-            fetchPromises.push(fetchPromise)
-          }
+            }
+            return node
+          })
+        },
+        [MATVIEWS_GROUP_KEY]: {
+          id: MATVIEWS_GROUP_KEY,
+          kind: 'folder',
+          name: `Materialized views (${matViewTables.length})`,
+          isExpanded: matViewTables.length === 0 ? false : getSectionExpanded(MATVIEWS_GROUP_KEY),
+          children: matViewTables.map(table => {
+            const node = createTableNode(table, MATVIEWS_GROUP_KEY, true, materializedViews, walTables, allColumns[table.table_name] ?? [])
+            if (table.hasColumnMatches) {
+              node.isExpanded = true
+              const columnsFolder = node.children.find(child => child.id.endsWith(':columns'))
+              if (columnsFolder) {
+                columnsFolder.isExpanded = true
+              }
+            }
+            return node
+          })
         }
-
-        await Promise.all(fetchPromises)
-        setSchemaTree(newTree)
-        setColumnsReady(true)
       };
 
-      fetchColumnsForExpandedTables()
+      fetchedSymbolsRef.current.clear()
+      setSchemaTree(newTree)
     }
-  }, [state.view, regularTables, matViewTables, materializedViews]);
+  }, [state.view, regularTables, matViewTables, materializedViews, walTables, allColumns]);
 
-  if (state.view === View.loading || (state.view === View.ready && !columnsReady)) {
+  const allColumnsRef = useRef(allColumns)
+  useEffect(() => {
+    if (allColumnsRef.current === allColumns) {
+      allColumnsRef.current = allColumns
+      return
+    }
+    allColumnsRef.current = allColumns
+
+    symbolColumnDetailsRef.current.clear()
+    fetchedSymbolsRef.current.clear()
+  }, [allColumns])
+
+  useEffect(() => {
+    schemaTreeRef.current = schemaTree
+  }, [schemaTree])
+
+  if (state.view === View.loading) {
     return <Loading />
   }
 

--- a/packages/web-console/src/scenes/Schema/VirtualTables/utils.ts
+++ b/packages/web-console/src/scenes/Schema/VirtualTables/utils.ts
@@ -1,55 +1,89 @@
 import { getSectionExpanded } from "../localStorageUtils"
-import { TreeNode, SchemaTree, FlattenedTreeItem } from "../VirtualTables"
+import type { InformationSchemaColumn } from "../../../utils/questdb/types"
+import { TreeNode, SchemaTree, FlattenedTreeItem, SymbolColumnDetails } from "../VirtualTables"
 import * as QuestDB from "../../../utils/questdb"
 
-export const createColumnNodes = (table: QuestDB.Table, parentId: string, columns: QuestDB.Column[]): TreeNode[] => {
+export const createSymbolDetailsNodes = (details: SymbolColumnDetails, parentId: string): TreeNode[] => {
+  return [
+    {
+      id: `${parentId}:indexed`,
+      kind: 'detail',
+      name: 'Indexed',
+      parent: parentId,
+      value: details.indexed ? 'Yes' : 'No',
+      children: []
+    },
+    {
+      id: `${parentId}:symbolCapacity`,
+      kind: 'detail',
+      name: 'Symbol capacity',
+      parent: parentId,
+      value: details.symbolCapacity.toString(),
+      children: []
+    },
+    {
+      id: `${parentId}:symbolCached`,
+      kind: 'detail',
+      name: 'Cached',
+      parent: parentId,
+      value: details.symbolCached ? 'Yes' : 'No',
+      children: []
+    }
+  ];
+}
+
+export const createSymbolDetailsPlaceholderNodes = (parentId: string): TreeNode[] => {
+  return [
+    {
+      id: `${parentId}:indexed`,
+      kind: 'detail',
+      name: 'Indexed',
+      isLoading: true,
+      parent: parentId,
+      value: 'Loading...',
+      children: []
+    },
+    {
+      id: `${parentId}:symbolCapacity`,
+      kind: 'detail',
+      name: 'Symbol capacity',
+      isLoading: true,
+      parent: parentId,
+      value: 'Loading...',
+      children: []
+    },
+    {
+      id: `${parentId}:symbolCached`,
+      kind: 'detail',
+      name: 'Cached',
+      isLoading: true,
+      parent: parentId,
+      value: 'Loading...',
+      children: []
+    }
+  ];
+}
+
+const createColumnNodes = (table: QuestDB.Table, parentId: string, columns: InformationSchemaColumn[]): TreeNode[] => {
   return columns.map(column => {
-    const columnId = `${parentId}:${column.column}`;
-    
+    const columnId = `${parentId}:${column.column_name}`
+    const isExpanded = getSectionExpanded(columnId)
+
     const columnNode: TreeNode = {
       id: columnId,
       kind: 'column',
-      name: column.column,
-      column,
+      table,
+      name: column.column_name,
       parent: parentId,
-      isExpanded: getSectionExpanded(columnId),
+      isExpanded,
       designatedTimestamp: table.designatedTimestamp,
-      type: column.type,
-      children: []
-    };
-
-    if (column.type === 'SYMBOL') {
-      columnNode.children = [
-        {
-          id: `${columnId}:indexed`,
-          kind: 'detail',
-          name: 'Indexed',
-          parent: columnId,
-          value: column.indexed ? 'Yes' : 'No',
-          children: []
-        },
-        {
-          id: `${columnId}:symbolCapacity`,
-          kind: 'detail',
-          name: 'Symbol capacity',
-          parent: columnId,
-          value: column.symbolCapacity.toString(),
-          children: []
-        },
-        {
-          id: `${columnId}:symbolCached`,
-          kind: 'detail',
-          name: 'Cached',
-          parent: columnId,
-          value: column.symbolCached ? 'Yes' : 'No',
-          children: []
-        }
-      ];
+      type: column.data_type,
+      children: isExpanded && column.data_type === 'SYMBOL' ? createSymbolDetailsPlaceholderNodes(columnId) : []
     }
 
-    return columnNode;
-  });
-  };
+    return columnNode
+  })
+}
 
 const createStorageDetailsNodes = (
   table: QuestDB.Table,
@@ -80,7 +114,8 @@ export const createTableNode = (
   parentId: string,
   isMatView: boolean = false,
   materializedViews: QuestDB.MaterializedView[] | undefined,
-  walTables: QuestDB.WalTable[] | undefined
+  walTables: QuestDB.WalTable[] | undefined,
+  tableColumns: InformationSchemaColumn[]
 ): TreeNode => {
   const tableId = `${parentId}:${table.table_name}`
   const matViewData = isMatView ? materializedViews?.find(mv => mv.view_name === table.table_name) : undefined
@@ -110,7 +145,7 @@ export const createTableNode = (
         table: table,
         parent: tableId,
         isExpanded: getSectionExpanded(columnsId),
-        children: []
+        children: createColumnNodes(table, columnsId, tableColumns)
       },
       {
         id: storageDetailsId,

--- a/packages/web-console/src/scenes/Schema/VirtualTables/utils.ts
+++ b/packages/web-console/src/scenes/Schema/VirtualTables/utils.ts
@@ -1,6 +1,6 @@
 import { getSectionExpanded } from "../localStorageUtils"
-import type { InformationSchemaColumn } from "../../../utils/questdb/types"
-import { TreeNode, SchemaTree, FlattenedTreeItem, SymbolColumnDetails } from "../VirtualTables"
+import type { InformationSchemaColumn, SymbolColumnDetails } from "../../../utils/questdb/types"
+import { TreeNode, SchemaTree, FlattenedTreeItem } from "../VirtualTables"
 import * as QuestDB from "../../../utils/questdb"
 
 export const createSymbolDetailsNodes = (details: SymbolColumnDetails, parentId: string): TreeNode[] => {
@@ -64,7 +64,7 @@ export const createSymbolDetailsPlaceholderNodes = (parentId: string): TreeNode[
   ];
 }
 
-const createColumnNodes = (table: QuestDB.Table, parentId: string, columns: InformationSchemaColumn[]): TreeNode[] => {
+ const createColumnNodes = (table: QuestDB.Table, parentId: string, columns: InformationSchemaColumn[]): TreeNode[] => {
   return columns.map(column => {
     const columnId = `${parentId}:${column.column_name}`
     const isExpanded = getSectionExpanded(columnId)

--- a/packages/web-console/src/scenes/Schema/index.tsx
+++ b/packages/web-console/src/scenes/Schema/index.tsx
@@ -145,6 +145,7 @@ const Schema = ({
   const { autoRefreshTables, updateSettings } = useLocalStorage()
   const [focusListenerActive, setFocusListenerActive] = useState(false)
   const listenerActiveRef = useRef(false)
+  const latestFocusChangeTimestampRef = useRef<number>(0)
   const { addBuffer } = useEditor()
   const { selectOpen, setSelectOpen, selectedTables, setSelectedTables } = useSchema()
 
@@ -279,7 +280,9 @@ const Schema = ({
   }, [])
 
   const focusListener = useCallback(() => {
-    if (listenerActiveRef.current) {
+    const now = Date.now()
+    if (listenerActiveRef.current && now - latestFocusChangeTimestampRef.current > 10_000) {
+      latestFocusChangeTimestampRef.current = now
       void fetchTables()
       void fetchColumns()
     }

--- a/packages/web-console/src/store/Query/reducers.ts
+++ b/packages/web-console/src/store/Query/reducers.ts
@@ -23,11 +23,12 @@
  ******************************************************************************/
 
 import { QueryAction, QueryAT, QueryStateShape, RunningType } from "../../types"
+import type { InformationSchemaColumn } from "utils/questdb"
 
 export const initialState: QueryStateShape = {
   notifications: [],
   tables: [],
-  columns: [],
+  columns: {},
   running: RunningType.NONE,
   queryNotifications: {},
   activeNotification: null,
@@ -230,9 +231,14 @@ const query = (state = initialState, action: QueryAction): QueryStateShape => {
     }
 
     case QueryAT.SET_COLUMNS: {
+      const { columns } = action.payload
+      const categorizedColumns = columns.reduce((acc, column) => {
+        acc[column.table_name] = [...(acc[column.table_name] || []), column]
+        return acc
+      }, {} as Record<string, InformationSchemaColumn[]>)
       return {
         ...state,
-        columns: action.payload.columns,
+        columns: categorizedColumns,
       }
     }
 

--- a/packages/web-console/src/store/Query/selectors.ts
+++ b/packages/web-console/src/store/Query/selectors.ts
@@ -53,7 +53,7 @@ const getRunning: (store: StoreShape) => RunningType = (store) =>
 
 const getTables: (store: StoreShape) => Table[] = (store) => store.query.tables
 
-const getColumns: (store: StoreShape) => InformationSchemaColumn[] = (store) =>
+const getColumns: (store: StoreShape) => Record<string, InformationSchemaColumn[]> = (store) =>
   store.query.columns
 
 export default {

--- a/packages/web-console/src/store/Query/types.ts
+++ b/packages/web-console/src/store/Query/types.ts
@@ -73,7 +73,7 @@ export type QueryNotifications = Readonly<{
 export type QueryStateShape = Readonly<{
   notifications: NotificationShape[]
   tables: Table[]
-  columns: InformationSchemaColumn[]
+  columns: Record<string, InformationSchemaColumn[]>
   result?: QueryRawResult
   running: RunningType
   queryNotifications: Record<number, Record<QueryKey, QueryNotifications>>

--- a/packages/web-console/src/utils/questdb/client.ts
+++ b/packages/web-console/src/utils/questdb/client.ts
@@ -339,6 +339,10 @@ export class Client {
     return await this.query<Column>(`SHOW COLUMNS FROM '${table}';`)
   }
 
+  async showSymbolColumnDetails(table: string, column: string): Promise<QueryResult<{designated: boolean, symbolCached: boolean, symbolCapacity: number, indexed: boolean}>> {
+    return await this.query<Column>(`WITH cols as (SHOW COLUMNS FROM '${table}') SELECT symbolCached, symbolCapacity, indexed FROM cols WHERE column = '${column}';`)
+  }
+
   async showMatViewDDL(table: string): Promise<QueryResult<{ddl: string}>> {
     return await this.query<{ddl: string}>(`SHOW CREATE MATERIALIZED VIEW '${table}';`)
   }

--- a/packages/web-console/src/utils/questdb/client.ts
+++ b/packages/web-console/src/utils/questdb/client.ts
@@ -23,6 +23,7 @@ import {
   Value,
   Preferences,
   Permission,
+  SymbolColumnDetails,
 } from "./types"
 import { ssoAuthState } from "../../modules/OAuth2/ssoAuthState";
 
@@ -339,8 +340,8 @@ export class Client {
     return await this.query<Column>(`SHOW COLUMNS FROM '${table}';`)
   }
 
-  async showSymbolColumnDetails(table: string, column: string): Promise<QueryResult<{designated: boolean, symbolCached: boolean, symbolCapacity: number, indexed: boolean}>> {
-    return await this.query<Column>(`WITH cols as (SHOW COLUMNS FROM '${table}') SELECT symbolCached, symbolCapacity, indexed FROM cols WHERE column = '${column}';`)
+  async showSymbolColumnDetails(table: string, column: string): Promise<QueryResult<{symbolCached: boolean, symbolCapacity: number, indexed: boolean}>> {
+    return await this.query<SymbolColumnDetails>(`WITH cols as (SHOW COLUMNS FROM '${table}') SELECT symbolCached, symbolCapacity, indexed FROM cols WHERE column = '${column}';`)
   }
 
   async showMatViewDDL(table: string): Promise<QueryResult<{ddl: string}>> {

--- a/packages/web-console/src/utils/questdb/types.ts
+++ b/packages/web-console/src/utils/questdb/types.ts
@@ -200,6 +200,12 @@ export type Column = {
   upsertKey: boolean
 }
 
+export type SymbolColumnDetails = {
+  symbolCached: boolean
+  symbolCapacity: number
+  indexed: boolean
+}
+
 export type Options = {
   limit?: string
   explain?: boolean


### PR DESCRIPTION
Uses https://github.com/questdb/ui/pull/476
Resolves https://github.com/questdb/ui/issues/363

- Adds column names to the schema search. Tables containing column matches are auto-expanded
- Removes redundant column requests on schema reload, uses the store to take column name and types
- Fetches symbol column details on demand while scrolling, using `SHOW COLUMNS FROM`. The data is cached until a schema refresh
- Adds a focus listener timeout (10s) such that schema will be refreshed only when the time elapsed as well