### PR TITLE
feat: enable dynamic Y-axis scaling in chart view

### DIFF
--- a/packages/web-console/src/js/console/quick-vis.ts
+++ b/packages/web-console/src/js/console/quick-vis.ts
@@ -190,6 +190,7 @@ export function quickVis(
           xAxis: optionXAxis,
           yAxis: {
             type: "value",
+            scale: true, // Enable dynamic scaling based on data values
           },
           series: series,
         }


### PR DESCRIPTION
## Problem
The chart view's Y-axis always starts at 0, making it difficult to visualize data with small variations around large baseline values.

For example, monitoring sensor data like:
- Temperature: 99.7°C - 100.6°C (0.9°C range)
- Pressure: 1012.8 - 1013.9 hPa (1.1 hPa range)

With the Y-axis scaled from 0-100, these small but important variations become nearly invisible.

## Solution
Enable the ECharts `scale: true` option for the Y-axis configuration. This allows the chart to dynamically scale based on actual data values instead of forcing zero as the minimum.

## Changes
- Modified `packages/web-console/src/js/console/quick-vis.ts`
- Added `scale: true` to the yAxis configuration in the chart options

## Result
- Charts now automatically scale to show the actual data range
- Small variations in large values are clearly visible
- No wasted chart space
- Improved data visualization for monitoring scenarios

## Testing
Tested with sensor data containing:
- Temperature readings: 99.7-100.6°C
- Pressure readings: 1012.8-1013.9 hPa

**Before:** Y-axis shows 0-100, data appears as flat line
**After:** Y-axis shows 99.7-100.6, variations are clearly visible

Fixes #45 