### PR TITLE
fix: prevent auth token refresh failure from deadlocking the client

### DIFF
--- a/src/utils/questdb/client.test.ts
+++ b/src/utils/questdb/client.test.ts
@@ -2,6 +2,8 @@ import "../../test/stubBrowserGlobals"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { Client } from "./client"
 import { Type } from "./types"
+import { ssoAuthState } from "../../modules/OAuth2/ssoAuthState"
+import { AuthPayload } from "../../modules/OAuth2/types"
 
 const response = (body: Record<string, unknown>): Response =>
   ({
@@ -60,5 +62,46 @@ describe("Client queryRaw NOTICE timings", () => {
     // Then no partial timing object is invented
     expect(result.type).toBe(Type.NOTICE)
     expect(result).not.toHaveProperty("timings")
+  })
+})
+
+describe("Client token refresh", () => {
+  afterEach(() => {
+    ssoAuthState.clearAuthPayload()
+  })
+
+  it("does not deadlock when a token refresh fails at the transport level", async () => {
+    // Given an active SSO session whose token is inside the 30s refresh window
+    ssoAuthState.setAuthPayload({
+      access_token: "stale",
+      refresh_token: "refresh",
+      expires_at: new Date(new Date().getTime() + 10_000).toString(),
+    } as AuthPayload)
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(response({ notice: "hint applied" })),
+    )
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    // And a refresh that rejects, e.g. the token endpoint is unreachable or
+    // answers with a non-JSON body
+    const client = new Client()
+    client.refreshTokenMethod = () => Promise.reject(new Error("network down"))
+
+    // When a query runs, it must not hang waiting on a stuck refresh flag: the
+    // failure is swallowed and the request proceeds with the stale token (the
+    // server would then answer 401 and drive the normal re-auth flow).
+    const result = await client.queryRaw("SELECT 1")
+
+    expect(result.type).toBe(Type.NOTICE)
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(errorSpy).toHaveBeenCalled()
+
+    // And a subsequent query still goes through — the flag was reset
+    await client.queryRaw("SELECT 1")
+    expect(fetch).toHaveBeenCalledTimes(2)
+
+    errorSpy.mockRestore()
   })
 })

--- a/src/utils/questdb/client.ts
+++ b/src/utils/questdb/client.ts
@@ -61,26 +61,38 @@ export class Client {
 
   private refreshAuthToken = async () => {
     Client.refreshTokenPending = true
-    await new Promise((resolve) => {
-      const interval = setInterval(async () => {
-        if (Client.numOfPendingQueries === 0) {
-          clearInterval(interval)
-          const newToken = await this.refreshTokenMethod()
-          if (newToken.access_token) {
-            this.setCommonHeaders({
-              ...this.commonHeaders,
-              Authorization: `Bearer ${
-                newToken.groups_encoded_in_token
-                  ? newToken.id_token
-                  : newToken.access_token
-              }`,
-            })
+    try {
+      // Wait until all in-flight queries have finished before swapping the auth
+      // header, so we don't change it out from under a pending request.
+      await new Promise<void>((resolve) => {
+        const interval = setInterval(() => {
+          if (Client.numOfPendingQueries === 0) {
+            clearInterval(interval)
+            resolve()
           }
-          Client.refreshTokenPending = false
-          return resolve(true)
-        }
-      }, 50)
-    })
+        }, 50)
+      })
+      const newToken = await this.refreshTokenMethod()
+      if (newToken.access_token) {
+        this.setCommonHeaders({
+          ...this.commonHeaders,
+          Authorization: `Bearer ${
+            newToken.groups_encoded_in_token
+              ? newToken.id_token
+              : newToken.access_token
+          }`,
+        })
+      }
+    } catch (error) {
+      // A transport-level failure (token endpoint unreachable, non-JSON
+      // response, etc.) must not leave refreshTokenPending stuck true, which
+      // would deadlock every subsequent query. We keep the stale token in
+      // place; the next request will get a 401 and drive the normal re-auth
+      // flow, matching what happens when there is no refresh token at all.
+      console.error("Failed to refresh the auth token", error)
+    } finally {
+      Client.refreshTokenPending = false
+    }
   }
 
   static encodeParams = (


### PR DESCRIPTION
## Problem

When OIDC is used, `Client.refreshAuthToken()` proactively refreshes the token ~30s before `expires_in` elapses. The token fetch was performed **inside an `async` `setInterval` callback**:

```js
const interval = setInterval(async () => {
  if (Client.numOfPendingQueries === 0) {
    clearInterval(interval)
    const newToken = await this.refreshTokenMethod()  // <-- rejects here
    ...
    Client.refreshTokenPending = false   // <-- never reached
    return resolve(true)                 // <-- never reached
  }
}, 50)
```

If `refreshTokenMethod()` rejected — a **transport-level failure** such as the token endpoint being unreachable, a CORS/DNS error, or a non-JSON response body (e.g. a reverse-proxy `502` HTML page) — the `await` threw before the flag was reset:

- The outer promise never settled, so `await this.refreshAuthToken()` hung forever (it never even rejected).
- The **static** `refreshTokenPending` flag was left stuck `true`.
- Every subsequent query then deadlocked on the `while (Client.refreshTokenPending)` wait loop.

Net effect: the Web Console **silently froze** — no query ran, no `401` was triggered, no logout, no error surfaced. Only a manual page reload recovered it.

This only affected the transport-failure case. A well-formed OAuth error response (e.g. `invalid_grant` for an expired refresh token) already degraded gracefully to the login screen, as does the no-refresh-token case (`401` → logout).

## Fix

Restructure `refreshAuthToken()` so the failure can't escape without cleanup:

- The `setInterval` now **only** waits for in-flight queries to drain, then `resolve()`s — a plain synchronous callback, no swallowed errors.
- The `refreshTokenMethod()` call moves into the main `async` body, wrapped in `try/catch/finally`.
- **`finally` always resets `refreshTokenPending`** — it can never get stuck again.
- **`catch`** logs and swallows the error, keeping the stale token in place. The next request then receives a `401`, which drives the existing `MSG_CONNECTION_UNAUTHORIZED` → logout flow — consistent with the no-refresh-token path.

The concurrency invariant is preserved: while `refreshTokenPending` is `true`, no new query passes the gate to increment `numOfPendingQueries`, so "0 pending queries when we refresh" still holds.

## Testing

- Added a regression test in `client.test.ts`: with an in-window SSO token and a `refreshTokenMethod` that rejects, the query still resolves, `console.error` fires, and a second query also goes through (proving the flag was reset). Against the old code this test hangs to timeout; against the fix it passes in ~100ms.
- `yarn test:unit src/utils/questdb/client.test.ts` — 3/3 pass
- `tsc --noEmit` — no new errors
- `eslint` on both changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)