### PR TITLE
chore(build): guard gitleaks license and pin action SHA

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@83d9cd684c87d95d656c1458ef04895a7f1cbd8e
         if: ${{ secrets.GITLEAKS_LICENSE != '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@83d9cd684c87d95d656c1458ef04895a7f1cbd8e
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
         if: ${{ env.HAS_GITLEAKS_LICENSE == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -9,12 +9,14 @@ on:
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
+    env:
+      HAS_GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE != '' }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@83d9cd684c87d95d656c1458ef04895a7f1cbd8e
-        if: ${{ secrets.GITLEAKS_LICENSE != '' }}
+        if: ${{ env.HAS_GITLEAKS_LICENSE == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}


### PR DESCRIPTION
## Summary
- skip the gitleaks action when `GITLEAKS_LICENSE` is unavailable
- pin `gitleaks/gitleaks-action` to commit `83d9cd684c87d95d656c1458ef04895a7f1cbd8e`

## Why
Public forks do not have access to `GITLEAKS_LICENSE`, so the workflow should skip that step instead of failing on forked pull requests.
