### PR TITLE
fix: remove implicit select suggestions filtering, context-aware function suggestions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          java-version: "17"
+          java-version: "25"
           distribution: "temurin"
           cache: maven
 

--- a/.github/workflows/tests_with_context_path.yml
+++ b/.github/workflows/tests_with_context_path.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          java-version: "17"
+          java-version: "25"
           distribution: "temurin"
           cache: maven
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@monaco-editor/react": "^4.7.0",
     "@phosphor-icons/react": "^2.1.10",
     "@popperjs/core": "2.4.2",
-    "@questdb/sql-parser": "0.1.8",
+    "@questdb/sql-parser": "0.1.9",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",
@@ -171,7 +171,9 @@
     "@types/react": "17.0.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "@monaco-editor/loader": "1.5.0"
+    "@monaco-editor/loader": "1.5.0",
+    "lodash": "4.18.1",
+    "lodash-es": "4.18.1"
   },
   "bundlewatch": {
     "files": [

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@monaco-editor/react": "^4.7.0",
     "@phosphor-icons/react": "^2.1.10",
     "@popperjs/core": "2.4.2",
-    "@questdb/sql-parser": "0.1.10",
+    "@questdb/sql-parser": "0.1.11",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@monaco-editor/react": "^4.7.0",
     "@phosphor-icons/react": "^2.1.10",
     "@popperjs/core": "2.4.2",
-    "@questdb/sql-parser": "0.1.9",
+    "@questdb/sql-parser": "0.1.10",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/src/scenes/Editor/Monaco/index.tsx
+++ b/src/scenes/Editor/Monaco/index.tsx
@@ -2212,6 +2212,7 @@ const MonacoEditor = ({ hidden = false }: { hidden?: boolean }) => {
               tabSize: 2,
               lineNumbersMinChars,
               wordBasedSuggestions: "off",
+              matchOnWordStartOnly: false,
             }}
             theme="dracula"
           />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2491,12 +2491,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@questdb/sql-parser@npm:0.1.8":
-  version: 0.1.8
-  resolution: "@questdb/sql-parser@npm:0.1.8"
+"@questdb/sql-parser@npm:0.1.9":
+  version: 0.1.9
+  resolution: "@questdb/sql-parser@npm:0.1.9"
   dependencies:
     chevrotain: "npm:^11.1.1"
-  checksum: 10/09ec2a8987da7714db515b4324ff8fd2e95a3b8c0070c4fb7b4c1d5655ade982bbc5f3123ad5ba1e42c437bc953670ae41a5456d8392e80ebf8ba5af49358556
+  checksum: 10/bb10d6ec147b9124be3f4f713f6e880dfe94abca1a6f39bdbe509e3ec2fcbd8a28df065fca9595377df60465af20f83a6d9a08cda40f6f64f086e592ba682a20
   languageName: node
   linkType: hard
 
@@ -2518,7 +2518,7 @@ __metadata:
     "@monaco-editor/react": "npm:^4.7.0"
     "@phosphor-icons/react": "npm:^2.1.10"
     "@popperjs/core": "npm:2.4.2"
-    "@questdb/sql-parser": "npm:0.1.8"
+    "@questdb/sql-parser": "npm:0.1.9"
     "@radix-ui/react-alert-dialog": "npm:^1.1.15"
     "@radix-ui/react-context-menu": "npm:^2.2.16"
     "@radix-ui/react-dialog": "npm:^1.1.15"
@@ -8536,10 +8536,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:4.17.23":
-  version: 4.17.23
-  resolution: "lodash-es@npm:4.17.23"
-  checksum: 10/1feae200df22eb0bd93ca86d485e77784b8a9fb1d13e91b66e9baa7a7e5e04be088c12a7e20c2250fc0bd3db1bc0ef0affc7d9e3810b6af2455a3c6bf6dde59e
+"lodash-es@npm:4.18.1":
+  version: 4.18.1
+  resolution: "lodash-es@npm:4.18.1"
+  checksum: 10/8bfad225ef09ef42b04283cdaf7830efcc2ba29ae41b56501c74422155ee1ccaa1f0f6e8319def3451a1fe54dec501c8e4bee622bae2b2d98ac993731e0a5cce
   languageName: node
   linkType: hard
 
@@ -8585,10 +8585,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.21":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 10/c08619c038846ea6ac754abd6dd29d2568aa705feb69339e836dfa8d8b09abbb2f859371e86863eda41848221f9af43714491467b5b0299122431e202bb0c532
+"lodash@npm:4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10/306fea53dfd39dad1f03d45ba654a2405aebd35797b673077f401edb7df2543623dc44b9effbb98f69b32152295fff725a4cec99c684098947430600c6af0c3f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2491,12 +2491,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@questdb/sql-parser@npm:0.1.10":
-  version: 0.1.10
-  resolution: "@questdb/sql-parser@npm:0.1.10"
+"@questdb/sql-parser@npm:0.1.11":
+  version: 0.1.11
+  resolution: "@questdb/sql-parser@npm:0.1.11"
   dependencies:
     chevrotain: "npm:11.1.1"
-  checksum: 10/89fd18e630b1b6407c099a59035723b4d9a4d28abf38ff1b48946003483c8f56e8882152f88c6305d1b57ab007eb8231673522ce83fc90893e868bdfa081ba60
+  checksum: 10/5449fa95d2c9a25873b953997782a59cc8a89a3cc56f3cc0dd91657fca76ef6905fbd4f940c7d0215db8d64bc86e013ace2f0145a5e29ef02fe3ac318bee035a
   languageName: node
   linkType: hard
 
@@ -2518,7 +2518,7 @@ __metadata:
     "@monaco-editor/react": "npm:^4.7.0"
     "@phosphor-icons/react": "npm:^2.1.10"
     "@popperjs/core": "npm:2.4.2"
-    "@questdb/sql-parser": "npm:0.1.10"
+    "@questdb/sql-parser": "npm:0.1.11"
     "@radix-ui/react-alert-dialog": "npm:^1.1.15"
     "@radix-ui/react-context-menu": "npm:^2.2.16"
     "@radix-ui/react-dialog": "npm:^1.1.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2491,12 +2491,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@questdb/sql-parser@npm:0.1.9":
-  version: 0.1.9
-  resolution: "@questdb/sql-parser@npm:0.1.9"
+"@questdb/sql-parser@npm:0.1.10":
+  version: 0.1.10
+  resolution: "@questdb/sql-parser@npm:0.1.10"
   dependencies:
-    chevrotain: "npm:^11.1.1"
-  checksum: 10/bb10d6ec147b9124be3f4f713f6e880dfe94abca1a6f39bdbe509e3ec2fcbd8a28df065fca9595377df60465af20f83a6d9a08cda40f6f64f086e592ba682a20
+    chevrotain: "npm:11.1.1"
+  checksum: 10/89fd18e630b1b6407c099a59035723b4d9a4d28abf38ff1b48946003483c8f56e8882152f88c6305d1b57ab007eb8231673522ce83fc90893e868bdfa081ba60
   languageName: node
   linkType: hard
 
@@ -2518,7 +2518,7 @@ __metadata:
     "@monaco-editor/react": "npm:^4.7.0"
     "@phosphor-icons/react": "npm:^2.1.10"
     "@popperjs/core": "npm:2.4.2"
-    "@questdb/sql-parser": "npm:0.1.9"
+    "@questdb/sql-parser": "npm:0.1.10"
     "@radix-ui/react-alert-dialog": "npm:^1.1.15"
     "@radix-ui/react-context-menu": "npm:^2.2.16"
     "@radix-ui/react-dialog": "npm:^1.1.15"
@@ -5272,7 +5272,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chevrotain@npm:^11.1.1":
+"chevrotain@npm:11.1.1":
   version: 11.1.1
   resolution: "chevrotain@npm:11.1.1"
   dependencies:


### PR DESCRIPTION
Related parser commit: https://github.com/questdb/sql-parser/commit/5a422b098fef678238bcb12fb1e71a59f42ba7e3

## Summary                                                                                                                                                                     
                                                                                                                                                                               
Bumps `@questdb/sql-parser` from 0.1.8 to 0.1.11 — autocomplete now picks function categories from the cursor's grammar context instead of dumping the full function list at every identifier position, implicit select statements suggestions are included in the statement start.
Fixes hanging editor when there is a trailing comma in the select list.


Adds manual resolutions for `lodash` and `lodash-es` to version `4.18.1` to resolve vulnerability scan issues
                                                                                                                                                                                 
  ## Examples     

  **`t|`**
  - Before: Not suggesting any tables
  - After: Suggests `trades` (if table exists), `tables`, `wal_tables` etc.                                                                                                                                                
   
  **`SELECT * FROM trades ASOF JOIN m|`**                                                                                                                                        
  - Before: 332 entries — `materialized_views`, `maxUncommittedRows`, `max`, `median`, `mid`, `millis`, `min`, …                                                               
  - After: 3 entries — `materialized_views`, `memory_metrics`, `table_writer_metrics`                                                                                            
                                                                                                                                                                                 
  **`SELECT * FROM trades WHERE price = c|`**                                                                                                                                    
  - Before: scalars + aggregates mixed (`coalesce`, `count`, `count_distinct`, `corr`, `covar_*`, …)                                                                             
  - After: scalars only (`coalesce`, `concat`, `cos`, `ceil`)                                                                                                                    
                                                                                                                                                                                 
  **`INSERT INTO trades VALUES (n|`**                                                                                                                                            
  - Before: 0 suggestions                                                                                                                                                        
  - After: `now`, `now_ns`, `nullif`, `nanos`, `netmask`                                                                                                                                                                                                                                                                                       