### PR TITLE
fix: change mcp bridge occurrences to mcp server

### DIFF
--- a/e2e/tests/console/agentBackgroundEdits.spec.js
+++ b/e2e/tests/console/agentBackgroundEdits.spec.js
@@ -42,7 +42,7 @@ const waitForPaired = () => {
     expect(win.__mcpFakeWS.framesOfType("hello").length).to.be.greaterThan(0)
   })
   cy.window().then((win) => win.__mcpFakeWS.helloAck())
-  cy.getByDataHook("mcp-bridge-status-pill", { timeout: 10000 }).should(
+  cy.getByDataHook("mcp-status-pill", { timeout: 10000 }).should(
     "contain",
     "MCP connected",
   )

--- a/e2e/tests/console/mcpBridgePermissions.spec.js
+++ b/e2e/tests/console/mcpBridgePermissions.spec.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-// E2E coverage for the MCP bridge permission system.
+// E2E coverage for the MCP server permission system.
 
 const contextPath = process.env.QDB_HTTP_CONTEXT_WEB_CONSOLE || ""
 const baseUrl = `http://localhost:9999${contextPath}`
@@ -63,7 +63,7 @@ const waitForPaired = () => {
     expect(win.__mcpFakeWS.framesOfType("hello").length).to.be.greaterThan(0)
   })
   cy.window().then((win) => win.__mcpFakeWS.helloAck())
-  cy.getByDataHook("mcp-bridge-status-pill", { timeout: 10000 }).should(
+  cy.getByDataHook("mcp-status-pill", { timeout: 10000 }).should(
     "contain",
     "MCP connected",
   )
@@ -74,7 +74,7 @@ const lastToolResult = (win, requestId) => {
   return results.find((r) => r.requestId === requestId)
 }
 
-describe("MCP bridge permissions (e2e)", () => {
+describe("MCP server permissions (e2e)", () => {
   beforeEach(() => {
     installValidateIntercept()
   })
@@ -104,10 +104,7 @@ describe("MCP bridge permissions (e2e)", () => {
       })
 
       cy.window().then((win) => win.__mcpFakeWS.helloAck())
-      cy.getByDataHook("mcp-bridge-status-pill").should(
-        "contain",
-        "MCP connected",
-      )
+      cy.getByDataHook("mcp-status-pill").should("contain", "MCP connected")
       cy.window().then((win) => {
         expect(
           JSON.parse(win.localStorage.getItem("mcp:permissions")),
@@ -270,7 +267,7 @@ describe("MCP bridge permissions (e2e)", () => {
       cy.getByDataHook("mcp-pair-consent-connect").click()
       waitForPaired()
 
-      cy.getByDataHook("mcp-bridge-status-pill").click()
+      cy.getByDataHook("mcp-status-pill").click()
       cy.getByDataHook("mcp-pair-popover").should("be.visible")
 
       cy.window().then((win) => {
@@ -289,7 +286,7 @@ describe("MCP bridge permissions (e2e)", () => {
         ).to.deep.equal({ grantSchemaAccess: true, read: true, write: false })
       })
 
-      cy.getByDataHook("mcp-bridge-status-pill").click()
+      cy.getByDataHook("mcp-status-pill").click()
       cy.getByDataHook("permissions-trigger").should("contain", "Read")
     })
 
@@ -298,7 +295,7 @@ describe("MCP bridge permissions (e2e)", () => {
       cy.getByDataHook("mcp-pair-consent-connect").click()
       waitForPaired()
 
-      cy.getByDataHook("mcp-bridge-status-pill").click()
+      cy.getByDataHook("mcp-status-pill").click()
       cy.getByDataHook("permissions-trigger").click()
       cy.getByDataHook("permission-level-write").click()
       cy.getByDataHook("mcp-pair-submit").should("contain", "Connect").click()
@@ -309,10 +306,7 @@ describe("MCP bridge permissions (e2e)", () => {
         ).to.deep.equal({ grantSchemaAccess: true, read: true, write: true })
         expect(win.__mcpFakeWS.framesOfType("hello")).to.have.length(1)
       })
-      cy.getByDataHook("mcp-bridge-status-pill").should(
-        "contain",
-        "MCP connected",
-      )
+      cy.getByDataHook("mcp-status-pill").should("contain", "MCP connected")
     })
   })
 
@@ -344,10 +338,7 @@ describe("MCP bridge permissions (e2e)", () => {
         })
         win.__mcpFakeWS.helloAck()
       })
-      cy.getByDataHook("mcp-bridge-status-pill").should(
-        "contain",
-        "MCP connected",
-      )
+      cy.getByDataHook("mcp-status-pill").should("contain", "MCP connected")
     })
   })
 })

--- a/e2e/tests/console/notebookResultRestore.spec.js
+++ b/e2e/tests/console/notebookResultRestore.spec.js
@@ -51,7 +51,7 @@ const waitForPaired = () => {
     expect(win.__mcpFakeWS.framesOfType("hello").length).to.be.greaterThan(0)
   })
   cy.window().then((win) => win.__mcpFakeWS.helloAck())
-  cy.getByDataHook("mcp-bridge-status-pill", { timeout: 10000 }).should(
+  cy.getByDataHook("mcp-status-pill", { timeout: 10000 }).should(
     "contain",
     "MCP connected",
   )

--- a/e2e/utils/mcpFakeWebSocket.js
+++ b/e2e/utils/mcpFakeWebSocket.js
@@ -1,4 +1,4 @@
-// Fake MCP-bridge WebSocket shared by the bridge e2e specs. Installed before
+// Fake mcp-server-questdb WebSocket shared by the MCP e2e specs. Installed before
 // the app boots; the instance is exposed on `win.__mcpFakeWS`.
 
 const TEST_BRIDGE_URL = "ws://127.0.0.1:57123"

--- a/src/components/McpSetupCommand/index.tsx
+++ b/src/components/McpSetupCommand/index.tsx
@@ -2,12 +2,14 @@ import React from "react"
 import styled from "styled-components"
 import { CopyButton } from "../CopyButton"
 import { CopyCommand } from "../icons/copy-command"
-import { EXPECTED_BRIDGE_VERSION } from "../../utils/mcp/protocolVersion"
+import {
+  EXPECTED_MCP_VERSION,
+  MCP_PACKAGE,
+  MCP_SETUP_COMMAND,
+} from "../../utils/mcp/protocolVersion"
 import { color } from "../../utils"
 import { trackEvent } from "../../modules/ConsoleEventTracker"
 import { ConsoleEvent } from "../../modules/ConsoleEventTracker/events"
-
-export const SETUP_COMMAND = `npx @questdb/mcp-bridge@${EXPECTED_BRIDGE_VERSION} setup`
 
 const Code = styled.span`
   flex: 1;
@@ -16,9 +18,7 @@ const Code = styled.span`
   font-family: ${({ theme }) => theme.fontMonospace};
   font-size: 1.3rem;
   color: ${color("offWhite2")};
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  overflow-wrap: anywhere;
 `
 
 const Package = styled.span`
@@ -29,6 +29,7 @@ const CopyCommandButton = styled(CopyButton)`
   && {
     height: auto;
     min-width: 0;
+    flex-shrink: 0;
     padding: 0.4rem;
     background: transparent;
     border: none;
@@ -57,13 +58,17 @@ export const McpSetupCommand = ({
 }) => (
   <>
     <Code>
-      npx <Package>@questdb/mcp-bridge@{EXPECTED_BRIDGE_VERSION}</Package> setup
+      npx{" "}
+      <Package>
+        {MCP_PACKAGE}@{EXPECTED_MCP_VERSION}
+      </Package>{" "}
+      setup
     </Code>
     <CopyCommandButton
       iconOnly
       skin="transparent"
       size="sm"
-      text={SETUP_COMMAND}
+      text={MCP_SETUP_COMMAND}
       icon={<CopyCommand size={iconSize} />}
       onCopy={() =>
         void trackEvent(ConsoleEvent.MCP_SETUP_COMMAND_COPY, { source })

--- a/src/components/NotebookOnboardingModal/Step2.tsx
+++ b/src/components/NotebookOnboardingModal/Step2.tsx
@@ -77,7 +77,7 @@ export const Step2 = ({
         analysis back and forth with your agent.
       </Bullet>
       <Bullet icon={<LockKeyIcon size={20} />} title="Privacy first">
-        The MCP bridge runs locally on your machine, your data is never sent to
+        The MCP server runs locally on your machine, your data is never sent to
         a remote server.
       </Bullet>
       <Bullet icon={<AirTrafficControlIcon size={20} />} title="Full control">

--- a/src/components/NotebookOnboardingModal/index.tsx
+++ b/src/components/NotebookOnboardingModal/index.tsx
@@ -37,7 +37,7 @@ const Content = styled(RadixDialog.Content)<{ $tall?: boolean }>`
   z-index: 101;
   display: flex;
   width: 90vw;
-  max-width: 96rem;
+  max-width: 100rem;
   min-height: ${({ $tall }) =>
     $tall ? "min(66.6rem, 85vh)" : "min(41.6rem, 85vh)"};
   max-height: 85vh;

--- a/src/components/NotebookOnboardingModal/shared.tsx
+++ b/src/components/NotebookOnboardingModal/shared.tsx
@@ -11,7 +11,7 @@ export const LeftPane = styled.div<{ $center?: boolean }>`
   min-height: 0;
   flex-direction: column;
   gap: 2rem;
-  padding: 3.2rem 3.2rem 2.8rem;
+  padding: 3.2rem 2.5rem 2.8rem;
   overflow-y: auto;
   ${({ $center }) => $center && "justify-content: safe center;"}
 `

--- a/src/providers/MCPBridgeProvider/PairingConsentModal.tsx
+++ b/src/providers/MCPBridgeProvider/PairingConsentModal.tsx
@@ -261,7 +261,7 @@ export const PairingConsentModal: React.FC<Props> = ({
               )}
             </IconBadge>
             <Title>
-              {succeeded ? "MCP Bridge connected" : "Connect to MCP Bridge?"}
+              {succeeded ? "MCP server connected" : "Connect to MCP server?"}
             </Title>
             <Lede>
               {succeeded
@@ -290,7 +290,7 @@ export const PairingConsentModal: React.FC<Props> = ({
               <TrustNote>
                 <ShieldCheckIcon size={16} weight="duotone" />
                 <span>
-                  <strong>Loopback only:</strong> The bridge runs on your
+                  <strong>Loopback only:</strong> The MCP server runs on your
                   machine and never leaves it. Every action runs through your
                   already-authenticated console session.
                 </span>
@@ -330,10 +330,10 @@ export const PairingConsentModal: React.FC<Props> = ({
               >
                 <WarningIcon size={16} weight="duotone" />
                 <StatusText>
-                  <strong>Could not connect to MCP bridge</strong>
+                  <strong>Could not connect to MCP server</strong>
                   <StatusDetail>
                     {error ??
-                      `Bridge stopped responding after ${MAX_RECONNECT_ATTEMPTS} attempts. Try again, or ask your coding agent for a fresh deep link.`}
+                      `MCP server stopped responding after ${MAX_RECONNECT_ATTEMPTS} attempts. Try again, or ask your coding agent for a fresh deep link.`}
                   </StatusDetail>
                 </StatusText>
               </StatusRow>

--- a/src/providers/MCPBridgeProvider/index.tsx
+++ b/src/providers/MCPBridgeProvider/index.tsx
@@ -13,7 +13,7 @@ import { dispatchMCPTool } from "../../utils/mcp/dispatchMCPTool"
 import { createNotebookFreshness } from "../../utils/notebooks/notebookFreshness"
 import { mcpTools } from "../../utils/tools/tools"
 import {
-  EXPECTED_BRIDGE_VERSION,
+  EXPECTED_MCP_VERSION,
   type BridgeVersionMismatch,
 } from "../../utils/mcp/protocolVersion"
 import type { ToolCallMessage } from "../../utils/mcp/types"
@@ -243,7 +243,7 @@ export const MCPBridgeProvider: React.FC<{ children: React.ReactNode }> = ({
         if (!aborter.signal.aborted) return false
         if (aborter.signal.reason === PERMISSIONS_REVOKED_REASON) {
           client.sendToolResult({
-            v: EXPECTED_BRIDGE_VERSION,
+            v: EXPECTED_MCP_VERSION,
             type: "tool_result",
             requestId: call.requestId,
             content: [
@@ -282,7 +282,7 @@ export const MCPBridgeProvider: React.FC<{ children: React.ReactNode }> = ({
             })
           }
           client.sendToolResult({
-            v: EXPECTED_BRIDGE_VERSION,
+            v: EXPECTED_MCP_VERSION,
             type: "tool_result",
             requestId: call.requestId,
             content: result.content,
@@ -307,7 +307,7 @@ export const MCPBridgeProvider: React.FC<{ children: React.ReactNode }> = ({
           const message =
             err instanceof Error ? err.message : "tool dispatch failed"
           client.sendToolResult({
-            v: EXPECTED_BRIDGE_VERSION,
+            v: EXPECTED_MCP_VERSION,
             type: "tool_result",
             requestId: call.requestId,
             content: [{ type: "text", text: `dispatch_error: ${message}` }],

--- a/src/scenes/Footer/MCPBridgeStatus/AgentChangesPopper.tsx
+++ b/src/scenes/Footer/MCPBridgeStatus/AgentChangesPopper.tsx
@@ -119,7 +119,7 @@ export const AgentChangesPopper: React.FC<Props> = ({
   // document body; return it to the pill the toast points at.
   const focusAnchorPill = useCallback(() => {
     anchorEl
-      ?.querySelector<HTMLElement>('[data-hook="mcp-bridge-status-pill"]')
+      ?.querySelector<HTMLElement>('[data-hook="mcp-status-pill"]')
       ?.focus()
   }, [anchorEl])
 

--- a/src/scenes/Footer/MCPBridgeStatus/BridgeSetupNotice.tsx
+++ b/src/scenes/Footer/MCPBridgeStatus/BridgeSetupNotice.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import styled from "styled-components"
 import { TerminalWindowIcon } from "@phosphor-icons/react"
-import { BRIDGE_SETUP_COMMAND } from "../../../utils/mcp/protocolVersion"
+import { MCP_SETUP_COMMAND } from "../../../utils/mcp/protocolVersion"
 import { CopyableCommand } from "./CopyableCommand"
 
 const Root = styled.div`
@@ -34,6 +34,6 @@ export const BridgeSetupNotice = () => (
       <TerminalWindowIcon size={16} weight="duotone" />
       <span>Haven&apos;t installed yet? Set it up in your terminal:</span>
     </Header>
-    <CopyableCommand command={BRIDGE_SETUP_COMMAND} />
+    <CopyableCommand command={MCP_SETUP_COMMAND} />
   </Root>
 )

--- a/src/scenes/Footer/MCPBridgeStatus/BridgeUpgradeNotice.tsx
+++ b/src/scenes/Footer/MCPBridgeStatus/BridgeUpgradeNotice.tsx
@@ -2,8 +2,8 @@ import React from "react"
 import styled from "styled-components"
 import { WarningIcon } from "@phosphor-icons/react"
 import {
-  BRIDGE_UPGRADE_COMMAND,
-  BRIDGE_VERSION_MISMATCH_COPY,
+  MCP_UPGRADE_COMMAND,
+  MCP_VERSION_MISMATCH_COPY,
   type BridgeVersionMismatch,
 } from "../../../utils/mcp/protocolVersion"
 import { CopyableCommand } from "./CopyableCommand"
@@ -27,14 +27,14 @@ export const BridgeUpgradeNotice = ({
 }: {
   severity: BridgeVersionMismatch
 }) => {
-  const copy = BRIDGE_VERSION_MISMATCH_COPY[severity]
+  const copy = MCP_VERSION_MISMATCH_COPY[severity]
   return (
     <>
       <WarningIcon size={16} weight="duotone" />
       <Text>
         <strong>{copy.title}</strong>
         <Detail>{copy.message}</Detail>
-        <CopyableCommand command={BRIDGE_UPGRADE_COMMAND} />
+        <CopyableCommand command={MCP_UPGRADE_COMMAND} />
       </Text>
     </>
   )

--- a/src/scenes/Footer/MCPBridgeStatus/CopyableCommand.tsx
+++ b/src/scenes/Footer/MCPBridgeStatus/CopyableCommand.tsx
@@ -19,13 +19,18 @@ const Command = styled.code`
   border: 1px solid ${({ theme }) => theme.color.selection};
   border-radius: 0.4rem;
   padding: 0.6rem 0.8rem;
-  word-break: break-all;
+  white-space: normal;
+  overflow-wrap: anywhere;
   user-select: all;
+`
+
+const CopyAction = styled(CopyButton)`
+  flex-shrink: 0;
 `
 
 export const CopyableCommand = ({ command }: { command: string }) => (
   <Row>
     <Command>{command}</Command>
-    <CopyButton text={command} iconOnly size="sm" />
+    <CopyAction text={command} iconOnly size="sm" />
   </Row>
 )

--- a/src/scenes/Footer/MCPBridgeStatus/PairPopover.tsx
+++ b/src/scenes/Footer/MCPBridgeStatus/PairPopover.tsx
@@ -415,7 +415,7 @@ export const MCPBridgePairPopover = forwardRef<HTMLDivElement, Props>(
 
     const canDisconnect = isPaired && status === "connected"
 
-    const title = succeeded ? "MCP Bridge connected" : "MCP Bridge"
+    const title = succeeded ? "MCP server connected" : "MCP server"
 
     const lede = succeeded
       ? "You can track the connection status from the bottom bar."
@@ -518,10 +518,10 @@ export const MCPBridgePairPopover = forwardRef<HTMLDivElement, Props>(
           <StatusRow $tone="danger" data-hook="mcp-pair-error" role="alert">
             <WarningIcon size={16} weight="duotone" />
             <StatusText>
-              <strong>Could not connect to MCP bridge</strong>
+              <strong>Could not connect to MCP server</strong>
               <StatusDetail>
                 {lastError ??
-                  `Bridge stopped responding after ${MAX_RECONNECT_ATTEMPTS} attempts. Try again, or ask your coding agent for a fresh deep link.`}
+                  `MCP server stopped responding after ${MAX_RECONNECT_ATTEMPTS} attempts. Try again, or ask your coding agent for a fresh deep link.`}
               </StatusDetail>
             </StatusText>
           </StatusRow>

--- a/src/scenes/Footer/MCPBridgeStatus/index.tsx
+++ b/src/scenes/Footer/MCPBridgeStatus/index.tsx
@@ -93,7 +93,7 @@ const Pill = forwardRef<
       type="button"
       title={title}
       aria-label={label}
-      data-hook="mcp-bridge-status-pill"
+      data-hook="mcp-status-pill"
       $tone={tone}
       $blink={blink}
       $newChanges={newChanges}
@@ -143,14 +143,14 @@ export const MCPBridgeStatus: React.FC = () => {
       "Click to enter MCP credentials manually, or ask Claude / Codex to pair this console."
   } else if (tone === "connected") {
     label = "MCP connected"
-    title = "Paired with the MCP bridge. Click to manage."
+    title = "Paired with the MCP server. Click to manage."
   } else if (tone === "warning") {
     label = "MCP connected"
     title =
-      "Connected, but the bridge version differs from what this console expects. Click to see the upgrade command."
+      "Connected, but the MCP server version differs from what this console expects. Click to see the upgrade command."
   } else if (tone === "connecting") {
     label = "MCP connecting…"
-    title = "Connecting to the bridge. Click to manage."
+    title = "Connecting to the MCP server. Click to manage."
   } else {
     label = "MCP disconnected"
     title =

--- a/src/utils/ai/shared.notebookTools.test.ts
+++ b/src/utils/ai/shared.notebookTools.test.ts
@@ -37,7 +37,7 @@ import {
 } from "../tools/permissions"
 import type { ValidateQueryResult } from "../questdb/types"
 import { dispatchMCPTool } from "../mcp/dispatchMCPTool"
-import { EXPECTED_BRIDGE_VERSION } from "../mcp/protocolVersion"
+import { EXPECTED_MCP_VERSION } from "../mcp/protocolVersion"
 import type { ToolExecutionContext } from "./shared"
 import { createNotebookFreshness } from "../notebooks/notebookFreshness"
 
@@ -2626,7 +2626,7 @@ describe("dispatchTool — run_query replay guard (sqlWriteExecuted)", () => {
 // inlines a richer payload there.
 describe("dispatchMCPTool — data-leak invariant", () => {
   const callOf = (name: string, args: Record<string, unknown> = {}) => ({
-    v: EXPECTED_BRIDGE_VERSION,
+    v: EXPECTED_MCP_VERSION,
     type: "tool_call" as const,
     requestId: "r-" + name,
     name,

--- a/src/utils/mcp/MCPBridgeClient.test.ts
+++ b/src/utils/mcp/MCPBridgeClient.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { MCPBridgeClient } from "./MCPBridgeClient"
-import { EXPECTED_BRIDGE_VERSION } from "./protocolVersion"
+import { EXPECTED_MCP_VERSION } from "./protocolVersion"
 import { WS_CLOSE_CODES, type HelloMessage, type ToolSchema } from "./types"
 
 // A version within the same major as expected — drifted enough to read as a
-// mismatch, yet never equal to EXPECTED_BRIDGE_VERSION whatever it's bumped to.
+// mismatch, yet never equal to EXPECTED_MCP_VERSION whatever it's bumped to.
 const [expectedMajor, expectedMinor, expectedPatch] =
-  EXPECTED_BRIDGE_VERSION.split(".").map(Number)
+  EXPECTED_MCP_VERSION.split(".").map(Number)
 const SAME_MAJOR_DRIFT = `${expectedMajor}.${expectedMinor + 1}.${expectedPatch}`
 
 class FakeWebSocket {
@@ -104,7 +104,7 @@ const handshake = (
 ) => {
   socket.open()
   socket.receive({
-    v: EXPECTED_BRIDGE_VERSION,
+    v: EXPECTED_MCP_VERSION,
     type: "hello_ack",
     sessionId,
     heartbeatIntervalMs: 5_000,
@@ -128,7 +128,7 @@ describe("MCPBridgeClient", () => {
     expect(hello.tools.length).toBe(1)
     expect(client.status).toBe("connecting")
     socket().receive({
-      v: EXPECTED_BRIDGE_VERSION,
+      v: EXPECTED_MCP_VERSION,
       type: "hello_ack",
       sessionId: "s-1",
       heartbeatIntervalMs: 5_000,
@@ -146,7 +146,7 @@ describe("MCPBridgeClient", () => {
     client.connect()
     handshake(client, socket())
     socket().receive({
-      v: EXPECTED_BRIDGE_VERSION,
+      v: EXPECTED_MCP_VERSION,
       type: "tool_call",
       requestId: "r1",
       name: "add_cell",
@@ -162,7 +162,7 @@ describe("MCPBridgeClient", () => {
     handshake(client, socket())
     socket().sent.length = 0
     socket().receive({
-      v: EXPECTED_BRIDGE_VERSION,
+      v: EXPECTED_MCP_VERSION,
       type: "ping",
       nonce: "abc",
     })
@@ -177,7 +177,7 @@ describe("MCPBridgeClient", () => {
     handshake(client, socket())
     expect(() =>
       socket().receive({
-        v: EXPECTED_BRIDGE_VERSION,
+        v: EXPECTED_MCP_VERSION,
         type: "future_unknown_message",
         payload: { whatever: 1 },
       }),
@@ -212,7 +212,7 @@ describe("MCPBridgeClient", () => {
     socket().dropFromServer()
     expect(client.status).toBe("reconnecting")
     client.sendToolResult({
-      v: EXPECTED_BRIDGE_VERSION,
+      v: EXPECTED_MCP_VERSION,
       type: "tool_result",
       requestId: "r1",
       content: [{ type: "text", text: "{}" }],
@@ -291,7 +291,7 @@ describe("MCPBridgeClient", () => {
     }
     expect(ping.type).toBe("ping")
     socket().receive({
-      v: EXPECTED_BRIDGE_VERSION,
+      v: EXPECTED_MCP_VERSION,
       type: "pong",
       nonce: ping.nonce,
     })

--- a/src/utils/mcp/MCPBridgeClient.ts
+++ b/src/utils/mcp/MCPBridgeClient.ts
@@ -1,7 +1,7 @@
 import {
-  BRIDGE_UPGRADE_COMMAND,
-  BRIDGE_VERSION_MISMATCH_COPY,
-  EXPECTED_BRIDGE_VERSION,
+  MCP_UPGRADE_COMMAND,
+  MCP_VERSION_MISMATCH_COPY,
+  EXPECTED_MCP_VERSION,
   isBridgeVersionMismatch,
   type BridgeVersionMismatch,
 } from "./protocolVersion"
@@ -32,15 +32,15 @@ const TERMINAL_BRIDGE_CLOSE_CODES = new Set<number>([
 
 const terminalCloseMessage = (code: number, reason: string): string => {
   if (code === WS_CLOSE_CODES.superseded) {
-    return "Another browser tab is paired with this bridge. Disconnect the other tab or pair this one via a fresh link."
+    return "Another browser tab is paired with this MCP server. Disconnect the other tab or pair this one via a fresh link."
   }
   if (code === WS_CLOSE_CODES.token_invalid) {
-    return "Pairing token is no longer valid — the bridge likely restarted. Re-pair via a fresh deep link."
+    return "Pairing token is no longer valid, the MCP server likely restarted. Re-pair via a fresh deep link."
   }
   if (code === WS_CLOSE_CODES.major_version_mismatch) {
-    return `${BRIDGE_VERSION_MISMATCH_COPY.major.message} ${BRIDGE_UPGRADE_COMMAND}`
+    return `${MCP_VERSION_MISMATCH_COPY.major.message} ${MCP_UPGRADE_COMMAND}`
   }
-  return reason || `Bridge closed with code ${code}.`
+  return reason || `MCP server closed with code ${code}.`
 }
 
 export type MCPBridgeClientStatus =
@@ -261,12 +261,12 @@ export class MCPBridgeClient {
     // Never log the token, not even a prefix — 4 bytes is enough to
     // confirm an exfiltrated token if a leak appears elsewhere.
     const hello: HelloMessage = {
-      v: EXPECTED_BRIDGE_VERSION,
+      v: EXPECTED_MCP_VERSION,
       type: "hello",
       token: this.opts.token,
       userAgent:
         typeof navigator !== "undefined" ? navigator.userAgent : "node",
-      expectedBridgeVersion: EXPECTED_BRIDGE_VERSION,
+      expectedBridgeVersion: EXPECTED_MCP_VERSION,
       consoleOrigin: this.opts.consoleOrigin,
       tools: this.opts.tools,
       permissions: this.permissions,
@@ -303,7 +303,7 @@ export class MCPBridgeClient {
         return
       case "ping":
         this.send({
-          v: EXPECTED_BRIDGE_VERSION,
+          v: EXPECTED_MCP_VERSION,
           type: "pong",
           nonce: parsed.nonce,
         } satisfies PongMessage)
@@ -427,7 +427,7 @@ export class MCPBridgeClient {
     const sentAt = monotonicNow()
     this.outstandingPing = { nonce, sentAt }
     this.send({
-      v: EXPECTED_BRIDGE_VERSION,
+      v: EXPECTED_MCP_VERSION,
       type: "ping",
       nonce,
     } satisfies PingMessage)

--- a/src/utils/mcp/dispatchMCPTool.test.ts
+++ b/src/utils/mcp/dispatchMCPTool.test.ts
@@ -7,7 +7,7 @@ import {
   type NotebookFreshness,
 } from "../notebooks/notebookFreshness"
 import { db } from "../../store/db"
-import { EXPECTED_BRIDGE_VERSION } from "./protocolVersion"
+import { EXPECTED_MCP_VERSION } from "./protocolVersion"
 import type { ToolCallMessage } from "./types"
 import type { ModelToolsClient } from "../ai/aiAssistant"
 import type { MetaToolContext } from "./metaResolvers"
@@ -61,7 +61,7 @@ const makeCall = (
   name: string,
   args: Record<string, unknown> = {},
 ): ToolCallMessage => ({
-  v: EXPECTED_BRIDGE_VERSION,
+  v: EXPECTED_MCP_VERSION,
   type: "tool_call",
   requestId: "r-" + name,
   name,

--- a/src/utils/mcp/protocolVersion.test.ts
+++ b/src/utils/mcp/protocolVersion.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest"
 import {
-  EXPECTED_BRIDGE_VERSION,
+  EXPECTED_MCP_VERSION,
   isBridgeVersionMismatch,
 } from "./protocolVersion"
 
 // Derive drifts from the expected version so these stay correct across bumps.
-const [major, minor, patch] = EXPECTED_BRIDGE_VERSION.split(".").map(Number)
+const [major, minor, patch] = EXPECTED_MCP_VERSION.split(".").map(Number)
 const bumped = (index: number): string => {
   const parts = [major, minor, patch]
   parts[index] += 1
@@ -17,14 +17,14 @@ describe("isBridgeVersionMismatch", () => {
     // Given the bridge reports the expected version
     // When compared
     // Then it is not a mismatch
-    expect(isBridgeVersionMismatch(EXPECTED_BRIDGE_VERSION)).toBe(false)
+    expect(isBridgeVersionMismatch(EXPECTED_MCP_VERSION)).toBe(false)
   })
 
   it("ignores pre-release / build suffixes on an otherwise-equal version", () => {
     // Given a version equal in major.minor.patch but with a suffix
     // When compared
     // Then it is not a mismatch
-    expect(isBridgeVersionMismatch(`${EXPECTED_BRIDGE_VERSION}-beta.1`)).toBe(
+    expect(isBridgeVersionMismatch(`${EXPECTED_MCP_VERSION}-beta.1`)).toBe(
       false,
     )
   })

--- a/src/utils/mcp/protocolVersion.ts
+++ b/src/utils/mcp/protocolVersion.ts
@@ -1,30 +1,32 @@
-// Bridge semver this console build was verified against. Stamped on every
+// MCP server semver this console build was verified against. Stamped on every
 // WS frame as `v` and echoed in `hello.expectedBridgeVersion`. Bridge
 // compares same-major (connect + warning) vs different-major (close 4004).
 // Bump in lockstep with verified bridge releases.
-export const EXPECTED_BRIDGE_VERSION = "0.3.0"
+export const EXPECTED_MCP_VERSION = "0.4.0"
 
 export type BridgeVersionMismatch = "major" | "minor"
 
-export const BRIDGE_UPGRADE_COMMAND = `npx @questdb/mcp-bridge@${EXPECTED_BRIDGE_VERSION} upgrade`
+export const MCP_PACKAGE = "@questdb/mcp-server-questdb"
 
-export const BRIDGE_SETUP_COMMAND = `npx @questdb/mcp-bridge@${EXPECTED_BRIDGE_VERSION} setup`
+export const MCP_UPGRADE_COMMAND = `npx ${MCP_PACKAGE}@${EXPECTED_MCP_VERSION} upgrade`
 
-export const BRIDGE_VERSION_MISMATCH_COPY: Record<
+export const MCP_SETUP_COMMAND = `npx ${MCP_PACKAGE}@${EXPECTED_MCP_VERSION} setup`
+
+export const MCP_VERSION_MISMATCH_COPY: Record<
   BridgeVersionMismatch,
   { title: string; message: string }
 > = {
   major: {
-    title: "MCP bridge version mismatch",
+    title: "MCP server version mismatch",
     message:
-      `This MCP bridge is incompatible with what this console expects (${EXPECTED_BRIDGE_VERSION}). ` +
-      `Upgrade your bridge with the following command and re-pair:`,
+      `This MCP server is incompatible with what this console expects (${EXPECTED_MCP_VERSION}). ` +
+      `Upgrade your MCP server with the following command and re-pair:`,
   },
   minor: {
-    title: "Update your MCP bridge",
+    title: "Update your MCP server",
     message:
-      `Connected successfully, but the bridge version doesn't match what this console expects ` +
-      `(${EXPECTED_BRIDGE_VERSION}). Some tools may not work as intended until you upgrade. ` +
+      `Connected successfully, but the MCP server version doesn't match what this console expects ` +
+      `(${EXPECTED_MCP_VERSION}). Some tools may not work as intended until you upgrade. ` +
       `Run this command and re-pair:`,
   },
 }
@@ -37,7 +39,7 @@ const parseSemver = (version: string): [number, number, number] | null => {
 
 export const isBridgeVersionMismatch = (bridgeVersion: string): boolean => {
   const bridge = parseSemver(bridgeVersion)
-  const expected = parseSemver(EXPECTED_BRIDGE_VERSION)
+  const expected = parseSemver(EXPECTED_MCP_VERSION)
   if (!bridge || !expected) return false
   return (
     bridge[0] !== expected[0] ||

--- a/src/utils/mcp/types.ts
+++ b/src/utils/mcp/types.ts
@@ -1,4 +1,4 @@
-// Wire-protocol types for the MCP Bridge WebSocket — must stay in sync
+// Wire-protocol types for the MCP server WebSocket — must stay in sync
 // with the bridge's own types. The `v` field on every frame carries the
 // bridge semver; same-major drift is tolerated, different majors hard-
 // reject with close 4004.
@@ -102,7 +102,7 @@ export type CloseReason =
   | "user_disconnect"
 
 // Application-range (4000+) WS close codes. Must stay in sync with
-// `mcp-bridge/src/types.ts WS_CLOSE_CODES`. Bridge originates 4001/4002/
+// `mcp-server-questdb/src/types.ts WS_CLOSE_CODES`. Bridge originates 4001/4002/
 // 4004/4005; UI may originate 4006/4007 (bridge accepts only). Origin
 // rejection happens pre-upgrade at the HTTP layer (403), no close code.
 export const WS_CLOSE_CODES = {

--- a/src/utils/notebookOnboarding.test.ts
+++ b/src/utils/notebookOnboarding.test.ts
@@ -29,7 +29,7 @@ describe("notebook onboarding visibility", () => {
       expect(shouldShowNotebookModal(onboarding)).toBe(false)
     })
 
-    it("stays hidden once an MCP bridge has ever connected", () => {
+    it("stays hidden once an MCP server has ever connected", () => {
       // Given the bridge has connected before, even if the flag is untouched
       const onboarding = { ...freshInstall, mcpEverConnected: true }
       // When deciding whether to show the modal
@@ -54,7 +54,7 @@ describe("notebook onboarding visibility", () => {
       expect(shouldShowMcpPromo(onboarding)).toBe(false)
     })
 
-    it("stays hidden once an MCP bridge has ever connected", () => {
+    it("stays hidden once an MCP server has ever connected", () => {
       // Given the bridge has connected before
       const onboarding = { ...freshInstall, mcpEverConnected: true }
       // When deciding whether to show the section


### PR DESCRIPTION
`@questdb/mcp-bridge` occurrences are changed to the new package name `@questdb/mcp-server-questdb`. 
`MCP bridge` occurrences are changed to `MCP server`.

Bumps expected MCP version to 0.4.0 - depends on https://github.com/questdb/mcp-server-questdb/pull/4