### PR TITLE
fix(console): auto-collapse sidebars on narrow viewports

### DIFF
--- a/src/hooks/useScreenSize.tsx
+++ b/src/hooks/useScreenSize.tsx
@@ -38,19 +38,32 @@ type Props = Readonly<{
 
 type ScreenSize = Readonly<{
   sm: boolean
+  // True below 1024 px: left schema/search panel auto-collapses so the
+  // notebook keeps a usable width even when the right panel is also open.
+  md: boolean
+  // True below 1280 px: right AI/table-details panel (470 px min-width)
+  // auto-collapses first because it has the larger footprint. The left panel
+  // remains available at 1024–1279 px.
+  lg: boolean
 }>
 
 enum Breakpoint {
   SM = 767,
+  MD = 1024,
+  LG = 1280,
 }
 
 const ScreenSizeContext = createContext<ScreenSize>({
   sm: window.innerWidth <= Breakpoint.SM,
+  md: window.innerWidth <= Breakpoint.MD,
+  lg: window.innerWidth <= Breakpoint.LG,
 })
 
 export const ScreenSizeProvider = ({ children }: Props) => {
   const [screenSize, setScreenSize] = useState<ScreenSize>({
     sm: window.innerWidth <= Breakpoint.SM,
+    md: window.innerWidth <= Breakpoint.MD,
+    lg: window.innerWidth <= Breakpoint.LG,
   })
   const [_screenSize, _setScreenSize] = useState<ScreenSize | undefined>()
 
@@ -58,6 +71,8 @@ export const ScreenSizeProvider = ({ children }: Props) => {
     const handleResize = throttle(16, () => {
       _setScreenSize({
         sm: window.innerWidth <= Breakpoint.SM,
+        md: window.innerWidth <= Breakpoint.MD,
+        lg: window.innerWidth <= Breakpoint.LG,
       })
     })
     window.addEventListener("resize", handleResize)

--- a/src/hooks/useScreenSize.tsx
+++ b/src/hooks/useScreenSize.tsx
@@ -37,13 +37,13 @@ type Props = Readonly<{
 }>
 
 type ScreenSize = Readonly<{
+  // ≤767px: all sidebars are auto-closed; user can reopen any of them.
   sm: boolean
-  // True below 1024 px: left schema/search panel auto-collapses so the
-  // notebook keeps a usable width even when the right panel is also open.
+  // ≤1024px: left schema/search panel is auto-closed; user can reopen it.
+  // Right sidebar was already closed by the lg transition.
   md: boolean
-  // True below 1280 px: right AI/table-details panel (470 px min-width)
-  // auto-collapses first because it has the larger footprint. The left panel
-  // remains available at 1024–1279 px.
+  // ≤1280px: right AI/table-details panel is auto-closed first (largest
+  // footprint at 470px min); left panel remains available. User can reopen.
   lg: boolean
 }>
 

--- a/src/hooks/useScreenSize.tsx
+++ b/src/hooks/useScreenSize.tsx
@@ -29,23 +29,18 @@ import React, {
   useEffect,
   useState,
 } from "react"
-import { shallowEqual } from "react-redux"
 import { throttle } from "throttle-debounce"
 
 type Props = Readonly<{
   children: ReactNode
 }>
 
-type ScreenSize = Readonly<{
-  // ≤767px: all sidebars are auto-closed; user can reopen any of them.
-  sm: boolean
-  // ≤1024px: left schema/search panel is auto-closed; user can reopen it.
-  // Right sidebar was already closed by the lg transition.
-  md: boolean
-  // ≤1280px: right AI/table-details panel is auto-closed first (largest
-  // footprint at 470px min); left panel remains available. User can reopen.
-  lg: boolean
-}>
+export enum ScreenSize {
+  SM,
+  MD,
+  LG,
+  XL,
+}
 
 enum Breakpoint {
   SM = 767,
@@ -53,27 +48,22 @@ enum Breakpoint {
   LG = 1280,
 }
 
-const ScreenSizeContext = createContext<ScreenSize>({
-  sm: window.innerWidth <= Breakpoint.SM,
-  md: window.innerWidth <= Breakpoint.MD,
-  lg: window.innerWidth <= Breakpoint.LG,
-})
+const getScreenSize = (): ScreenSize => {
+  const width = window.innerWidth
+  if (width <= Breakpoint.SM) return ScreenSize.SM
+  if (width <= Breakpoint.MD) return ScreenSize.MD
+  if (width <= Breakpoint.LG) return ScreenSize.LG
+  return ScreenSize.XL
+}
+
+const ScreenSizeContext = createContext<ScreenSize>(getScreenSize())
 
 export const ScreenSizeProvider = ({ children }: Props) => {
-  const [screenSize, setScreenSize] = useState<ScreenSize>({
-    sm: window.innerWidth <= Breakpoint.SM,
-    md: window.innerWidth <= Breakpoint.MD,
-    lg: window.innerWidth <= Breakpoint.LG,
-  })
-  const [_screenSize, _setScreenSize] = useState<ScreenSize | undefined>()
+  const [screenSize, setScreenSize] = useState(getScreenSize)
 
   useEffect(() => {
     const handleResize = throttle(16, () => {
-      _setScreenSize({
-        sm: window.innerWidth <= Breakpoint.SM,
-        md: window.innerWidth <= Breakpoint.MD,
-        lg: window.innerWidth <= Breakpoint.LG,
-      })
+      setScreenSize(getScreenSize())
     })
     window.addEventListener("resize", handleResize)
 
@@ -81,12 +71,6 @@ export const ScreenSizeProvider = ({ children }: Props) => {
       window.removeEventListener("resize", handleResize)
     }
   }, [])
-
-  useEffect(() => {
-    if (_screenSize && !shallowEqual(_screenSize, screenSize)) {
-      setScreenSize(_screenSize)
-    }
-  }, [screenSize, _screenSize])
 
   return (
     <ScreenSizeContext.Provider value={screenSize}>

--- a/src/scenes/Console/index.tsx
+++ b/src/scenes/Console/index.tsx
@@ -100,7 +100,7 @@ const viewModes: {
 
 const Console = () => {
   const dispatch = useDispatch()
-  const { sm } = useScreenSize()
+  const { sm, md, lg } = useScreenSize()
   const {
     resultsSplitterBasis,
     updateSettings,
@@ -147,6 +147,7 @@ const Console = () => {
   return (
     <Root>
       <Allotment
+        proportionalLayout={false}
         onDragEnd={(sizes) => {
           // sizes[1] is the AI chat panel width when it's open
           if (activeSidebar !== null && sizes[1] !== undefined) {
@@ -294,7 +295,9 @@ const Console = () => {
                       <Allotment.Pane
                         preferredSize={leftPanelState.width}
                         visible={
-                          (isDataSourcesPanelOpen || isSearchPanelOpen) && !sm
+                          (isDataSourcesPanelOpen || isSearchPanelOpen) &&
+                          !sm &&
+                          !md
                         }
                         minSize={320}
                       >
@@ -332,7 +335,7 @@ const Console = () => {
         <Allotment.Pane
           minSize={470}
           preferredSize={aiChatPanelWidth}
-          visible={!!activeSidebar}
+          visible={!!activeSidebar && !lg}
         >
           <SidePanelRight id="side-panel-right" />
         </Allotment.Pane>

--- a/src/scenes/Console/index.tsx
+++ b/src/scenes/Console/index.tsx
@@ -7,7 +7,7 @@ import { Tooltip } from "../../components"
 import Editor from "../Editor"
 import Result from "../Result"
 import Schema from "../Schema"
-import { useScreenSize } from "../../hooks"
+import { ScreenSize, useScreenSize } from "../../hooks"
 import { useLocalStorage } from "../../providers/LocalStorageProvider"
 import { StoreKey } from "../../utils/localStorage/types"
 import { useSelector } from "react-redux"
@@ -20,7 +20,7 @@ import { BUTTON_ICON_SIZE } from "../../consts"
 import { PrimaryToggleButton } from "../../components"
 import { Import } from "./import"
 import { BottomPanel } from "../../store/Console/types"
-import { Allotment, AllotmentHandle } from "allotment"
+import { Allotment, AllotmentHandle, LayoutPriority } from "allotment"
 import { Import as ImportIcon } from "../../components/icons/import"
 import { useSettings, useSearch } from "../../providers"
 import { SearchPanel } from "../Search"
@@ -100,7 +100,7 @@ const viewModes: {
 
 const Console = () => {
   const dispatch = useDispatch()
-  const { sm, md, lg } = useScreenSize()
+  const screenSize = useScreenSize()
   const {
     resultsSplitterBasis,
     updateSettings,
@@ -122,6 +122,7 @@ const Console = () => {
   const resultRef = React.useRef<HTMLDivElement>(null)
   const importRef = React.useRef<HTMLDivElement>(null)
   const horizontalSplitterRef = React.useRef<AllotmentHandle>(null)
+  const previousScreenSizeRef = React.useRef(ScreenSize.XL)
 
   const showPanel = (panel: BottomPanel) => {
     if (resultRef.current) {
@@ -144,32 +145,20 @@ const Console = () => {
     showPanel(activeBottomPanel)
   }, [activeBottomPanel])
 
-  // Crossing into ≤1280px: auto-close the right sidebar so the notebook
-  // keeps usable width. The user can reopen it at any time.
   useEffect(() => {
-    if (lg) {
+    const previousScreenSize = previousScreenSizeRef.current
+    previousScreenSizeRef.current = screenSize
+    const shrankInto = (size: ScreenSize) =>
+      previousScreenSize > size && screenSize <= size
+
+    if (shrankInto(ScreenSize.LG) || shrankInto(ScreenSize.SM)) {
       dispatch(actions.console.closeSidebar())
     }
-  }, [lg]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Crossing into ≤1024px: auto-close the left panels. The right sidebar
-  // was already closed by the lg effect above.
-  useEffect(() => {
-    if (md) {
+    if (shrankInto(ScreenSize.MD) || shrankInto(ScreenSize.SM)) {
       updateLeftPanelState({ type: null, width: leftPanelState.width })
       setSearchPanelOpen(false)
     }
-  }, [md]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Crossing into ≤767px: close everything, including any panel the user
-  // manually re-opened while in the md range.
-  useEffect(() => {
-    if (sm) {
-      dispatch(actions.console.closeSidebar())
-      updateLeftPanelState({ type: null, width: leftPanelState.width })
-      setSearchPanelOpen(false)
-    }
-  }, [sm]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [screenSize])
 
   return (
     <Root>
@@ -182,7 +171,7 @@ const Console = () => {
           }
         }}
       >
-        <Allotment.Pane>
+        <Allotment.Pane priority={LayoutPriority.High}>
           <MainContent>
             <ContentArea>
               <Sidebar align="top">
@@ -321,6 +310,7 @@ const Console = () => {
                         preferredSize={leftPanelState.width}
                         visible={isDataSourcesPanelOpen || isSearchPanelOpen}
                         minSize={320}
+                        priority={LayoutPriority.Low}
                       >
                         <Schema open={isDataSourcesPanelOpen} />
                         <SearchPanel
@@ -328,7 +318,7 @@ const Console = () => {
                           open={isSearchPanelOpen}
                         />
                       </Allotment.Pane>
-                      <Allotment.Pane>
+                      <Allotment.Pane priority={LayoutPriority.High}>
                         <Editor />
                       </Allotment.Pane>
                     </Allotment>
@@ -357,6 +347,7 @@ const Console = () => {
           minSize={470}
           preferredSize={aiChatPanelWidth}
           visible={!!activeSidebar}
+          priority={LayoutPriority.Low}
         >
           <SidePanelRight id="side-panel-right" />
         </Allotment.Pane>

--- a/src/scenes/Console/index.tsx
+++ b/src/scenes/Console/index.tsx
@@ -144,6 +144,33 @@ const Console = () => {
     showPanel(activeBottomPanel)
   }, [activeBottomPanel])
 
+  // Crossing into ≤1280px: auto-close the right sidebar so the notebook
+  // keeps usable width. The user can reopen it at any time.
+  useEffect(() => {
+    if (lg) {
+      dispatch(actions.console.closeSidebar())
+    }
+  }, [lg]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Crossing into ≤1024px: auto-close the left panels. The right sidebar
+  // was already closed by the lg effect above.
+  useEffect(() => {
+    if (md) {
+      updateLeftPanelState({ type: null, width: leftPanelState.width })
+      setSearchPanelOpen(false)
+    }
+  }, [md]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Crossing into ≤767px: close everything, including any panel the user
+  // manually re-opened while in the md range.
+  useEffect(() => {
+    if (sm) {
+      dispatch(actions.console.closeSidebar())
+      updateLeftPanelState({ type: null, width: leftPanelState.width })
+      setSearchPanelOpen(false)
+    }
+  }, [sm]) // eslint-disable-line react-hooks/exhaustive-deps
+
   return (
     <Root>
       <Allotment
@@ -159,35 +186,33 @@ const Console = () => {
           <MainContent>
             <ContentArea>
               <Sidebar align="top">
-                {!sm && (
-                  <Tooltip
-                    placement="right"
-                    content={`${isDataSourcesPanelOpen ? "Hide" : "Show"} data sources`}
+                <Tooltip
+                  placement="right"
+                  content={`${isDataSourcesPanelOpen ? "Hide" : "Show"} data sources`}
+                >
+                  <Navigation
+                    data-hook="tables-panel-button"
+                    direction="left"
+                    onClick={() => {
+                      if (isDataSourcesPanelOpen) {
+                        void trackEvent(ConsoleEvent.SCHEMA_OPEN)
+                        updateLeftPanelState({
+                          type: null,
+                          width: leftPanelState.width,
+                        })
+                      } else {
+                        void trackEvent(ConsoleEvent.SCHEMA_CLOSE)
+                        updateLeftPanelState({
+                          type: LeftPanelType.DATASOURCES,
+                          width: leftPanelState.width,
+                        })
+                      }
+                    }}
+                    selected={isDataSourcesPanelOpen}
                   >
-                    <Navigation
-                      data-hook="tables-panel-button"
-                      direction="left"
-                      onClick={() => {
-                        if (isDataSourcesPanelOpen) {
-                          void trackEvent(ConsoleEvent.SCHEMA_OPEN)
-                          updateLeftPanelState({
-                            type: null,
-                            width: leftPanelState.width,
-                          })
-                        } else {
-                          void trackEvent(ConsoleEvent.SCHEMA_CLOSE)
-                          updateLeftPanelState({
-                            type: LeftPanelType.DATASOURCES,
-                            width: leftPanelState.width,
-                          })
-                        }
-                      }}
-                      selected={isDataSourcesPanelOpen}
-                    >
-                      <Database2 size={BUTTON_ICON_SIZE} />
-                    </Navigation>
-                  </Tooltip>
-                )}
+                    <Database2 size={BUTTON_ICON_SIZE} />
+                  </Navigation>
+                </Tooltip>
                 <Tooltip
                   placement="right"
                   content={
@@ -294,11 +319,7 @@ const Console = () => {
                     >
                       <Allotment.Pane
                         preferredSize={leftPanelState.width}
-                        visible={
-                          (isDataSourcesPanelOpen || isSearchPanelOpen) &&
-                          !sm &&
-                          !md
-                        }
+                        visible={isDataSourcesPanelOpen || isSearchPanelOpen}
                         minSize={320}
                       >
                         <Schema open={isDataSourcesPanelOpen} />
@@ -335,7 +356,7 @@ const Console = () => {
         <Allotment.Pane
           minSize={470}
           preferredSize={aiChatPanelWidth}
-          visible={!!activeSidebar && !lg}
+          visible={!!activeSidebar}
         >
           <SidePanelRight id="side-panel-right" />
         </Allotment.Pane>

--- a/src/scenes/Editor/Menu/index.tsx
+++ b/src/scenes/Editor/Menu/index.tsx
@@ -36,7 +36,7 @@ import {
   TransitionDuration,
   SetupAIAssistant,
 } from "../../../components"
-import { useKeyPress, useScreenSize } from "../../../hooks"
+import { ScreenSize, useKeyPress, useScreenSize } from "../../../hooks"
 import { actions, selectors } from "../../../store"
 import { color } from "../../../utils"
 import QueryPicker from "../QueryPicker"
@@ -140,7 +140,7 @@ const Menu = () => {
   const escPress = useKeyPress("Escape")
   const { consoleConfig } = useSettings()
   const opened = useSelector(selectors.console.getSideMenuOpened)
-  const { sm } = useScreenSize()
+  const isSmallScreen = useScreenSize() === ScreenSize.SM
   const { exampleQueriesVisited, updateSettings } = useLocalStorage()
   const handleQueriesToggle = useCallback((active: boolean) => {
     if (!exampleQueriesVisited && active) {
@@ -160,13 +160,13 @@ const Menu = () => {
   }, [escPress])
 
   useEffect(() => {
-    if (!sm && opened) {
+    if (!isSmallScreen && opened) {
       dispatch(actions.console.toggleSideMenu())
     }
-  }, [dispatch, opened, sm])
+  }, [dispatch, opened, isSmallScreen])
 
   return (
-    <Wrapper _display={sm ? "none" : "inline"}>
+    <Wrapper _display={isSmallScreen ? "none" : "inline"}>
       <Separator />
 
       {consoleConfig.savedQueries && consoleConfig.savedQueries.length > 0 && (
@@ -221,7 +221,7 @@ const Menu = () => {
         )}
       </MenuItems>
 
-      {sm && (
+      {isSmallScreen && (
         <SideMenuMenuButton
           skin="transparent"
           onClick={handleSideMenuButtonClick}

--- a/src/scenes/Notifications/index.tsx
+++ b/src/scenes/Notifications/index.tsx
@@ -40,7 +40,7 @@ import {
   PaneWrapper,
   Text,
 } from "../../components"
-import { useScreenSize } from "../../hooks"
+import { ScreenSize, useScreenSize } from "../../hooks"
 import { selectors } from "../../store"
 import { TerminalBox, Subtract, ArrowUpS } from "@styled-icons/remix-line"
 import Notification from "./Notification"
@@ -131,7 +131,7 @@ const Notifications = ({
       ),
     ) || {}
   const activeNotification = useSelector(selectors.query.getActiveNotification)
-  const { sm } = useScreenSize()
+  const isSmallScreen = useScreenSize() === ScreenSize.SM
   const [isMinimized, setIsMinimized] = useState(true)
   const contentRef = useRef<HTMLDivElement | null>(null)
 
@@ -181,10 +181,10 @@ const Notifications = ({
   }, [isMinimized])
 
   useEffect(() => {
-    if (sm) {
+    if (isSmallScreen) {
       setIsMinimized(true)
     }
-  }, [sm])
+  }, [isSmallScreen])
 
   return (
     <Wrapper minimized={isMinimized} data-hook="notifications-wrapper">


### PR DESCRIPTION
Part **B** of #574: when the viewport shrinks, auto-collapse the left and right sidebars so the notebook stays the primary, usable surface.

Stacks on #581 (Part A).

### Changes
**`src/hooks/useScreenSize.tsx`**
- Add `md` (1024px) and `lg` (1280px) breakpoints alongside the existing `sm` (767px)
- Same throttled resize + `shallowEqual` update pattern as `sm`

**`src/scenes/Console/index.tsx`**
- **Right panel** (`AI` / table details): hide below **1280px** (`!lg`) — larger footprint (470px min), collapses first
- **Left panel** (schema / search): hide below **1024px** (`!md`) — in addition to existing `!sm` at 767px
- Set `proportionalLayout={false}` on the outer `Allotment` so the AI panel restores its saved `preferredSize` after resize instead of expanding to max width

### Behaviour

| Viewport | Right panel | Left panel | Notebook |
|---|---|---|---|
| > 1280px | visible if open | visible if open | normal layout |
| 1025–1280px | auto-hidden | visible if open | gains ~470px |
| 768–1024px | auto-hidden | auto-hidden | fills center |
| ≤ 767px | auto-hidden | auto-hidden | same as before (`sm`) |

Panel open/close state (Redux `activeSidebar`, localStorage `leftPanelState`) is **not** mutated — panels restore when the viewport widens past the threshold.

### Out of scope
- Mobile icon visibility (datasource hidden at `sm`) – pre-existing
- Drawer/overlay for panel toggles on very narrow viewports – **follow-up if desired**

- Closes: #574 (Part B)
- Stacked on: #581  
