### PR TITLE
fix(web-console): do not start a quote in comments

### DIFF
--- a/packages/browser-tests/cypress/commands.js
+++ b/packages/browser-tests/cypress/commands.js
@@ -369,12 +369,15 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
-  "clearStorageAndVisit",
-  (url, clearLocalStorage = true) => {
+  "handleStorageAndVisit",
+  (url, clearLocalStorage = true, localStorageItems = {}) => {
     cy.visit(url, {
       onBeforeLoad: (win) => {
         if (clearLocalStorage) {
           win.localStorage.clear();
+        }
+        for (const [key, value] of Object.entries(localStorageItems)) {
+          win.localStorage.setItem(key, value);
         }
         win.indexedDB.deleteDatabase("web-console");
       },
@@ -382,15 +385,18 @@ Cypress.Commands.add(
   }
 );
 
-Cypress.Commands.add("loadConsoleWithAuth", (clearWarnings = false) => {
-  cy.clearStorageAndVisit(baseUrl);
-  cy.loginWithUserAndPassword();
-  if (clearWarnings) {
-    cy.clearSimulatedWarnings();
-    cy.clearStorageAndVisit(baseUrl, false);
-    cy.getEditor().should("be.visible");
+Cypress.Commands.add(
+  "loadConsoleWithAuth",
+  (clearWarnings = false, localStorageItems = {}) => {
+    cy.handleStorageAndVisit(baseUrl, true, localStorageItems);
+    cy.loginWithUserAndPassword();
+    if (clearWarnings) {
+      cy.clearSimulatedWarnings();
+      cy.handleStorageAndVisit(baseUrl, false, localStorageItems);
+      cy.getEditor().should("be.visible");
+    }
   }
-});
+);
 
 Cypress.Commands.add(
   "loadConsoleAsAdminAndCreateSSOGroup",

--- a/packages/web-console/src/scenes/Editor/Monaco/utils.ts
+++ b/packages/web-console/src/scenes/Editor/Monaco/utils.ts
@@ -273,7 +273,9 @@ export const getQueriesFromPosition = (
       }
 
       case "'": {
-        inQuote = !inQuote
+        if (!inMultiLineComment && !inSingleLineComment) {
+          inQuote = !inQuote
+        }
         column++
         break
       }


### PR DESCRIPTION
The query extraction logic was problematic due to not ignoring single quotes inside a comment. It was taking
```sql
/* This shows us whether there's
stronger buying or selling interest.
*/
DECLARE
  @bid_prices := bids[1],
  @bid_volumes := bids[2],
  @ask_prices := asks[1],
  @ask_volumes := asks[2],
  @best_bid_price := bids[1, 1],
  @best_ask_price := asks[1, 1]
SELECT
  timestamp,
  round((@best_bid_price + @best_ask_price) / 2, 2) mid_price,
  (mid_price - @bid_prices) * @bid_volumes weighted_bid_pressure,
  (@ask_prices - mid_price) * @ask_volumes weighted_ask_pressure
FROM market_data WHERE timestamp > dateadd('h', -1, now()) AND symbol='EURUSD';
select 1;
```
as a single query. This PR adds a check for comments when toggling the `inQuote` variable