### PR TITLE
Schema: enhance table filter to search table and column names with safe in-memory auto-expansion

### DIFF
--- a/packages/browser-tests/cypress/integration/console/schema.spec.js
+++ b/packages/browser-tests/cypress/integration/console/schema.spec.js
@@ -112,6 +112,28 @@ describe("questdb schema with working tables", () => {
     );
   });
 
+  it("should append view data queries from context menu", () => {
+    cy.getByDataHook("schema-table-title").contains("btc_trades").rightclick();
+    cy.getByDataHook("table-context-menu-view-data")
+      .filter(":visible")
+      .click();
+    cy.getEditorContent().should("contain", "SELECT * FROM btc_trades LIMIT 1000;");
+    cy.clearEditor();
+
+    cy.getByDataHook("schema-table-title").contains("btc_trades").rightclick();
+    cy.getByDataHook("table-context-menu-view-data-ts-desc")
+      .filter(":visible")
+      .click();
+    cy.getEditorContent().should("contain", "SELECT * FROM btc_trades ORDER BY timestamp DESC LIMIT 1000;");
+    cy.clearEditor();
+
+    cy.getByDataHook("schema-table-title").contains("btc_trades").rightclick();
+    cy.getByDataHook("table-context-menu-view-data-ts-asc")
+      .filter(":visible")
+      .click();
+    cy.getEditorContent().should("contain", "SELECT * FROM btc_trades ORDER BY timestamp ASC LIMIT 1000;");
+  });
+
   after(() => {
     cy.loadConsoleWithAuth();
     tables.forEach((table) => {
@@ -362,6 +384,20 @@ describe("questdb schema with suspended tables with Linux OS error codes", () =>
       "chicago_weather_stations"
     );
     cy.getByDataHook("schema-filter-suspended-button").click();
+  });
+
+  it("should show view data options in context menu for suspended tables", () => {
+    cy.getByDataHook("schema-table-title").contains("btc_trades").rightclick();
+    cy.getByDataHook("table-context-menu-view-data")
+      .filter(":visible")
+      .should("contain", "View data (Top 1000)");
+    cy.getByDataHook("table-context-menu-view-data-ts-desc")
+      .filter(":visible")
+      .should("contain", "View latest by timestamp (Top 1000)");
+    cy.getByDataHook("table-context-menu-view-data-ts-asc")
+      .filter(":visible")
+      .should("contain", "View earliest by timestamp (Top 1000)");
+    cy.get("body").click(); // Close context menu
   });
 
   it("should show the suspension dialog on context menu click with details for btc_trades", () => {

--- a/packages/web-console/src/components/ContextMenu/index.tsx
+++ b/packages/web-console/src/components/ContextMenu/index.tsx
@@ -7,7 +7,7 @@ const StyledContent = styled(ContextMenuPrimitive.Content)`
   border-radius: 0.5rem;
   padding: 0.4rem;
   box-shadow: 0 0.2rem 0.8rem rgba(0, 0, 0, 0.36); /* vscode-widget-shadow */
-  z-index: 9999;
+  z-index: 10000;
   min-width: 160px;
 `
 
@@ -59,7 +59,8 @@ const StyledSubTrigger = styled(ContextMenuPrimitive.SubTrigger)`
     background-image: url("data:image/svg+xml;base64,PHN2ZyBmaWxsPSIjZmZmIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8cGF0aCBkPSJNMTAuNTkgMTJsLTQuMjktNC4yOWExIDEgMCAxIDEgMS40MS0xLjQxbDUgNWEgMSAxIDAgMCAxIDAgMS40MWwtNS41IDUuNWExIDEgMCAxIDEtMS40MS0xLjQxTDEwLjU5IDEyeiIgLz4KPC9zdmc+");
   }
 
-  &[data-highlighted] {
+  &[data-highlighted],
+  &[data-state="open"] {
     background: #043c5c;
     border: 1px solid #8be9fd;
   }

--- a/packages/web-console/src/scenes/Schema/VirtualTables/utils.ts
+++ b/packages/web-console/src/scenes/Schema/VirtualTables/utils.ts
@@ -1,7 +1,34 @@
 import { getSectionExpanded } from "../localStorageUtils"
-import type { InformationSchemaColumn, SymbolColumnDetails } from "../../../utils/questdb/types"
-import { TreeNode, SchemaTree, FlattenedTreeItem } from "../VirtualTables"
+import type { InformationSchemaColumn, SymbolColumnDetails, PartitionBy } from "../../../utils/questdb/types"
 import * as QuestDB from "../../../utils/questdb"
+import { TreeNodeKind } from "../Row"
+
+type FlattenedTreeItem = {
+  id: string
+  kind: TreeNodeKind
+  name: string
+  value?: string
+  table?: QuestDB.Table
+  matViewData?: QuestDB.MaterializedView
+  walTableData?: QuestDB.WalTable
+  parent?: string
+  isExpanded?: boolean
+  isLoading?: boolean
+  designatedTimestamp?: string
+  partitionBy?: PartitionBy
+  walEnabled?: boolean
+  type?: string
+}
+
+type TreeNode = FlattenedTreeItem & {
+  children: TreeNode[]
+}
+
+export type SchemaTree = {
+  [key: string]: TreeNode
+}
+
+export type { TreeNode, FlattenedTreeItem }
 
 export const createSymbolDetailsNodes = (details: SymbolColumnDetails, parentId: string): TreeNode[] => {
   return [


### PR DESCRIPTION
### Description
Enhanced the table filter in the Schema panel to search both table names and column names. When a column matches the search query, the table automatically expands (in-memory only) to show the matching columns.

### Changes

- **Filter logic:** Updated table filtering to include column name matches using existing Redux allColumns data.
- **Auto-expansion:** Tables with matching columns now auto-expand their table row AND columns folder during search.
- **State management:** Search-driven expansions are purely in-memory and never persist to localStorage.
- **Race condition fix:** Added cleanup mechanism (isCancelled flag) to prevent stale async operations from causing incorrect expansion states during rapid input changes.

### Implementation Details

- **Column matching:** Uses `allColumns` from the Redux store (already fetched via `information_schema.columns()`); no additional network requests.
- **`tablesWithColumnMatches` Set:** Computed via `useMemo` to track which tables need auto-expansion.
- **In-memory expansion:** Sets `node.isExpanded = true` directly on tree nodes without calling `setSectionExpanded()` (which writes to `localStorage`).
- **Async safety:** Effect cleanup function prevents race conditions when users type/delete rapidly.

### Behavior

- **Search for table name** → table stays collapsed (existing behavior preserved).
- **Search for column name** → table + columns auto-expand, matching columns are visible.
- **Clear search** → all expansions revert to localStorage state (user’s manual expansions preserved).
- **Rapid typing/backspace** → no ghost expansions.

### Testing

Tested with sample tables containing columns like col_string, col_ts, sensor_id:
- Column search correctly expands matching tables.
- Table name search maintains collapsed state.
- Rapid input (backspace spam) correctly handles state without stale expansions.
- Clearing search restores previous expansion states.

### Video
https://github.com/user-attachments/assets/91008eb0-252a-49ae-ac5d-f049838d93fb