### PR TITLE
fix: recognize the TO REMOTE storage policy stage across the console

### DIFF
--- a/e2e/tests/console/tableDetails.spec.js
+++ b/e2e/tests/console/tableDetails.spec.js
@@ -1208,7 +1208,7 @@ describe("TableDetailsDrawer", () => {
             if (row && typeof row[0] === "string") {
               row[0] = row[0].replace(
                 /(\bPARTITION\s+BY\s+\w+)/i,
-                "$1 STORAGE POLICY(TO PARQUET 3 DAYS, DROP NATIVE 10 DAYS, DROP LOCAL 1 YEARS)",
+                "$1 STORAGE POLICY(TO PARQUET 3 DAYS, TO REMOTE 10 DAYS, DROP LOCAL 1 YEARS)",
               )
             }
           })
@@ -1228,7 +1228,7 @@ describe("TableDetailsDrawer", () => {
         .within(() => {
           cy.contains("To Parquet").should("be.visible")
           cy.contains("3 Days").should("be.visible")
-          cy.contains("Drop Native").should("be.visible")
+          cy.contains("To Remote").should("be.visible")
           cy.contains("10 Days").should("be.visible")
           cy.contains("Drop Local").should("be.visible")
           cy.contains("1 Year").should("be.visible")

--- a/e2e/tests/enterprise/tableDetails.spec.js
+++ b/e2e/tests/enterprise/tableDetails.spec.js
@@ -19,7 +19,7 @@ describe("TableDetailsDrawer in enterprise", () => {
         .within(() => {
           cy.contains("Not configured").should("be.visible")
           cy.contains("To Parquet").should("not.exist")
-          cy.contains("Drop Native").should("not.exist")
+          cy.contains("To Remote").should("not.exist")
           cy.contains("Drop Local").should("not.exist")
           cy.contains("Drop Remote").should("not.exist")
         })

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@monaco-editor/react": "^4.7.0",
     "@phosphor-icons/react": "^2.1.10",
     "@popperjs/core": "2.4.2",
-    "@questdb/sql-parser": "0.1.14",
+    "@questdb/sql-parser": "0.1.15",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/scripts/run_ent_browser_tests.sh
+++ b/scripts/run_ent_browser_tests.sh
@@ -131,8 +131,9 @@ echo $MVN_REPO
 CORE_CLASSES=tmp/questdb-enterprise/questdb/core/target/classes
 ENT_CLASSES=tmp/questdb-enterprise/questdb-ent/target/classes
 JAR_JNI=org/questdb/jar-jni/1.1.1/jar-jni-1.1.1.jar
+JVM_ARGS="--add-exports=java.base/jdk.internal.vm=ALL-UNNAMED"
 
-$JAVA_HOME/bin/java -cp $CORE_CLASSES:$ENT_CLASSES:$MVN_REPO/$JAR_JNI com.questdb.EntServerMain -d tmp/dbroot &
+$JAVA_HOME/bin/java $JVM_ARGS -cp $CORE_CLASSES:$ENT_CLASSES:$MVN_REPO/$JAR_JNI com.questdb.EntServerMain -d tmp/dbroot &
 PID2="$!"
 yarn test:e2e:enterprise
 TEST_EXIT=$?

--- a/src/scenes/Schema/TableDetailsDrawer/DetailsTab.tsx
+++ b/src/scenes/Schema/TableDetailsDrawer/DetailsTab.tsx
@@ -180,7 +180,7 @@ export const DetailsTab = ({
     [ddl],
   )
   const hasStoragePolicy = storagePolicyClauses.length > 0
-  const hasTtl = tableData.ttlValue !== 0
+  const hasTtl = (tableData.ttlValue ?? 0) !== 0
   const showStoragePolicySection = isEnterprise || hasStoragePolicy
 
   return (

--- a/src/scenes/Schema/TableDetailsDrawer/utils.test.ts
+++ b/src/scenes/Schema/TableDetailsDrawer/utils.test.ts
@@ -1,5 +1,32 @@
 import { describe, it, expect } from "vitest"
-import { extractStoragePolicyClauses } from "./utils"
+import { extractStoragePolicyClauses, formatTTL } from "./utils"
+
+describe("formatTTL", () => {
+  it("returns None for a value of 0", () => {
+    expect(formatTTL(0, "HOURS")).toBe("None")
+  })
+
+  it("returns None when the server omits the ttl columns", () => {
+    // Given a server older than 8.2.2, whose tables() has no ttl columns
+    expect(formatTTL(undefined, undefined)).toBe("None")
+  })
+
+  it("uses a singular Title Case unit for a value of 1", () => {
+    // Given the server reports the unit as either singular or plural
+    // Then a value of 1 always renders with a singular unit
+    expect(formatTTL(1, "MONTHS")).toBe("1 Month")
+    expect(formatTTL(1, "MONTH")).toBe("1 Month")
+    expect(formatTTL(1, "HOURS")).toBe("1 Hour")
+  })
+
+  it("uses a plural Title Case unit for values other than 1", () => {
+    // Given the server reports the unit as either singular or plural
+    // Then any value other than 1 always renders with a plural unit
+    expect(formatTTL(3, "MONTH")).toBe("3 Months")
+    expect(formatTTL(3, "MONTHS")).toBe("3 Months")
+    expect(formatTTL(2, "YEAR")).toBe("2 Years")
+  })
+})
 
 describe("extractStoragePolicyClauses", () => {
   it("returns an empty array when the DDL has no storage policy", () => {
@@ -38,12 +65,36 @@ describe("extractStoragePolicyClauses", () => {
   it("extracts all clauses in pipeline order", () => {
     const ddl = `CREATE TABLE 'trades' (price DOUBLE, ts TIMESTAMP)
       timestamp(ts) PARTITION BY DAY
-      STORAGE POLICY(TO PARQUET 1 DAYS, DROP NATIVE 10 DAYS, DROP LOCAL 1 MONTHS, DROP REMOTE 2 YEARS);`
+      STORAGE POLICY(TO PARQUET 1 DAYS, TO REMOTE 10 DAYS, DROP LOCAL 1 MONTHS, DROP REMOTE 2 YEARS);`
     expect(extractStoragePolicyClauses(ddl)).toEqual([
       { action: "To Parquet", duration: "1 Day" },
-      { action: "Drop Native", duration: "10 Days" },
+      { action: "To Remote", duration: "10 Days" },
       { action: "Drop Local", duration: "1 Month" },
       { action: "Drop Remote", duration: "2 Years" },
+    ])
+  })
+
+  it("returns an empty array for the retired DROP NATIVE syntax", () => {
+    // Given a DDL from a pre-release server build that still emits the
+    // removed DROP NATIVE stage — the parse failure deliberately degrades
+    // to "no clauses" rather than an error
+    const ddl = `CREATE TABLE 'trades' (price DOUBLE, ts TIMESTAMP)
+      timestamp(ts) PARTITION BY DAY
+      STORAGE POLICY(TO PARQUET 3 DAYS, DROP NATIVE 10 DAYS);`
+    expect(extractStoragePolicyClauses(ddl)).toEqual([])
+  })
+
+  it("extracts TO PARQUET + TO REMOTE with a trailing OWNED BY (reported repro)", () => {
+    // Given the reported DDL whose TO REMOTE clause used to fail the parse
+    const ddl = `CREATE TABLE 'corporate_bonds' (
+      ts TIMESTAMP, isin SYMBOL, price DOUBLE
+    ) timestamp(ts) PARTITION BY DAY
+    STORAGE POLICY(TO PARQUET 3 DAYS, TO REMOTE 30 DAYS)
+    OWNED BY 'admin';`
+    // Then both stages render instead of an empty "Not configured" section
+    expect(extractStoragePolicyClauses(ddl)).toEqual([
+      { action: "To Parquet", duration: "3 Days" },
+      { action: "To Remote", duration: "30 Days" },
     ])
   })
 })

--- a/src/scenes/Schema/TableDetailsDrawer/utils.ts
+++ b/src/scenes/Schema/TableDetailsDrawer/utils.ts
@@ -35,16 +35,23 @@ export function formatRowCount(count: number | string | null): string {
     : Number(count).toLocaleString()
 }
 
-export function formatTTL(value: number, unit: string): string {
-  if (value === 0) return "None"
-  return `${value} ${unit}`
+function formatDurationUnit(value: number, unit: string): string {
+  const lower = unit.toLowerCase()
+  const singular = lower.endsWith("s") ? lower.slice(0, -1) : lower
+  const normalized = value === 1 ? singular : `${singular}s`
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1)
+}
+
+export function formatTTL(value?: number, unit?: string): string {
+  if (!value || !unit) return "None"
+  return `${value} ${formatDurationUnit(value, unit)}`
 }
 
 export type StoragePolicyClause = { action: string; duration: string }
 
 const STORAGE_POLICY_LABELS = [
   ["toParquet", "To Parquet"],
-  ["dropNative", "Drop Native"],
+  ["toRemote", "To Remote"],
   ["dropLocal", "Drop Local"],
   ["dropRemote", "Drop Remote"],
 ] as const
@@ -63,10 +70,12 @@ export function extractStoragePolicyClauses(
   return STORAGE_POLICY_LABELS.flatMap(([key, label]) => {
     const v = policy[key]
     if (!v) return []
-    const unit = v.unit.charAt(0).toUpperCase() + v.unit.slice(1).toLowerCase()
-    const normalizedUnit =
-      v.value === 1 ? (unit.endsWith("s") ? unit.slice(0, -1) : unit) : unit
-    return [{ action: label, duration: `${v.value} ${normalizedUnit}` }]
+    return [
+      {
+        action: label,
+        duration: `${v.value} ${formatDurationUnit(v.value, v.unit)}`,
+      },
+    ]
   })
 }
 

--- a/src/utils/generateMatViewDDL.test.ts
+++ b/src/utils/generateMatViewDDL.test.ts
@@ -1,4 +1,9 @@
 import { describe, it, expect } from "vitest"
+import {
+  parseOne,
+  type CreateMaterializedViewStatement,
+  type StoragePolicy,
+} from "@questdb/sql-parser"
 import { generateMatViewDDL } from "./generateMatViewDDL"
 
 describe("generateMatViewDDL", () => {
@@ -708,14 +713,14 @@ describe("generateMatViewDDL", () => {
     })
   })
 
-  describe("STORAGE POLICY wins over TTL when source has both", () => {
-    it("source has STORAGE POLICY only → matview has STORAGE POLICY, no TTL", () => {
+  describe("source retention shape", () => {
+    it("source has STORAGE POLICY without DROP LOCAL → matview has neither", () => {
       const ddl = `CREATE TABLE 'trades' (price DOUBLE, ts TIMESTAMP)
         timestamp(ts) PARTITION BY DAY
         STORAGE POLICY(TO PARQUET 3 DAYS);`
       const result = generateMatViewDDL(ddl)
       expect(result).not.toMatch(/\bTTL\s+\d/i)
-      expect(result).toMatch(/STORAGE\s+POLICY/i)
+      expect(result).not.toMatch(/STORAGE\s+POLICY/i)
     })
 
     it("source has TTL only → matview has TTL, no STORAGE POLICY", () => {
@@ -730,103 +735,50 @@ describe("generateMatViewDDL", () => {
   })
 
   describe("STORAGE POLICY propagation", () => {
-    // QuestDB Enterprise (PartitionBy.validateTtlGranularity) requires each
-    // STORAGE POLICY clause to be an integer multiple of the matview partition
-    // size, and toParquet ≤ dropNative ≤ dropLocal ≤ dropRemote. The generator
-    // projects every clause into the matview partition's natural unit (DAYS
-    // for DAY, MONTHS for MONTH, YEARS for YEAR), preserves monotonic order,
-    // and ladder-bumps the terminal clause so the matview outlives the source.
-    // Behavior is edition-agnostic.
+    // Released QuestDB Enterprise rejects STORAGE POLICY on materialized
+    // views outright, so the generator never emits one. Retention still
+    // carries over as a plain TTL laddered from the source's DROP LOCAL
+    // stage (the point where source data stops being available locally);
+    // a policy without DROP LOCAL keeps data forever, so the matview gets
+    // no TTL either.
     const tableWithPolicy = (policy: string) => `CREATE TABLE 'trades' (
       symbol SYMBOL, price DOUBLE, ts TIMESTAMP
     ) timestamp(ts) PARTITION BY DAY STORAGE POLICY(${policy});`
 
-    it("projects sub-month TO PARQUET to partition unit and ladder-bumps the terminal", () => {
-      // Source PARTITION BY DAY → matview PARTITION BY MONTH (1h SAMPLE BY rung).
-      // 3 DAYS rounds up to 1 MONTHS; terminal bump → next ladder rung → 1 YEARS.
-      const result = generateMatViewDDL(tableWithPolicy("TO PARQUET 3 DAYS"))
-      expect(result).toMatch(
-        /STORAGE\s+POLICY\(\s*TO\s+PARQUET\s+1\s+YEAR\s*\)/i,
-      )
-    })
-
-    it("all four clauses: each projected to MONTH partition, terminal bumped", () => {
+    it("never emits STORAGE POLICY on the generated matview", () => {
       const result = generateMatViewDDL(
         tableWithPolicy(
-          "TO PARQUET 3 DAYS, DROP NATIVE 10 DAYS, DROP LOCAL 1 MONTHS, DROP REMOTE 1 YEARS",
+          "TO PARQUET 3 DAYS, TO REMOTE 10 DAYS, DROP LOCAL 1 MONTHS, DROP REMOTE 1 YEARS",
         ),
       )
-      // 3d, 10d, 1M all round up to 1 MONTHS (≤-ordering allows equal).
-      expect(result).toMatch(/TO\s+PARQUET\s+1\s+MONTH\b/i)
-      expect(result).toMatch(/DROP\s+NATIVE\s+1\s+MONTH\b/i)
-      expect(result).toMatch(/DROP\s+LOCAL\s+1\s+MONTH\b/i)
-      // Terminal 1 YEARS (= 13 partition units after rounding) bumps to 2 YEARS.
-      expect(result).toMatch(/DROP\s+REMOTE\s+2\s+YEARS/i)
+      expect(result).not.toMatch(/STORAGE\s+POLICY/i)
     })
 
-    it("three clauses: non-terminals projected, terminal ladder-bumped", () => {
+    it("ladders the DROP LOCAL stage into the matview TTL", () => {
+      // Given a DAY source (→ MONTH matview) dropping local data after 1 month
       const result = generateMatViewDDL(
-        tableWithPolicy(
-          "TO PARQUET 3 DAYS, DROP NATIVE 10 DAYS, DROP LOCAL 1 MONTHS",
-        ),
+        tableWithPolicy("TO PARQUET 3 DAYS, DROP LOCAL 1 MONTHS"),
       )
-      expect(result).toMatch(/TO\s+PARQUET\s+1\s+MONTH\b/i)
-      expect(result).toMatch(/DROP\s+NATIVE\s+1\s+MONTH\b/i)
-      // Terminal 1 MONTHS bumps one rung up the ladder → 1 YEARS.
-      expect(result).toMatch(/DROP\s+LOCAL\s+1\s+YEAR\b/i)
+      // Then the matview outlives it by one TTL ladder rung
+      expect(result).toMatch(/TTL\s+1\s+YEAR\b/i)
     })
 
-    it("non-terminal clauses below the matview partition are all rounded up to 1 partition", () => {
-      // 3d, 10d both round up to 1 MONTHS for a MONTH-partitioned matview.
-      // Verifies compliance with validateTtlGranularity for MONTH partition
-      // (which rejects any hour-based value).
+    it("policy without DROP LOCAL keeps data forever → no TTL, no policy", () => {
       const result = generateMatViewDDL(
-        tableWithPolicy(
-          "TO PARQUET 3 DAYS, DROP NATIVE 10 DAYS, DROP LOCAL 1 YEARS",
-        ),
+        tableWithPolicy("TO PARQUET 3 DAYS, TO REMOTE 30 DAYS"),
       )
-      expect(result).toMatch(/PARTITION\s+BY\s+MONTH/i)
-      expect(result).toMatch(/TO\s+PARQUET\s+1\s+MONTH\b/i)
-      expect(result).toMatch(/DROP\s+NATIVE\s+1\s+MONTH\b/i)
-      // Terminal 1 YEARS (13 partition units after rounding) bumps to 2 YEARS.
-      expect(result).toMatch(/DROP\s+LOCAL\s+2\s+YEARS/i)
-    })
-
-    it("all-1-year clauses: stay at 1 YEARS span, terminal bumps to 2 YEARS", () => {
-      // 1y rounds to 13 partition units (1y = 365d ÷ 30d ≈ 12.16 → ceil 13).
-      // ≤-ordering allows the equal 13-month spans for non-terminals; terminal
-      // bumps off the ladder to 2 YEARS.
-      const result = generateMatViewDDL(
-        tableWithPolicy(
-          "TO PARQUET 1 YEARS, DROP NATIVE 1 YEARS, DROP LOCAL 1 YEARS, DROP REMOTE 1 YEARS",
-        ),
-      )
-      expect(result).toMatch(/TO\s+PARQUET\s+13\s+MONTHS/i)
-      expect(result).toMatch(/DROP\s+NATIVE\s+13\s+MONTHS/i)
-      expect(result).toMatch(/DROP\s+LOCAL\s+13\s+MONTHS/i)
-      expect(result).toMatch(/DROP\s+REMOTE\s+2\s+YEARS/i)
-    })
-
-    it("source with STORAGE POLICY only: TTL absent, clauses projected to partition multiples", () => {
-      const ddl = `CREATE TABLE 'trades' (
-        symbol SYMBOL, price DOUBLE, ts TIMESTAMP
-      ) timestamp(ts) PARTITION BY DAY STORAGE POLICY(TO PARQUET 3 DAYS, DROP NATIVE 10 DAYS);`
-      const result = generateMatViewDDL(ddl)
       expect(result).not.toMatch(/\bTTL\s+\d/i)
-      expect(result).toMatch(/TO\s+PARQUET\s+1\s+MONTH\b/i)
-      // DROP NATIVE is the terminal clause; 1 MONTHS bumps to 1 YEARS.
-      expect(result).toMatch(/DROP\s+NATIVE\s+1\s+YEAR\b/i)
+      expect(result).not.toMatch(/STORAGE\s+POLICY/i)
     })
 
-    it("source materialized view with STORAGE POLICY propagates to derived matview", () => {
+    it("source materialized view with a policy propagates DROP LOCAL as TTL", () => {
       const ddl = `CREATE MATERIALIZED VIEW 'src_5m' WITH BASE 'base' AS (
         SELECT timestamp, last(price) AS price FROM base SAMPLE BY 5m
-      ) PARTITION BY MONTH STORAGE POLICY(TO PARQUET 7 DAYS, DROP NATIVE 14 DAYS);`
+      ) PARTITION BY MONTH STORAGE POLICY(TO PARQUET 7 DAYS, DROP LOCAL 14 DAYS);`
       const result = generateMatViewDDL(ddl)
-      // Matview partition stays MONTH (5m → 30m → MONTH). Both clauses round
-      // up to 1 MONTHS; terminal bumps to 1 YEARS.
-      expect(result).toMatch(/TO\s+PARQUET\s+1\s+MONTH\b/i)
-      expect(result).toMatch(/DROP\s+NATIVE\s+1\s+YEAR\b/i)
+      // 14 DAYS sits below the MONTH matview partition → 1 MONTH → 1 YEAR
+      expect(result).toMatch(/TTL\s+1\s+YEAR\b/i)
+      expect(result).not.toMatch(/STORAGE\s+POLICY/i)
     })
 
     it("source has no STORAGE POLICY → output has none", () => {
@@ -836,17 +788,115 @@ describe("generateMatViewDDL", () => {
       expect(generateMatViewDDL(ddl)).not.toMatch(/STORAGE\s+POLICY/i)
     })
 
-    it("user repro: PARTITION BY DAY source with mixed-unit policy projects to MONTH matview", () => {
-      // Regression test for the failure: QuestDB Enterprise rejected
-      // `PARTITION BY MONTH STORAGE POLICY(TO PARQUET 3 DAYS, ...)` because
-      // day-based values aren't integer multiples of MONTH.
-      const ddl = `CREATE TABLE 'abc' (col1 DOUBLE, ts TIMESTAMP) timestamp(ts) PARTITION BY DAY STORAGE POLICY(TO PARQUET 3 DAYS, DROP NATIVE 10 DAYS, DROP LOCAL 1 YEARS);`
+    it("user repro: policy-bearing DAY source generates enterprise-accepted DDL", () => {
+      // Regression: Enterprise rejected the generated DDL twice over —
+      // day-granularity clauses on a MONTH matview, and then any
+      // STORAGE POLICY on a materialized view at all.
+      const ddl = `CREATE TABLE 'abc' (col1 DOUBLE, ts TIMESTAMP) timestamp(ts) PARTITION BY DAY STORAGE POLICY(TO PARQUET 3 DAYS, TO REMOTE 10 DAYS, DROP LOCAL 1 YEARS);`
       const result = generateMatViewDDL(ddl)
       expect(result).toMatch(/PARTITION\s+BY\s+MONTH/i)
-      // Every clause must be a months-based value (validateTtlGranularity).
-      expect(result).not.toMatch(
-        /STORAGE\s+POLICY[^)]*\d+\s+(?:HOURS|DAYS|WEEKS)\b/i,
-      )
+      expect(result).not.toMatch(/STORAGE\s+POLICY/i)
+      // DROP LOCAL 1 YEARS ladders to a 2 YEARS TTL
+      expect(result).toMatch(/TTL\s+2\s+YEARS/i)
+    })
+
+    describe("any generated retention compiles as TTL-only", () => {
+      // Sweeps source kinds × policy shapes and re-parses every generated
+      // DDL: STORAGE POLICY must never survive (released servers reject it
+      // on matviews), and a TTL appears iff the source has a DROP LOCAL
+      // stage — a positive whole number in a unit the matview partition
+      // accepts, strictly outliving the source's local retention.
+      const APPROX_SECONDS: Record<string, number> = {
+        HOURS: 3600,
+        DAYS: 86400,
+        WEEKS: 7 * 86400,
+        MONTHS: 30 * 86400,
+        YEARS: 365 * 86400,
+      }
+      const ALLOWED_UNITS: Record<string, string[]> = {
+        DAY: ["DAYS", "MONTHS", "YEARS"],
+        MONTH: ["MONTHS", "YEARS"],
+        YEAR: ["YEARS"],
+      }
+
+      const approxSeconds = (clause?: { value: number; unit: string }) =>
+        clause ? clause.value * APPROX_SECONDS[clause.unit] : undefined
+
+      const sourceTableDdl = (partition: string, policy: string) =>
+        `CREATE TABLE 'src' (price DOUBLE, ts TIMESTAMP) timestamp(ts) PARTITION BY ${partition} STORAGE POLICY(${policy});`
+      const sourceMatViewDdl = (sampleBy: string, policy: string) =>
+        `CREATE MATERIALIZED VIEW 'src' WITH BASE 'base' AS (SELECT ts, last(price) AS price FROM base SAMPLE BY ${sampleBy}) PARTITION BY MONTH STORAGE POLICY(${policy});`
+
+      const SOURCES: Array<[string, (policy: string) => string]> = [
+        ["table PARTITION BY HOUR", (p) => sourceTableDdl("HOUR", p)],
+        ["table PARTITION BY DAY", (p) => sourceTableDdl("DAY", p)],
+        ["table PARTITION BY WEEK", (p) => sourceTableDdl("WEEK", p)],
+        ["table PARTITION BY MONTH", (p) => sourceTableDdl("MONTH", p)],
+        ["table PARTITION BY YEAR", (p) => sourceTableDdl("YEAR", p)],
+        ["matview SAMPLE BY 30s (→ DAY)", (p) => sourceMatViewDdl("30s", p)],
+        ["matview SAMPLE BY 5m (→ MONTH)", (p) => sourceMatViewDdl("5m", p)],
+        ["matview SAMPLE BY 1h (→ YEAR)", (p) => sourceMatViewDdl("1h", p)],
+        ["matview SAMPLE BY 1d (→ YEAR)", (p) => sourceMatViewDdl("1d", p)],
+      ]
+
+      const POLICIES = [
+        "TO PARQUET 12 HOURS",
+        "TO REMOTE 3d",
+        "DROP LOCAL 2 WEEKS",
+        "DROP REMOTE 1 YEARS",
+        "TO PARQUET 3 DAYS, TO REMOTE 30 DAYS",
+        "TO PARQUET 30 DAYS, TO REMOTE 3 DAYS",
+        "TO PARQUET 3d, DROP LOCAL 1M",
+        "TO REMOTE 2 WEEKS, DROP LOCAL 45 DAYS",
+        "DROP LOCAL 1M, DROP REMOTE 2 YEARS",
+        "TO PARQUET 1 DAYS, TO REMOTE 10 DAYS, DROP LOCAL 1 MONTHS",
+        "TO PARQUET 3 DAYS, TO REMOTE 10 DAYS, DROP LOCAL 1 MONTHS, DROP REMOTE 1 YEARS",
+        "TO PARQUET 2 YEARS, TO REMOTE 2 YEARS, DROP LOCAL 2 YEARS, DROP REMOTE 2 YEARS",
+      ]
+
+      it.each(SOURCES)("%s", (_label, ddlForPolicy) => {
+        for (const policy of POLICIES) {
+          // Given a source carrying this storage policy
+          const sourceDdl = ddlForPolicy(policy)
+          const context = `source: ${sourceDdl}`
+
+          // When generating a matview DDL from it
+          const result = generateMatViewDDL(sourceDdl)
+          const stmt = parseOne(
+            result.replace(/^--[^\n]*\n/, ""),
+          ) as CreateMaterializedViewStatement
+
+          // Then the output parses as a matview without a storage policy
+          expect(stmt.type, context).toBe("createMaterializedView")
+          expect(stmt.storagePolicy, context).toBeUndefined()
+
+          const sourceDropLocal = (
+            parseOne(sourceDdl) as { storagePolicy?: StoragePolicy }
+          ).storagePolicy?.dropLocal
+
+          // Then a TTL exists iff the source drops local data
+          if (!sourceDropLocal) {
+            expect(stmt.ttl, context).toBeUndefined()
+            continue
+          }
+          const ttl = stmt.ttl
+          expect(ttl, context).toBeDefined()
+          if (!ttl) continue
+
+          // Then it is a positive whole number in a unit the matview
+          // partition accepts, strictly outliving the source's local
+          // retention
+          expect(Number.isInteger(ttl.value) && ttl.value > 0, context).toBe(
+            true,
+          )
+          const allowedUnits = ALLOWED_UNITS[stmt.partitionBy ?? ""]
+          expect(allowedUnits, context).toBeDefined()
+          expect(allowedUnits, context).toContain(ttl.unit)
+          expect(approxSeconds(ttl), context).toBeGreaterThan(
+            approxSeconds(sourceDropLocal) ?? 0,
+          )
+        }
+      })
     })
   })
 })

--- a/src/utils/generateMatViewDDL.ts
+++ b/src/utils/generateMatViewDDL.ts
@@ -175,13 +175,6 @@ const PARTITION_INFO: Partial<
   YEAR: { interval: "1y", ttlUnit: "YEARS" },
 }
 
-const STORAGE_POLICY_PIPELINE_ORDER = [
-  "toParquet",
-  "dropNative",
-  "dropLocal",
-  "dropRemote",
-] as const
-
 const HEADER =
   "-- Review SAMPLE BY, PARTITION BY, TTL, refresh clause, and aggregates before running."
 
@@ -233,11 +226,6 @@ const ladderStringToTTL = (s: string): TTLAst | null => {
   return { value: Number(m[1]), unit }
 }
 
-const ttlSeconds = (ttl: TTLAst): number | null => {
-  const s = ttlToLadderString(ttl)
-  return s ? toSeconds(s) : null
-}
-
 const partitionInfo = (
   partition: CreateMaterializedViewStatement["partitionBy"],
 ) => (partition ? PARTITION_INFO[partition] : undefined)
@@ -270,69 +258,12 @@ const deriveNextTTL = (
   return ladderStringToTTL(nextTTL(baseline))
 }
 
-const projectClauseToPartition = (
-  src: TTLAst,
-  partition: CreateMaterializedViewStatement["partitionBy"],
-): TTLAst | null => {
-  const info = partitionInfo(partition)
-  if (!info) return null
-  const partSec = toSeconds(info.interval)
-  const srcSec = ttlSeconds(src)
-  if (partSec == null || srcSec == null) return null
-  const count = Math.max(1, Math.ceil(srcSec / partSec))
-  return { value: count, unit: info.ttlUnit }
-}
-
-const projectStoragePolicyForMatView = (
-  source: StoragePolicy,
-  partition: CreateMaterializedViewStatement["partitionBy"],
-): StoragePolicy | null => {
-  const present = STORAGE_POLICY_PIPELINE_ORDER.filter(
-    (k) => source[k] !== undefined,
-  )
-  if (present.length === 0) return null
-
-  const next: StoragePolicy = { type: "storagePolicy" }
-  const terminal = present[present.length - 1]
-  let prevSec = 0
-  for (const kind of present) {
-    let projected = projectClauseToPartition(source[kind] as TTLAst, partition)
-    // Unreachable in practice: partition is always DAY/MONTH/YEAR here
-    if (!projected) return null
-
-    let projectedSec = ttlSeconds(projected) ?? 0
-    while (projectedSec > 0 && projectedSec < prevSec) {
-      projected = { ...projected, value: projected.value + 1 }
-      projectedSec = ttlSeconds(projected) ?? 0
-    }
-
-    if (kind === terminal) {
-      const bumpedStr = ttlToLadderString(projected)
-      const bumped = bumpedStr ? ladderStringToTTL(nextTTL(bumpedStr)) : null
-      if (bumped) {
-        projected = bumped
-        projectedSec = ttlSeconds(projected) ?? projectedSec
-      }
-    }
-
-    next[kind] = projected
-    prevSec = projectedSec
-  }
-  return next
-}
-
 const projectRetention = (
   src: { ttl?: TTLAst; storagePolicy?: StoragePolicy },
   partitionBy: CreateMaterializedViewStatement["partitionBy"],
-): Pick<CreateMaterializedViewStatement, "ttl" | "storagePolicy"> => {
-  const storagePolicy = src.storagePolicy
-    ? (projectStoragePolicyForMatView(src.storagePolicy, partitionBy) ??
-      undefined)
-    : undefined
-  const ttl = storagePolicy
-    ? undefined
-    : (deriveNextTTL(src.ttl, partitionBy) ?? undefined)
-  return { ttl, storagePolicy }
+): Pick<CreateMaterializedViewStatement, "ttl"> => {
+  const retention = src.storagePolicy ? src.storagePolicy.dropLocal : src.ttl
+  return { ttl: deriveNextTTL(retention, partitionBy) ?? undefined }
 }
 
 const matchesPattern = (name: string, patterns: string[]): boolean =>

--- a/src/utils/questdb/types.ts
+++ b/src/utils/questdb/types.ts
@@ -178,8 +178,8 @@ export type Table = {
   designatedTimestamp: string
   walEnabled: boolean
   dedup: boolean
-  ttlValue: number
-  ttlUnit: string
+  ttlValue?: number
+  ttlUnit?: string
   matView?: boolean // Optional for backward compatibility with older servers
   table_type?: TableType // Optional for backward compatibility with older servers
   directoryName: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -2491,12 +2491,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@questdb/sql-parser@npm:0.1.14":
-  version: 0.1.14
-  resolution: "@questdb/sql-parser@npm:0.1.14"
+"@questdb/sql-parser@npm:0.1.15":
+  version: 0.1.15
+  resolution: "@questdb/sql-parser@npm:0.1.15"
   dependencies:
     chevrotain: "npm:11.1.1"
-  checksum: 10/394b0f5877d7d76886030a02067b48fefd0f287446d67f22658072d52b7505d93db0b5b842256e625b278d4a6fee9557a84d8ce87d48feea91b57f599db0416e
+  checksum: 10/7d4d6b1f7f863c6c9d89cd038e87a3bb01e7134e83a75bc75b9ff5d4fda29a19902c91cbd4fbb95e00aa8e5d524c0b9d0184e78c41d37d9368ab07b02c500fbb
   languageName: node
   linkType: hard
 
@@ -2518,7 +2518,7 @@ __metadata:
     "@monaco-editor/react": "npm:^4.7.0"
     "@phosphor-icons/react": "npm:^2.1.10"
     "@popperjs/core": "npm:2.4.2"
-    "@questdb/sql-parser": "npm:0.1.14"
+    "@questdb/sql-parser": "npm:0.1.15"
     "@radix-ui/react-alert-dialog": "npm:^1.1.15"
     "@radix-ui/react-context-menu": "npm:^2.2.16"
     "@radix-ui/react-dialog": "npm:^1.1.15"


### PR DESCRIPTION
## What's changed

- **Table details drawer** understands the current storage-policy grammar (`TO PARQUET / TO REMOTE / DROP LOCAL / DROP REMOTE`). Previously a policy containing `TO REMOTE` failed to parse and the drawer showed "Not configured" for a table that has one.
- **Create materialized view** on a policy-bearing source now generates DDL the server accepts: the policy's `DROP LOCAL` stage becomes a laddered matview `TTL`. Servers reject `STORAGE POLICY` on materialized views, so the previously generated DDL always failed.
- Bumps `@questdb/sql-parser` to **0.1.15** (adds `TO REMOTE`, removes the unsupported `DROP NATIVE`, registers `storage_policies()` for autocomplete, faithful long-form TTL literals).

Infra ride-alongs: OSS submodule bump; enterprise e2e script gains `--add-exports=java.base/jdk.internal.vm` needed to boot the newer server build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
