### PR TITLE
refactor: remove autoRefreshMigrated marker and implicit chart auto-refresh migration

### DIFF
--- a/src/scenes/Editor/Monaco/importTabs.ts
+++ b/src/scenes/Editor/Monaco/importTabs.ts
@@ -309,7 +309,6 @@ const sanitizeNotebookSettings = (
   }
   if (isAutoRefresh(item.autoRefreshDefault))
     settings.autoRefreshDefault = item.autoRefreshDefault
-  if (item.autoRefreshMigrated === true) settings.autoRefreshMigrated = true
   return settings
 }
 

--- a/src/store/notebook.test.ts
+++ b/src/store/notebook.test.ts
@@ -2,9 +2,7 @@ import { describe, it, expect } from "vitest"
 import {
   dropLegacyChartConfigs,
   migrateCellName,
-  migrateImplicitChartAutoRefresh,
   migrateLegacyCellNames,
-  type AutoRefresh,
   type NotebookCell,
   type NotebookViewState,
 } from "./notebook"
@@ -14,13 +12,6 @@ const cell = (over: Partial<NotebookCell> & { id: string }): NotebookCell => ({
   value: "",
   ...over,
 })
-
-const chart = (id: string, autoRefresh?: AutoRefresh): NotebookCell =>
-  cell(
-    autoRefresh === undefined
-      ? { id, mode: "draw" }
-      : { id, mode: "draw", autoRefresh },
-  )
 
 describe("migrateCellName", () => {
   it("promotes a legacy chartConfig.name to the cell name and drops the old copy", () => {
@@ -53,69 +44,6 @@ describe("migrateCellName", () => {
     // When migrated
     // Then the explicit name wins and the cell is returned unchanged
     expect(migrateCellName(input)).toBe(input)
-  })
-})
-
-describe("migrateImplicitChartAutoRefresh", () => {
-  it("stamps an explicit Auto onto implicit charts so they keep polling under the Off fallback", () => {
-    // Given a legacy notebook whose charts polled through the implicit fallback
-    const state: NotebookViewState = {
-      cells: [chart("a"), chart("b", "5s"), cell({ id: "r", mode: "run" })],
-    }
-
-    // When the notebook loads
-    const result = migrateImplicitChartAutoRefresh(state)
-
-    // Then only the implicit chart gains the stamp; explicit and run cells
-    // stay untouched
-    expect(result.cells[0].autoRefresh).toBe(true)
-    expect(result.cells[1].autoRefresh).toBe("5s")
-    expect(result.cells[2].autoRefresh).toBeUndefined()
-  })
-
-  it("never synthesizes a notebook default", () => {
-    // Given an untouched chart-only notebook
-    const result = migrateImplicitChartAutoRefresh({ cells: [chart("a")] })
-
-    // Then the chart is stamped but the notebook stays unconfigured
-    expect(result.cells[0].autoRefresh).toBe(true)
-    expect(result.settings?.autoRefreshDefault).toBeUndefined()
-  })
-
-  it("yields to a stored notebook default so implicit charts inherit it", () => {
-    // Given a notebook whose owner chose a notebook-wide cadence
-    const state: NotebookViewState = {
-      cells: [chart("a")],
-      settings: { autoRefreshDefault: "30s" },
-    }
-
-    // When the notebook loads
-    const result = migrateImplicitChartAutoRefresh(state)
-
-    // Then the cells stay exactly as-is and the default survives
-    expect(result.cells).toBe(state.cells)
-    expect(result.settings?.autoRefreshDefault).toBe("30s")
-  })
-
-  it("marks the view migrated so the stamp runs only once", () => {
-    // Given an unmigrated notebook
-    const result = migrateImplicitChartAutoRefresh({ cells: [chart("a")] })
-
-    // Then the view carries the marker and a second pass is identity
-    expect(result.settings?.autoRefreshMigrated).toBe(true)
-    expect(migrateImplicitChartAutoRefresh(result)).toBe(result)
-  })
-
-  it("never re-stamps a migrated view, so a cleared chart override survives a reload", () => {
-    // Given a migrated notebook whose chart the user reset to "inherit"
-    const state: NotebookViewState = {
-      cells: [chart("a")],
-      settings: { autoRefreshMigrated: true },
-    }
-
-    // When the notebook loads again
-    // Then the chart stays inherited instead of reverting to Auto
-    expect(migrateImplicitChartAutoRefresh(state)).toBe(state)
   })
 })
 

--- a/src/store/notebook.ts
+++ b/src/store/notebook.ts
@@ -134,7 +134,6 @@ export type NotebookSettings = {
   layout?: CellLayoutItem[]
   variables?: NotebookVariable[]
   autoRefreshDefault?: AutoRefresh
-  autoRefreshMigrated?: true
 }
 
 export type NotebookViewState = {
@@ -191,28 +190,3 @@ export const migrateLegacyCellNames = (
   state.cells.some(hasLegacyChartName)
     ? { ...state, cells: state.cells.map(migrateCellName) }
     : state
-
-// Charts drawn before the uniform-Off fallback polled through an implicit
-// per-view Auto. The migration writes that liveness as an explicit Auto
-// override so they keep polling; grids never polled, and stay off. No
-// notebook default is ever synthesized. The marker makes the write one-time:
-// on a migrated view an undefined autoRefresh is a deliberate "inherit".
-export const migrateImplicitChartAutoRefresh = (
-  state: NotebookViewState,
-): NotebookViewState => {
-  if (state.settings?.autoRefreshMigrated) return state
-  const legacyLiveChart = (cell: NotebookCell) =>
-    cell.mode === "draw" &&
-    cell.autoRefresh === undefined &&
-    state.settings?.autoRefreshDefault === undefined
-  const cells = state.cells.some(legacyLiveChart)
-    ? state.cells.map((cell) =>
-        legacyLiveChart(cell) ? { ...cell, autoRefresh: true as const } : cell,
-      )
-    : state.cells
-  return {
-    ...state,
-    cells,
-    settings: { ...state.settings, autoRefreshMigrated: true },
-  }
-}

--- a/src/utils/notebooks/notebookDexieView.ts
+++ b/src/utils/notebooks/notebookDexieView.ts
@@ -6,7 +6,6 @@ import {
   dropLegacyChartConfigs,
   exceedsCellLineLimit,
   MAX_CELL_LINES,
-  migrateImplicitChartAutoRefresh,
   migrateLegacyCellNames,
 } from "../../store/notebook"
 import type {
@@ -28,9 +27,7 @@ type NotebookBufferMeta =
   | { kind: "not_a_notebook" }
 
 export const migratePersistedNotebookView = (view: NotebookViewState) =>
-  migrateImplicitChartAutoRefresh(
-    dropLegacyChartConfigs(migrateLegacyCellNames(view)),
-  )
+  dropLegacyChartConfigs(migrateLegacyCellNames(view))
 
 export const readNotebookBufferMeta = async (
   bufferId: number,


### PR DESCRIPTION
## What

Removes the `autoRefreshMigrated` marker field and the `migrateImplicitChartAutoRefresh` load-time migration from #595. `undefined` auto-refresh on a chart cell now always means "inherit the notebook default", with no special case for records saved before #595.

## Why

The marker served one very narrow purpose: it made a one-time stamp idempotent. The stamp itself only converted an implicit legacy behavior into an explicit override. That is a dummy field from the user's point of view — no one sets it, no one reads it after the first load, yet every notebook record would carry it forever. Removing the migration keeps the settings shape minimal and the read path free of version-detection logic.

## Downside (accepted)

Charts saved before #595 polled through an implicit per-view Auto. After this change they load as "inherit", which resolves to Off when the notebook has no default:

- They freeze silently. A frozen chart shows its last snapshot and looks identical to a live chart.
- Recovery is manual, per cell. Setting the notebook default to Auto overshoots: grids inherit it too and start polling, which they never did before.
- The change is one-way. Once new code reads an old record, legacy `undefined` and deliberate "inherit" become indistinguishable, so this migration cannot be shipped retroactively.

#595 has not been in a tagged release, so the exposure today is dev environments. Production users get the new semantics directly when the next release ships. Browsers that already ran a stamped build keep an inert `autoRefreshMigrated: true` property in stored records; nothing reads it, and Dexie needs no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
