### PR TITLE
client: fix 'occured' -> 'occurred' in error message

### DIFF
--- a/src/utils/questdb/client.ts
+++ b/src/utils/questdb/client.ts
@@ -194,7 +194,7 @@ export class Client {
 
       const genericErrorPayload = {
         ...err,
-        error: "An error occured, please try again",
+        error: "An error occurred, please try again",
       }
 
       if (error instanceof DOMException) {


### PR DESCRIPTION
Error message in `src/utils/questdb/client.ts` line 197 reads `An error occured, please try again`. User-visible. Fixed to `occurred`. String-literal-only change.