### PR TITLE
chore: bump sql-parser to 0.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@monaco-editor/react": "^4.7.0",
     "@phosphor-icons/react": "^2.1.10",
     "@popperjs/core": "2.4.2",
-    "@questdb/sql-parser": "0.1.6",
+    "@questdb/sql-parser": "0.1.8",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2491,12 +2491,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@questdb/sql-parser@npm:0.1.6":
-  version: 0.1.6
-  resolution: "@questdb/sql-parser@npm:0.1.6"
+"@questdb/sql-parser@npm:0.1.8":
+  version: 0.1.8
+  resolution: "@questdb/sql-parser@npm:0.1.8"
   dependencies:
     chevrotain: "npm:^11.1.1"
-  checksum: 10/ebf9b038cef3d49ef994fa8f8aa0be92ac112e7fb81755b88c5c09b1aa9e44bb6197e0a00a841ae50cfc7d44969aa9151c9eec3b8d76f2f982624f76c458c389
+  checksum: 10/09ec2a8987da7714db515b4324ff8fd2e95a3b8c0070c4fb7b4c1d5655ade982bbc5f3123ad5ba1e42c437bc953670ae41a5456d8392e80ebf8ba5af49358556
   languageName: node
   linkType: hard
 
@@ -2518,7 +2518,7 @@ __metadata:
     "@monaco-editor/react": "npm:^4.7.0"
     "@phosphor-icons/react": "npm:^2.1.10"
     "@popperjs/core": "npm:2.4.2"
-    "@questdb/sql-parser": "npm:0.1.6"
+    "@questdb/sql-parser": "npm:0.1.8"
     "@radix-ui/react-alert-dialog": "npm:^1.1.15"
     "@radix-ui/react-context-menu": "npm:^2.2.16"
     "@radix-ui/react-dialog": "npm:^1.1.15"


### PR DESCRIPTION
### Added
- Add `timestamp_sequence_ns` function [#21](https://github.com/questdb/sql-parser/pull/21)
- `array_elem_min`, `array_elem_max`, `array_elem_sum`, `array_elem_avg`, `now_ns`, `systimestamp_ns`, `rnd_timestamp_ns` functions [#19](https://github.com/questdb/sql-parser/pull/19)
- LATERAL JOIN support: `{INNER|LEFT|CROSS} JOIN LATERAL (subquery)` and standalone `FROM t, LATERAL (subquery)` [6e5e5e7](https://github.com/questdb/sql-parser/commit/6e5e5e7)
- UNNEST support including JSON UNNEST [6e5e5e7](https://github.com/questdb/sql-parser/commit/6e5e5e7)
- PARQUET column config in CREATE/ALTER table statements [6e5e5e7](https://github.com/questdb/sql-parser/commit/6e5e5e7)
